### PR TITLE
Implement { global }

### DIFF
--- a/src/constructors/global.js
+++ b/src/constructors/global.js
@@ -1,0 +1,10 @@
+import css from './css'
+import GlobalStyle from '../models/GlobalStyle'
+import type { Interpolation } from '../types'
+
+const global = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
+  const globalStyle = new GlobalStyle(css(strings, ...interpolations))
+  globalStyle.generateAndInject()
+}
+
+export default global

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@
 import css from './constructors/css'
 import toggle from './constructors/toggle'
 import styled from './constructors/styled'
+import global from './constructors/global'
 
-export { css, toggle }
+export { css, toggle, global }
 
 export default styled

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -32,19 +32,19 @@ export default class ComponentStyle {
   generateStyles(executionContext: Object) {
     if (!styleSheet.injected) styleSheet.inject()
     const flatCSS = flatten(this.rules, executionContext).join('')
-    const emojis = toEmoji(hashStr(flatCSS))
-    if (!generated[emojis]) {
-      const root = parse(`.${emojis} { ${flatCSS} }`)
+    const selector = toEmoji(hashStr(flatCSS))
+    if (!generated[selector]) {
+      const root = parse(`.${selector} { ${flatCSS} }`)
       postcssNested(root)
-      generated[emojis] = root.toResult().css
+      generated[selector] = root.toResult().css
     }
-    return emojis
+    return selector
   }
 
-  injectStyles(emojis: string) {
-    if (inserted[emojis]) return
+  injectStyles(selector: string) {
+    if (inserted[selector]) return
 
-    styleSheet.insert(generated[emojis])
-    inserted[emojis] = true
+    styleSheet.insert(generated[selector])
+    inserted[selector] = true
   }
 }

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -1,0 +1,24 @@
+import { StyleSheet } from 'glamor/lib/sheet'
+
+import type { RuleSet } from '../types'
+import flatten from '../utils/flatten'
+import parse from '../vendor/postcss-safe-parser/parse'
+import postcssNested from '../vendor/postcss-nested'
+
+const styleSheet = new StyleSheet({ speedy: false, maxLength: 40 })
+
+export default class ComponentStyle {
+  rules: RuleSet
+
+  constructor(rules: RuleSet) {
+    this.rules = rules
+  }
+
+  generateAndInject() {
+    if (!styleSheet.injected) styleSheet.inject()
+    const flatCSS = flatten(this.rules).join('')
+    const root = parse(flatCSS)
+    postcssNested(root)
+    styleSheet.insert(root.toResult().css)
+  }
+}


### PR DESCRIPTION
- Rename "emoji" to "selector" – those aren't staying emojis :wink: (though we definitely need an opt-in "emoji mode"…)
- Add { global }

**NOTE: Haven't been able to actually test this in a project because linking locally isn't working for me. PLEASE TEST**