### PR TITLE
docs(readme): Fix links on the table of content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,5 @@ This is the `styled-components` documentation.
 - [Tips and Tricks](./tips-and-tricks.md): A few handy tips for working with `styled-components`
 - [Tagged Template Literals](./tagged-template-literals.md): How do they work?
 - [What CSS we support](./css-we-support.md): What parts & extensions of CSS can you use within a component?
-- [Theming](./docs/theming.md): How to work with themes
+- [Theming](./theming.md): How to work with themes
 - [Shared Component Libraries](./docs/shared-component-libraries.md): Tips for setting up a shared component library


### PR DESCRIPTION
Fix the `theming.md` link

Also, the `shared-component-libraries.md` file does not exist. Do you still want to keep the link ?