### PR TITLE
Dynamic values (proof of concept)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.2.1",
     "expect": "^1.20.2",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "proxyquire": "^1.7.10"
   },
   "babel": {
     "presets": [

--- a/src/constructors/element.js
+++ b/src/constructors/element.js
@@ -9,13 +9,15 @@ const element = (tagName, ...rules) => {
 
   /* Return a stateless functional component that simply renders
   * a HTML element with our styles applied. */
-  return (props) => {
+  const component = (props) => {
     /* Need to be able to regenerate styles if things change, but for now everything's static */
     if (!className) className = styleRoot.injectStyles()
     return createElement(tagName, Object.assign({}, props, {
       className: [props.className, className].join(' '),
     }))
   }
+  component.displayName = `Styled(${tagName.displayName || tagName})`
+  return component
 }
 
 export default element

--- a/src/constructors/element.js
+++ b/src/constructors/element.js
@@ -4,16 +4,14 @@ import Root from '../models/Root'
 
 const element = (tagName, ...rules) => {
   const styleRoot = new Root(...rules)
-  /* Don't generate the styles now, only on render */
-  let className
+  console.log(styleRoot)
 
   /* Return a stateless functional component that simply renders
   * a HTML element with our styles applied. */
   const component = (props) => {
     /* Need to be able to regenerate styles if things change, but for now everything's static */
-    if (!className) className = styleRoot.injectStyles()
     return createElement(tagName, Object.assign({}, props, {
-      className: [props.className, className].join(' '),
+      className: [props.className, styleRoot.injectStyles(props)].join(' '),
     }))
   }
   component.displayName = `Styled(${tagName.displayName || tagName})`

--- a/src/constructors/test/element.test.js
+++ b/src/constructors/test/element.test.js
@@ -1,0 +1,56 @@
+import proxyquire from 'proxyquire'
+import expect from 'expect'
+
+// Inject FakeRoot into the "import '../models/Root'" call in element.js with proxyquire
+const injectStylesSpy = expect.createSpy()
+const constructorSpy = expect.createSpy()
+const generatedClassname = 'generated-classname'
+class FakeRoot {
+  constructor(...rules) {
+    constructorSpy(...rules)
+  }
+  injectStyles() {
+    injectStylesSpy()
+    return generatedClassname
+  }
+}
+const element = proxyquire('../element', { '../models/Root': FakeRoot })
+
+describe('element', () => {
+  afterEach(() => {
+    injectStylesSpy.restore()
+    constructorSpy.restore()
+  })
+
+  it('should return a stateless functional component', () => {
+    expect(element('div')).toBeA('function')
+  })
+
+  it('should add the rules to the style root on creation', () => {
+    const rule1 = 'background: "red";'
+    const rule2 = 'color: "blue";'
+    element('div', rule1, rule2)
+    expect(constructorSpy).toHaveBeenCalled()
+    expect(constructorSpy).toHaveBeenCalledWith(rule1, rule2)
+  })
+
+  it('should call injectStyles of the style root on render', () => {
+    // Pretend a react render is happening
+    element('div')({})
+    expect(injectStylesSpy).toHaveBeenCalled()
+  })
+
+  it('should adopt the classname of the injectStyles call', () => {
+    // Pretend a react render is happening
+    const renderedComp = element('div')({})
+    expect(renderedComp.props.className).toEqual(` ${generatedClassname}`)
+  })
+
+  it('should adopt a passed in className', () => {
+    const className = 'other-classname'
+    const renderedComp = element('div')({
+      className,
+    })
+    expect(renderedComp.props.className).toEqual(`${className} ${generatedClassname}`)
+  })
+})

--- a/src/models/DynamicRule.js
+++ b/src/models/DynamicRule.js
@@ -1,0 +1,11 @@
+import ValidRuleSetChild from './ValidRuleSetChild'
+import css from "../constructors/css";
+
+export default class DynamicRule extends ValidRuleSetChild {
+  constructor(before, func, after) {
+    super()
+
+    console.log({before, func: func.toString(), after})
+    this.flatten = props => css`\n${before}${func(props) || ''}${after}`.flatten(props)
+  }
+}

--- a/src/models/MediaQuery.js
+++ b/src/models/MediaQuery.js
@@ -13,8 +13,8 @@ export default class MediaQuery extends ValidRuleSetChild {
   }
 
   /* No nesting! */
-  flatten() {
-    const { rules, fragments } = this.ruleSet.flatten()
+  flatten(context) {
+    const { rules, fragments } = this.ruleSet.flatten(context)
     if (fragments.length > 0) console.error("Fragments aren't supported in Media Queries yet")
     return rules
   }

--- a/src/models/NestedSelector.js
+++ b/src/models/NestedSelector.js
@@ -7,9 +7,9 @@ export default class NestedSelector extends ValidRuleSetChild {
     this.ruleSet = ruleSet
   }
 
-  flatten() {
+  flatten(context) {
     const { selector } = this
-    const { rules, fragments } = this.ruleSet.flatten()
+    const { rules, fragments } = this.ruleSet.flatten(context)
     return { selector, rules, fragments }
   }
 }

--- a/src/models/Root.js
+++ b/src/models/Root.js
@@ -25,8 +25,8 @@ export default class Root {
   }
 
   /* This is aphrodite-specifc but could be changed up */
-  injectStyles() {
-    const { rules, fragments } = this.ruleSet.flatten()
+  injectStyles(context) {
+    const { rules, fragments } = this.ruleSet.flatten(context)
     const className = `_${hashObject({ rules, fragments })}`
     injectCss(`.${className}`, rules, fragments)
     return className

--- a/src/models/RuleSet.js
+++ b/src/models/RuleSet.js
@@ -2,6 +2,7 @@ import Rule from './Rule'
 import MediaQuery from './MediaQuery'
 import NestedSelector from './NestedSelector'
 import ValidRuleSetChild from './ValidRuleSetChild'
+import DynamicRule from "./DynamicRule";
 
 /*
 * A RuleSet stores the leaf nodes that apply to some level
@@ -26,16 +27,20 @@ export default class RuleSet extends ValidRuleSetChild {
     })
   }
 
-  flatten() {
+  flatten(context) {
     const rules = {}
     const fragments = []
     this.rules.forEach((r) => {
       if (r instanceof Rule) {
         rules[r.property] = r.value
       } else if (r instanceof MediaQuery) {
-        rules[r.fullQuery()] = r.flatten()
+        rules[r.fullQuery()] = r.flatten(context)
       } else if (r instanceof NestedSelector) {
-        fragments.push(r.flatten())
+        fragments.push(r.flatten(context))
+      } else if (r instanceof DynamicRule) {
+        const dynamic = r.flatten(context)
+        Object.keys(dynamic.rules).forEach(rr => rules[rr] = dynamic.rules[rr])
+        fragments.push(...dynamic.fragments)
       }
     })
 


### PR DESCRIPTION
Messssssssy atm but this is what I've been wanting to demonstrate the whole time. I think this is why we need tagged template literals, rather than just strings that are concatenated-at-definition-time

This now works:

```jsx
const A = styled.div`
  margin-top: 2rem;
  ${({hasBorder}) => hasBorder && 'border: 1px solid blue;'}
  color: ${props => props.color || 'black'};
  ${css`font-weight: bold;`}
  &:hover {
    text-transform: uppercase;
  }
`
```

```jsx
<A color="red">Omfg</A>
<A color="orange">Look</A>
<A hasBorder>At this shit</A>
```

![image](https://cloud.githubusercontent.com/assets/23264/18497720/1178f2c0-7a74-11e6-8b53-5897d64fa587.png)

Now... that `props` that we pass in... what if that merged both React context _and_ props. Looks for, say, a `theme` object on context then `Object.apply`s everything in props over the top. Basically turning the whole theming/contextual overrides into one simple conventional mechanism.

The implementation needs work but **I like this an alot**