### PR TITLE
Add keyframes support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "glamor": "^2.15.5",
     "js-base64": "^2.1.9",
     "lodash": "^4.15.0",
+    "node-uuid": "^1.4.7",
     "react": "^15.3.2",
     "source-map": "^0.5.6",
     "supports-color": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "glamor": "^2.15.5",
     "js-base64": "^2.1.9",
     "lodash": "^4.15.0",
-    "node-uuid": "^1.4.7",
     "react": "^15.3.2",
     "source-map": "^0.5.6",
     "supports-color": "^3.1.2"

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,0 +1,13 @@
+// @flow
+import uuid from 'node-uuid'
+import css from './css'
+import GlobalStyle from '../models/GlobalStyle'
+import type { Interpolation } from '../types'
+
+export default (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
+  const name = uuid.v4()
+  const rules = css(strings, ...interpolations)
+  const keyframes = new GlobalStyle(rules, `@keyframes ${name}`)
+  keyframes.generateAndInject()
+  return name
+}

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -8,7 +8,7 @@ const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 
 export default (strings: Array<string>, ...interpolations: Array<Interpolation>): Number => {
   const rules = css(strings, ...interpolations)
-  const name = hashStr(replaceWhitespace(JSON.stringify(rules)))
+  const name = `k${hashStr(replaceWhitespace(JSON.stringify(rules)))}`
   const keyframes = new GlobalStyle(rules, `@keyframes ${name}`)
   keyframes.generateAndInject()
   return name

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,12 +1,14 @@
 // @flow
-import uuid from 'node-uuid'
+import hashStr from 'glamor/lib/hash'
 import css from './css'
 import GlobalStyle from '../models/GlobalStyle'
 import type { Interpolation } from '../types'
 
-export default (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
-  const name = uuid.v4()
+const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
+
+export default (strings: Array<string>, ...interpolations: Array<Interpolation>): Number => {
   const rules = css(strings, ...interpolations)
+  const name = hashStr(replaceWhitespace(JSON.stringify(rules)))
   const keyframes = new GlobalStyle(rules, `@keyframes ${name}`)
   keyframes.generateAndInject()
   return name

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -1,7 +1,6 @@
 import expect from 'expect'
 import proxyquire from 'proxyquire'
-
-let keyframes = require('../keyframes')
+import keyframes from '../keyframes'
 
 const KEYFRAMES_REGEX = /@keyframes\s*(\S+)\s*\{/
 
@@ -34,10 +33,14 @@ const stubbedSheet = {
   '@global': true,
 }
 
+const stubbedKeyframes = proxyquire('../keyframes', {
+  '../vendor/glamor/sheet': stubbedSheet,
+  './vendor/glamor/sheet': stubbedSheet,
+  'glamor/lib/sheet': stubbedSheet,
+})
+
 describe.only('keyframes', () => {
   beforeEach(() => {
-    keyframes = require('../keyframes') // eslint-disable-line global-require
-
     insertSpy.reset()
   })
 
@@ -65,12 +68,8 @@ describe.only('keyframes', () => {
         opacity: 1;
       }
     `
-    keyframes = proxyquire('../keyframes', {
-      '../vendor/glamor/sheet': stubbedSheet,
-      './vendor/glamor/sheet': stubbedSheet,
-      'glamor/lib/sheet': stubbedSheet,
-    })
-    const name = keyframes`${rules}`
+
+    const name = stubbedKeyframes`${rules}`
 
     expect(insertSpy).toHaveBeenCalled()
     expect(insertSpy.calls.length).toEqual(1)

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -4,15 +4,6 @@ import keyframes from '../keyframes'
 
 const KEYFRAMES_REGEX = /@keyframes\s*(\S+)\s*\{/
 
-/**
- * @author https://github.com/defunctzombie
- * @author https://github.com/broofa
- * @see https://github.com/broofa/node-uuid/issues/41
- */
-function isUUID(str) {
-  return /[0-9a-f]{22}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(str)
-}
-
 const hasValidKeyframesDeclaration = (str) => KEYFRAMES_REGEX.test(str)
 const getKeyframesNameFromCSS = (str) => str.match(KEYFRAMES_REGEX)[1]
 
@@ -35,11 +26,9 @@ const stubbedSheet = {
 
 const stubbedKeyframes = proxyquire('../keyframes', {
   '../vendor/glamor/sheet': stubbedSheet,
-  './vendor/glamor/sheet': stubbedSheet,
-  'glamor/lib/sheet': stubbedSheet,
 })
 
-describe.only('keyframes', () => {
+describe('keyframes', () => {
   beforeEach(() => {
     insertSpy.reset()
   })
@@ -52,11 +41,7 @@ describe.only('keyframes', () => {
       100% {
         opacity: 1;
       }
-    `).toBeA('string')
-  })
-
-  it('should use a UUID as the name', () => {
-    expect(isUUID(keyframes``)).toBe(true)
+    `).toBeA('number')
   })
 
   it('should insert the correct styles', () => {

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -1,0 +1,85 @@
+import expect from 'expect'
+import proxyquire from 'proxyquire'
+
+let keyframes = require('../keyframes')
+
+const KEYFRAMES_REGEX = /@keyframes\s*(\S+)\s*\{/
+
+/**
+ * @author https://github.com/defunctzombie
+ * @author https://github.com/broofa
+ * @see https://github.com/broofa/node-uuid/issues/41
+ */
+function isUUID(str) {
+  return /[0-9a-f]{22}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(str)
+}
+
+const hasValidKeyframesDeclaration = (str) => KEYFRAMES_REGEX.test(str)
+const getKeyframesNameFromCSS = (str) => str.match(KEYFRAMES_REGEX)[1]
+
+/**
+ * Setup
+ */
+const insertSpy = expect.createSpy()
+
+class StubStylesheet {
+  inject() {}
+  insert(...args) {
+    insertSpy(...args)
+  }
+ }
+
+const stubbedSheet = {
+  StyleSheet: StubStylesheet,
+  '@global': true,
+}
+
+describe.only('keyframes', () => {
+  beforeEach(() => {
+    keyframes = require('../keyframes') // eslint-disable-line global-require
+
+    insertSpy.reset()
+  })
+
+  it('should return its name', () => {
+    expect(keyframes`
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `).toBeA('string')
+  })
+
+  it('should use a UUID as the name', () => {
+    expect(isUUID(keyframes``)).toBe(true)
+  })
+
+  it('should insert the correct styles', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `
+    keyframes = proxyquire('../keyframes', {
+      '../vendor/glamor/sheet': stubbedSheet,
+      './vendor/glamor/sheet': stubbedSheet,
+      'glamor/lib/sheet': stubbedSheet,
+    })
+    const name = keyframes`${rules}`
+
+    expect(insertSpy).toHaveBeenCalled()
+    expect(insertSpy.calls.length).toEqual(1)
+    expect(
+      hasValidKeyframesDeclaration(insertSpy.calls[0].arguments[0])
+    ).toEqual(true)
+    expect(
+      getKeyframesNameFromCSS(insertSpy.calls[0].arguments[0])
+    ).toEqual(name)
+    expect(insertSpy.calls[0].arguments[0]).toInclude(rules)
+  })
+})

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -41,7 +41,7 @@ describe('keyframes', () => {
       100% {
         opacity: 1;
       }
-    `).toBeA('number')
+    `).toBeA('string')
   })
 
   it('should insert the correct styles', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ import css from './constructors/css'
 import toggle from './constructors/toggle'
 import styled from './constructors/styled'
 import global from './constructors/global'
+import keyframes from './constructors/keyframes'
 
-export { css, toggle, global }
+export { css, toggle, global, keyframes }
 
 export default styled

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -1,3 +1,4 @@
+// @flow
 import { StyleSheet } from 'glamor/lib/sheet'
 
 import type { RuleSet } from '../types'
@@ -9,14 +10,19 @@ const styleSheet = new StyleSheet({ speedy: false, maxLength: 40 })
 
 export default class ComponentStyle {
   rules: RuleSet
+  selector: ?string
 
-  constructor(rules: RuleSet) {
+  constructor(rules: RuleSet, selector: ?string) {
     this.rules = rules
+    this.selector = selector
   }
 
   generateAndInject() {
     if (!styleSheet.injected) styleSheet.inject()
-    const flatCSS = flatten(this.rules).join('')
+    let flatCSS = flatten(this.rules).join('')
+    if (this.selector) {
+      flatCSS = `${this.selector} {${flatCSS}\n}`
+    }
     const root = parse(flatCSS)
     postcssNested(root)
     styleSheet.insert(root.toResult().css)

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -1,10 +1,10 @@
 // @flow
-import { StyleSheet } from 'glamor/lib/sheet'
+import parse from '../vendor/postcss-safe-parser/parse'
+import { StyleSheet } from '../vendor/glamor/sheet'
+import postcssNested from '../vendor/postcss-nested'
 
 import type { RuleSet } from '../types'
 import flatten from '../utils/flatten'
-import parse from '../vendor/postcss-safe-parser/parse'
-import postcssNested from '../vendor/postcss-nested'
 
 const styleSheet = new StyleSheet({ speedy: false, maxLength: 40 })
 


### PR DESCRIPTION
Adds first support for

```JS
import { keyframes } from 'styled-components'

const fadeIn = keyframes`
  0% {
    opacity: 0;
  }
  100% {
    opacity: 1;
  }
`
```

We might need to use a different name generator (UUIDs aren't very _nice_) and we might need to optionally let people pass in a name that we prepend before our unique stuff for easier debugging.

**NOTE: UNTESTED IN REAL PROJECT, PLEASE VERIFY** (still can't `npm link`)