### PR TITLE
Preserving declaration order

### DIFF
--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -12,6 +12,9 @@ const styleSheet = new StyleSheet({ speedy: false, maxLength: 40 })
 const generated = {}
 const inserted = {}
 
+interface UpdateableRule {
+}
+
 /*
  ComponentStyle is all the CSS-specific stuff, not
  the React-specific stuff.
@@ -19,11 +22,13 @@ const inserted = {}
 export default class ComponentStyle {
   rules: RuleSet
   insertedRule: Object
+  builtState: string
 
   constructor(rules: RuleSet) {
     this.rules = rules
     if (!styleSheet.injected) styleSheet.inject()
     this.insertedRule = styleSheet.insert('')
+    this.builtState = ''
   }
 
   /*
@@ -46,7 +51,8 @@ export default class ComponentStyle {
   injectStyles(emojis: string) {
     if (inserted[emojis]) return
 
-    this.insertedRule.updateRule(generated[emojis])
+    this.builtState += generated[emojis]
+    this.insertedRule.updateRule(this.builtState)
     inserted[emojis] = true
   }
 }

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -1,6 +1,6 @@
 // @flow
 import hashStr from 'glamor/lib/hash'
-import { StyleSheet } from 'glamor/lib/sheet'
+import { StyleSheet } from '../vendor/glamor/sheet'
 
 import type { RuleSet } from '../types'
 import flatten from '../utils/flatten'
@@ -18,9 +18,12 @@ const inserted = {}
  */
 export default class ComponentStyle {
   rules: RuleSet
+  insertedRule: Object
 
   constructor(rules: RuleSet) {
     this.rules = rules
+    if (!styleSheet.injected) styleSheet.inject()
+    this.insertedRule = styleSheet.insert('')
   }
 
   /*
@@ -30,7 +33,6 @@ export default class ComponentStyle {
    * Returns the hash to be injected on render()
    * */
   generateStyles(executionContext: Object) {
-    if (!styleSheet.injected) styleSheet.inject()
     const flatCSS = flatten(this.rules, executionContext).join('')
     const emojis = toEmoji(hashStr(flatCSS))
     if (!generated[emojis]) {
@@ -44,7 +46,7 @@ export default class ComponentStyle {
   injectStyles(emojis: string) {
     if (inserted[emojis]) return
 
-    styleSheet.insert(generated[emojis])
+    this.insertedRule.updateRule(generated[emojis])
     inserted[emojis] = true
   }
 }

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -12,9 +12,6 @@ const styleSheet = new StyleSheet({ speedy: false, maxLength: 40 })
 const generated = {}
 const inserted = {}
 
-interface UpdateableRule {
-}
-
 /*
  ComponentStyle is all the CSS-specific stuff, not
  the React-specific stuff.
@@ -22,13 +19,11 @@ interface UpdateableRule {
 export default class ComponentStyle {
   rules: RuleSet
   insertedRule: Object
-  builtState: string
 
   constructor(rules: RuleSet) {
     this.rules = rules
     if (!styleSheet.injected) styleSheet.inject()
     this.insertedRule = styleSheet.insert('')
-    this.builtState = ''
   }
 
   /*
@@ -51,8 +46,7 @@ export default class ComponentStyle {
   injectStyles(emojis: string) {
     if (inserted[emojis]) return
 
-    this.builtState += generated[emojis]
-    this.insertedRule.updateRule(this.builtState)
+    this.insertedRule.appendRule(generated[emojis])
     inserted[emojis] = true
   }
 }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -32,6 +32,7 @@ export default (tagName: any, rules: RuleSet) => {
       const executionContext = Object.assign({}, newProps, { theme, updateTheme })
       /* Do all the work to generate the CSS because this can modify the theme */
       this.generatedClassName = componentStyle.generateStyles(executionContext)
+      /* Inject the styles */
       componentStyle.injectStyles(this.generatedClassName)
     }
 
@@ -49,15 +50,6 @@ export default (tagName: any, rules: RuleSet) => {
       propsForElement.className = [className, this.generatedClassName].filter(x => x).join(' ')
 
       return createElement(tagName, propsForElement, children)
-    }
-
-    /* Once rendered, inject the CSS. This means that nested elements' CSS
-    * is injected first, then the wrapping elements. This allows a StyleComponent
-    * to wrap another. */
-    componentDidMount() {
-      this.componentDidUpdate()
-    }
-    componentDidUpdate() {
     }
   }
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -32,6 +32,7 @@ export default (tagName: any, rules: RuleSet) => {
       const executionContext = Object.assign({}, newProps, { theme, updateTheme })
       /* Do all the work to generate the CSS because this can modify the theme */
       this.generatedClassName = componentStyle.generateStyles(executionContext)
+      componentStyle.injectStyles(this.generatedClassName)
     }
 
     /* eslint-disable react/prop-types */
@@ -57,7 +58,6 @@ export default (tagName: any, rules: RuleSet) => {
       this.componentDidUpdate()
     }
     componentDidUpdate() {
-      componentStyle.injectStyles(this.generatedClassName)
     }
   }
 

