### PR TITLE
[WIP] Implement @keyframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "aphrodite": "^0.5.0",
     "fbjs": "^0.8.3",
     "lodash": "^4.15.0",
+    "node-uuid": "^1.4.7",
     "react": "^15.3.0",
     "string-hash": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "aphrodite": "^0.5.0",
     "fbjs": "^0.8.3",
     "lodash": "^4.15.0",
-    "react": "^15.3.0"
+    "react": "^15.3.0",
+    "string-hash": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,8 +1,12 @@
 // @flow
-import concat from './concat'
+import uuid from 'node-uuid'
 import ValidRuleSetChild from '../models/ValidRuleSetChild'
 import Keyframes from '../models/Keyframes'
+import Root from '../models/Root'
+import css from './css'
 
-export default (name: string, ...rules: Array<typeof ValidRuleSetChild>) => (
-  new Keyframes(name, concat(...rules))
-)
+export default (...rules: Array<typeof ValidRuleSetChild>) => {
+  const name = uuid.v4()
+  const styleRoot = new Root(css(...rules))
+  return new Keyframes(name, styleRoot).getName()
+}

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,0 +1,8 @@
+// @flow
+import concat from './concat'
+import ValidRuleSetChild from '../models/ValidRuleSetChild'
+import Keyframes from '../models/Keyframes'
+
+export default (name: string, ...rules: Array<typeof ValidRuleSetChild>) => (
+  new Keyframes(name, concat(...rules))
+)

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -234,4 +234,66 @@ describe('css', () => {
       ))
     })
   })
+
+  describe('keyframes', () => {
+    it('should handle keyframes', () => {
+      expect(css`
+        0% {
+          opacity: 0;
+        }
+        100% {
+          opacity: 1;
+        }
+      `).toEqual(concat(
+        nested('0%',
+          rule('opacity', '0')
+        ),
+        nested('100%',
+          rule('opacity', '1')
+        )
+      ))
+    })
+
+    it('should handle keyframes with from/to', () => {
+      expect(css`
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      `).toEqual(concat(
+        nested('from',
+          rule('opacity', '0')
+        ),
+        nested('to',
+          rule('opacity', '1')
+        )
+      ))
+    })
+
+    it('should handle keyframes with mixed from/to and percentages', () => {
+      expect(css`
+        from {
+          opacity: 0;
+        }
+        50% {
+          opacity: 0.25;
+        }
+        to {
+          opacity: 1;
+        }
+      `).toEqual(concat(
+        nested('from',
+          rule('opacity', '0')
+        ),
+        nested('50%',
+          rule('opacity', '0.25')
+        ),
+        nested('to',
+          rule('opacity', '1')
+        )
+      ))
+    })
+  })
 })

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -1,10 +1,9 @@
 import expect from 'expect'
-import css, { generateName } from '../css'
+import css from '../css'
 import concat from '../concat'
 import rule from '../rule'
 import nested from '../nested'
 import media from '../media'
-import keyframes from '../keyframes'
 
 describe('css', () => {
   describe('simple inputs', () => {
@@ -232,132 +231,6 @@ describe('css', () => {
           media('screen and (max-width: 500px) and (min-width: 1000px)',
           rule('background', 'blue')
         )
-      ))
-    })
-  })
-
-  describe('keyframes', () => {
-    it('should handle simple keyframes', () => {
-      expect(css`
-        @keyframes some-name {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-        animation-name: some-name;
-      `).toEqual(concat(
-        keyframes(generateName('some-name', false, 24),
-          nested('0%',
-            rule('opacity', '0'),
-          ),
-          nested('100%',
-            rule('opacity', '1'),
-          )
-        ),
-        rule('animationName', generateName('some-name', false, 24))
-      ))
-    })
-
-    it('should handle multiple keyframes', () => {
-      expect(css`
-        @keyframes some-name {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-        @keyframes some-other-name {
-          0% {
-            opacity: 1;
-          }
-          100% {
-            opacity: 0;
-          }
-        }
-        animation-name: some-name;
-        animation-name: some-other-name;
-      `).toEqual(concat(
-        keyframes(generateName('some-name', false, 25),
-          nested('0%',
-            rule('opacity', '0'),
-          ),
-          nested('100%',
-            rule('opacity', '1'),
-          )
-        ),
-        keyframes(generateName('some-other-name', false, 25),
-          nested('0%',
-            rule('opacity', '1'),
-          ),
-          nested('100%',
-            rule('opacity', '0'),
-          )
-        ),
-        rule('animationName', generateName('some-name', false, 25)),
-        rule('animationName', generateName('some-other-name', false, 25))
-      ))
-    })
-
-    // TODO
-    it.skip('should handle overrides', () => {
-      expect(css`
-        @keyframes some-name {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-        @keyframes some-name {
-          0% {
-            opacity: 1;
-          }
-          100% {
-            opacity: 0;
-          }
-        }
-        animation-name: some-name;
-      `).toEqual(concat(
-        keyframes(generateName('some-name', false, 26),
-          nested('0%',
-            rule('opacity', '1'),
-          ),
-          nested('100%',
-            rule('opacity', '0'),
-          )
-        ),
-        rule('animationName', generateName('some-name', false, 26))
-      ))
-    })
-
-    // TODO
-    it.skip('should handle animation name inside animation declaration', () => {
-      expect(css`
-        @keyframes some-name {
-          0% {
-            opacity: 0;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-        animation: some-name 150ms;
-      `).toEqual(concat(
-        keyframes(generateName('some-name', false, 27),
-          nested('0%',
-            rule('opacity', '1'),
-          ),
-          nested('100%',
-            rule('opacity', '0'),
-          )
-        ),
-        rule('animation', `${generateName('some-name', false, 27)} 150ms`)
       ))
     })
   })

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -256,7 +256,8 @@ describe('css', () => {
           nested('100%',
             rule('opacity', '1'),
           )
-        )
+        ),
+        rule('animation', 'some-name 150ms')
       ))
     })
   })

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -4,6 +4,7 @@ import concat from '../concat'
 import rule from '../rule'
 import nested from '../nested'
 import media from '../media'
