### PR TITLE
Update build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 lib
 npm-debug.log
+dist
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.travis.yml
+appveyor.yml
+webpack.config.js
+.flowconfig
+.eslintrc
+.eslintignore

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel --out-dir lib src",
-    "build:watch": "npm run build -- --watch",
+    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
+    "prebuild:lib": "rm -rf lib/*",
+    "build:lib": "babel --out-dir lib src",
+    "prebuild:umd": "rm -rf dist/*",
+    "build:umd": "webpack --config webpack.config.js src/index.js dist/styled-components.js",
+    "build:umd:min": "MINIFY_JS=true webpack --config webpack.config.js src/index.js dist/styled-components.min.js",
+    "build:watch": "npm run build:lib -- --watch",
     "test": "mocha \"./src/**/*.test.js\" --require babel-core/register",
     "test:watch": "npm run test -- --watch",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "eslint src",
-    "prepublish": "rm -rf lib/* && npm run build"
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -38,8 +43,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
-    "babel-core": "^6.13.2",
     "babel-eslint": "^6.1.2",
+    "babel-loader": "^6.2.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-preset-latest": "^6.14.0",
@@ -52,7 +57,8 @@
     "expect": "^1.20.2",
     "flow-bin": "^0.32.0",
     "mocha": "^3.0.2",
-    "proxyquire": "^1.7.10"
+    "proxyquire": "^1.7.10",
+    "webpack": "^1.13.2"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "babel-eslint": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
-    "babel-preset-es2015": "^6.13.2",
-    "babel-preset-es2016": "^6.11.3",
+    "babel-preset-latest": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
@@ -57,8 +56,7 @@
   },
   "babel": {
     "presets": [
-      "es2015",
-      "es2016",
+      "latest",
       "react"
     ],
     "plugins": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+const webpack = require('webpack')
+
+const plugins = [
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': 'production',
+  }),
+]
+
+if (process.env.MINIFY_JS) {
+  plugins.push(new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false,
+    },
+  }))
+}
+
+module.exports = {
+  output: {
+    library: 'styled-components',
+    libraryTarget: 'umd',
+  },
+  module: {
+    loaders: [
+      {
+        loader: 'babel',
+        test: /\.js$/,
+        exclude: /node_modules/,
+      },
+      {
+        loader: 'json',
+        test: /\.json$/,
+      },
+    ],
+  },
+  plugins: plugins, // eslint-disable-line object-shorthand
+}


### PR DESCRIPTION
- Use babel-preset-latest to get all the latest ESXXXX goodies automatically
- Create normal and minified UMD build for usage with bower or a script tag
- npmignore unnecessary files to be on there (supersedes #22)