### PR TITLE
Fix UMD build

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -6,7 +6,7 @@ module.exports = [{
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'styled-components.js',
-    library: 'styled-components',
+    library: 'styled',
     libraryTarget: 'umd',
   },
   externals: {
@@ -25,13 +25,12 @@ module.exports = [{
       },
     ],
   },
-  plugins: [new webpack.DefinePlugin({ 'process.env.NODE_ENV': 'production' })],
 }, {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'styled-components.min.js',
-    library: 'styled-components',
+    library: 'styled',
     libraryTarget: 'umd',
   },
   externals: {
@@ -51,7 +50,6 @@ module.exports = [{
     ],
   },
   plugins: [
-    new webpack.DefinePlugin({ 'process.env.NODE_ENV': 'production' }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,


### PR DESCRIPTION
This fixes the UMD build, which means you can drop a script tag in a HTML and it'll just work 💃 (as long as React is also there) `styled.keyframes`, `styled.css`, etc. also all exist, to do `styled.div` you'll have to do `styled.default.div` since it's transpiled ES6 which is good anyway.

Closes #49 

Example:

```HTML
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Test</title>
  </head>
  <body>
    <div id="root"></div>
    <!-- Load React and ReactDOM globally -->
    <script src="https://fb.me/react-15.0.0.js"></script>
    <script src="https://fb.me/react-dom-15.0.0.js"></script>
    <!-- Load styled-components globally -->
    <script type="text/javascript" src="./dist/styled-components.js"></script>
    <!-- BEWARE: Transpiled code below -->
    <script>
    var _templateObject = _taggedTemplateLiteral(['\n  background-color: red;\n  width: 20px;\n  height: 20px;\n'], ['\n  background-color: red;\n  width: 20px;\n  height: 20px;\n']);

    function _taggedTemplateLiteral(strings, raw) { return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }

    var TestComp = styled.default.div(_templateObject);

    ReactDOM.render(React.createElement(TestComp, null), document.getElementById('root'));
    </script>
  </body>
</html>

```