+import keyframes from '../keyframes'
 
 describe('css', () => {
   describe('simple inputs', () => {
@@ -230,6 +231,31 @@ describe('css', () => {
           rule('background', 'red'),
           media('screen and (max-width: 500px) and (min-width: 1000px)',
           rule('background', 'blue')
+        )
+      ))
+    })
+  })
+
+  describe('keyframes', () => {
+    it('should handle simple keyframes', () => {
+      expect(css`
+        @keyframes some-name {
+          0% {
+            opacity: 0;
+          }
+          100% {
+            opacity: 1;
+          }
+        }
+        animation: some-name 150ms;
+      `).toEqual(concat(
+        keyframes('some-name',
+          nested('0%',
+            rule('opacity', '0'),
+          ),
+          nested('100%',
+            rule('opacity', '1'),
+          )
         )
       ))
     })

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -249,7 +249,7 @@ describe('css', () => {
         }
         animation-name: some-name;
       `).toEqual(concat(
-        keyframes(generateName('some-name', 1),
+        keyframes(generateName('some-name', false, 24),
           nested('0%',
             rule('opacity', '0'),
           ),
@@ -257,7 +257,107 @@ describe('css', () => {
             rule('opacity', '1'),
           )
         ),
-        rule('animationName', generateName('some-name', 1))
+        rule('animationName', generateName('some-name', false, 24))
+      ))
+    })
+
+    it('should handle multiple keyframes', () => {
+      expect(css`
+        @keyframes some-name {
+          0% {
+            opacity: 0;
+          }
+          100% {
+            opacity: 1;
+          }
+        }
+        @keyframes some-other-name {
+          0% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0;
+          }
+        }
+        animation-name: some-name;
+        animation-name: some-other-name;
+      `).toEqual(concat(
+        keyframes(generateName('some-name', false, 25),
+          nested('0%',
+            rule('opacity', '0'),
+          ),
+          nested('100%',
+            rule('opacity', '1'),
+          )
+        ),
+        keyframes(generateName('some-other-name', false, 25),
+          nested('0%',
+            rule('opacity', '1'),
+          ),
+          nested('100%',
+            rule('opacity', '0'),
+          )
+        ),
+        rule('animationName', generateName('some-name', false, 25)),
+        rule('animationName', generateName('some-other-name', false, 25))
+      ))
+    })
+
+    // TODO
+    it.skip('should handle overrides', () => {
+      expect(css`
+        @keyframes some-name {
+          0% {
+            opacity: 0;
+          }
+          100% {
+            opacity: 1;
+          }
+        }
+        @keyframes some-name {
+          0% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0;
+          }
+        }
+        animation-name: some-name;
+      `).toEqual(concat(
+        keyframes(generateName('some-name', false, 26),
+          nested('0%',
+            rule('opacity', '1'),
+          ),
+          nested('100%',
+            rule('opacity', '0'),
+          )
+        ),
+        rule('animationName', generateName('some-name', false, 26))
+      ))
+    })
+
+    // TODO
+    it.skip('should handle animation name inside animation declaration', () => {
+      expect(css`
+        @keyframes some-name {
+          0% {
+            opacity: 0;
+          }
+          100% {
+            opacity: 1;
+          }
+        }
+        animation: some-name 150ms;
+      `).toEqual(concat(
+        keyframes(generateName('some-name', false, 27),
+          nested('0%',
+            rule('opacity', '1'),
+          ),
+          nested('100%',
+            rule('opacity', '0'),
+          )
+        ),
+        rule('animation', `${generateName('some-name', false, 27)} 150ms`)
       ))
     })
   })

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -1,5 +1,5 @@
 import expect from 'expect'
-import css from '../css'
+import css, { generateName } from '../css'
 import concat from '../concat'
 import rule from '../rule'
 import nested from '../nested'
@@ -247,9 +247,9 @@ describe('css', () => {
             opacity: 1;
           }
         }
-        animation: some-name 150ms;
+        animation-name: some-name;
       `).toEqual(concat(
-        keyframes('some-name',
+        keyframes(generateName('some-name', 1),
           nested('0%',
             rule('opacity', '0'),
           ),
@@ -257,7 +257,7 @@ describe('css', () => {
             rule('opacity', '1'),
           )
         ),
-        rule('animation', 'some-name 150ms')
+        rule('animationName', generateName('some-name', 1))
       ))
     })
   })

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -1,0 +1,48 @@
+import expect from 'expect'
+import proxyquire from 'proxyquire'
+
+/**
+ * @author https://github.com/defunctzombie
+ * @author https://github.com/broofa
+ * @see https://github.com/broofa/node-uuid/issues/41
+ */
+function isUUID(str: string): boolean {
+  return /[0-9a-f]{22}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(str)
+}
+
+// Inject FakeRoot into the "import '../models/Root'" call in keyframes.js with proxyquire
+const injectStylesSpy = expect.createSpy()
+const generatedClassname = 'generated-classname'
+class FakeRoot {
+  injectStyles() {
+    injectStylesSpy()
+    return generatedClassname
+  }
+}
+const keyframes = proxyquire('../keyframes', { '../models/Root': FakeRoot })
+
+describe('keyframes', () => {
+  afterEach(() => {
+    injectStylesSpy.restore()
+  })
+
+  it('should return its name', () => {
+    expect(keyframes`
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `).toBeA('string')
+  })
+
+  it('should use a UUID as the name', () => {
+    expect(isUUID(keyframes``)).toBe(true)
+  })
+
+  it('should inject styles when called', () => {
+    keyframes`` // eslint-disable-line no-unused-expressions
+    expect(injectStylesSpy).toHaveBeenCalled()
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,11 @@
 import css from './constructors/css'
 import toggle from './constructors/toggle'
 import trait from './constructors/trait'
+import keyframes from './constructors/keyframes'
 import styled from './constructors/styled'
 
 export {
-  css, toggle, trait,
+  css, toggle, trait, keyframes,
 }
 
 export default styled

--- a/src/models/Keyframes.js
+++ b/src/models/Keyframes.js
@@ -1,14 +1,19 @@
 // @flow
 import ValidRuleSetChild from './ValidRuleSetChild'
-import RuleSet from './RuleSet'
+import Root from './Root'
 
-export default class MediaQuery extends ValidRuleSetChild {
+export default class Keyframes extends ValidRuleSetChild {
   name: string;
-  keyframes: RuleSet;
+  styleRoot: Root;
 
-  constructor(name: string, keyframes: RuleSet) {
+  constructor(name: string, styleRoot: Root) {
     super()
     this.name = name
-    this.keyframes = keyframes
+    this.styleRoot = styleRoot
+    styleRoot.injectStyles()
+  }
+
+  getName(): string {
+    return this.name
   }
 }

--- a/src/models/Keyframes.js
+++ b/src/models/Keyframes.js
@@ -1,0 +1,14 @@
+// @flow
+import ValidRuleSetChild from './ValidRuleSetChild'
+import RuleSet from './RuleSet'
+
+export default class MediaQuery extends ValidRuleSetChild {
+  name: string;
+  keyframes: RuleSet;
+
+  constructor(name: string, keyframes: RuleSet) {
+    super()
+    this.name = name
+    this.keyframes = keyframes
+  }
+}


### PR DESCRIPTION
Implements `@keyframes` support. Since we aim to support all of CSS (contrary to Radium, Aphrodite,...) I figured having `@keyframes` support built-in without any helpers is what we should be doing.

The name mangling is very very rudimentary at the moment and will break if you put two different `@keyframes` into one `styled.something`. Need to find a better way to do this.

**TODO**:

- [ ] Proper name mangling
- [ ] Support `animation: some-name 150ms;` (currently only support `animation-name: bla;`)
- [ ] Way more tests for complex cases

Closes #14 