--- a/src/vendor/README.md
+++ b/src/vendor/README.md
@@ -2,7 +2,10 @@ Vendored postcss source as of [31ae472](https://github.com/postcss/postcss/tree/
 
 Vendored postcss-nested source as of [e709092](https://github.com/postcss/postcss-nested/tree/e7090926839cf916f6a24c3ad4079c1206d93b2d)
 
+Vendored glamor/sheet.js as of [582dde4](https://github.com/threepointone/glamor/blob/582dde44713bcbe9212a961706c06a34a4ebccb0/src/sheet.js)
+
 Then hacked things around:
 
 * Deleted `previous-map.js` and all references to it because it `require('fs')`ed
 * Deleted reference to `postcss` within `postcss-nested` & simply exported the transform function
+* Made `StyleSheet.insert()` return something with an `update()` method

--- a/src/vendor/glamor/sheet.js
+++ b/src/vendor/glamor/sheet.js
@@ -87,7 +87,7 @@ export class StyleSheet {
           // in other words, just the cssText field
           const serverRule = { cssText: rule }
           this.sheet.cssRules.push(serverRule)
-          return {serverRule, updateRule: (newCss => serverRule.cssText = newCss)}
+          return {serverRule, appendRule: (newCss => serverRule.cssText += newCss)}
         }
       }
     }
@@ -128,7 +128,7 @@ export class StyleSheet {
       else{
         const textNode = document.createTextNode(rule)
         last(this.tags).appendChild(textNode)
-        insertedRule = { textNode, updateRule: newCss => (textNode.data = newCss)}
+        insertedRule = { textNode, appendRule: newCss => textNode.appendData(newCss)}
 
         if(!this.isSpeedy) {
           // sighhh

--- a/src/vendor/glamor/sheet.js
+++ b/src/vendor/glamor/sheet.js
@@ -1,0 +1,175 @@
+/*
+
+high performance StyleSheet for css-in-js systems
+
+- uses multiple style tags behind the scenes for millions of rules
+- uses `insertRule` for appending in production for *much* faster performance
+- 'polyfills' on server side
+
+
+// usage
+
+import StyleSheet from 'glamor/lib/sheet'
+let styleSheet = new StyleSheet()
+
+styleSheet.inject()
+- 'injects' the stylesheet into the page (or into memory if on server)
+
+styleSheet.insert('#box { border: 1px solid red; }')
+- appends a css rule into the stylesheet
+
+styleSheet.flush()
+- empties the stylesheet of all its contents
+
+
+*/
+
+function last(arr) {
+  return arr[arr.length -1]
+}
+
+function sheetForTag(tag) {
+  for(let i = 0; i < document.styleSheets.length; i++) {
+    if(document.styleSheets[i].ownerNode === tag) {
+      return document.styleSheets[i]
+    }
+  }
+}
+
+const isBrowser = typeof document !== 'undefined'
+const isDev = (x => (x === 'development') || !x)(process.env.NODE_ENV)
+const isTest = process.env.NODE_ENV === 'test'
+
+const oldIE = (() => {
+  if(isBrowser) {
+    let div = document.createElement('div')
+    div.innerHTML = '<!--[if lt IE 10]><i></i><![endif]-->'
+    return div.getElementsByTagName('i').length === 1
+  }
+})()
+
+function makeStyleTag() {
+  let tag = document.createElement('style')
+  tag.type = 'text/css'
+  tag.appendChild(document.createTextNode(''));
+  (document.head || document.getElementsByTagName('head')[0]).appendChild(tag)
+  return tag
+}
+
+
+export class StyleSheet {
+  constructor({
+    speedy = !isDev && !isTest,
+    maxLength = (isBrowser && oldIE) ? 4000 : 65000
+  } = {}) {
+    this.isSpeedy = speedy // the big drawback here is that the css won't be editable in devtools
+    this.sheet = undefined
+    this.tags = []
+    this.maxLength = maxLength
+    this.ctr = 0
+  }
+  inject() {
+    if(this.injected) {
+      throw new Error('already injected stylesheet!')
+    }
+    if(isBrowser) {
+      // this section is just weird alchemy I found online off many sources
+      this.tags[0] = makeStyleTag()
+      // this weirdness brought to you by firefox
+      this.sheet = sheetForTag(this.tags[0])
+    }
+    else {
+      // server side 'polyfill'. just enough behavior to be useful.
+      this.sheet  = {
+        cssRules: [],
+        insertRule: rule => {
+          // enough 'spec compliance' to be able to extract the rules later
+          // in other words, just the cssText field
+          const serverRule = { cssText: rule }
+          this.sheet.cssRules.push(serverRule)
+          return {serverRule, updateRule: (newCss => serverRule.cssText = newCss)}
+        }
+      }
+    }
+    this.injected = true
+  }
+  speedy(bool) {
+    if(this.ctr !== 0) {
+      throw new Error(`cannot change speedy mode after inserting any rule to sheet. Either call speedy(${bool}) earlier in your app, or call flush() before speedy(${bool})`)
+    }
+    this.isSpeedy = !!bool
+  }
+  _insert(rule) {
+    // this weirdness for perf, and chrome's weird bug
+    // https://stackoverflow.com/questions/20007992/chrome-suddenly-stopped-accepting-insertrule
+    try {
+      this.sheet.insertRule(rule, this.sheet.cssRules.length) // todo - correct index here
+    }
+    catch(e) {
+      if(isDev) {
+        // might need beter dx for this
+        console.warn('whoops, illegal rule inserted', rule) //eslint-disable-line no-console
+      }
+    }
+
+  }
+  insert(rule) {
+    let insertedRule
+
+    if(isBrowser) {
+      // this is the ultrafast version, works across browsers
+      if(this.isSpeedy && this.sheet.insertRule) {
+        this._insert(rule)
+      }
+      // more browser weirdness. I don't even know
+      else if(this.tags.length > 0 && last(this.tags).styleSheet) {
+        last(this.tags).styleSheet.cssText+= rule
+      }
+      else{
+        const textNode = document.createTextNode(rule)
+        last(this.tags).appendChild(textNode)
+        insertedRule = { textNode, updateRule: newCss => (textNode.data = newCss)}
+
+        if(!this.isSpeedy) {
+          // sighhh
+          this.sheet = sheetForTag(last(this.tags))
+        }
+      }
+    }
+    else{
+      // server side is pretty simple
+      insertedRule = this.sheet.insertRule(rule)
+    }
+
+    this.ctr++
+    if(isBrowser && this.ctr % this.maxLength === 0) {
+      this.tags.push(makeStyleTag())
+      this.sheet = sheetForTag(last(this.tags))
+    }
+    return insertedRule
+  }
+  flush() {
+    if(isBrowser) {
+      this.tags.forEach(tag => tag.parentNode.removeChild(tag))
+      this.tags = []
+      this.sheet = null
+      this.ctr = 0
+      // todo - look for remnants in document.styleSheets
+    }
+    else {
+      // simpler on server
+      this.sheet.cssRules = []
+    }
+    this.injected = false
+  }
+  rules() {
+    if(!isBrowser) {
+      return this.sheet.cssRules
+    }
+    let arr = []
+    this.tags.forEach(tag => arr.splice(arr.length, 0, ...Array.from(
+        sheetForTag(tag).cssRules
+      )))
+    return arr
+  }
+}


### PR DESCRIPTION
Inserting a null rule on ComponentStyle creation, then reusing that on each insert. It means that

```js
const X = styled.div` .. `
const Y = styled.div` ... `
const Z = styled.div` ... `
```

will be _guaranteed_ to be injected in `X`, `Y` and `Z` order, **regardless of which order they're rendered in**. This is a much more predictable behaviour, but I'm a bit worried about the performance of replacing styles at arbitrary points in the injected styles (since it could potentially invalidate a lot of the existing CSSOM).

Still, I can't think of a better way around it for now. Better to be correct and slow than fast & wrong, at least until we have hard data about performance to base an informed decision.