### PR TITLE
Fix react-router v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
   "main": "lib/index.js",
   "scripts": {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -40,8 +40,8 @@ export default (ComponentStyle: any) => {
         // If there is a theme in the context, subscribe to the event emitter. This
         // is necessary due to pure components blocking context updates, this circumvents
         // that by updating when an event is emitted
-        if (this.context.broadcasts) {
-          const subscribe = this.context.broadcasts[CHANNEL]
+        if (this.context[CHANNEL]) {
+          const subscribe = this.context[CHANNEL]
           this.unsubscribe = subscribe(theme => {
             // This will be called once immediately
             this.setState({ theme })
@@ -81,7 +81,7 @@ export default (ComponentStyle: any) => {
 
     StyledComponent.displayName = isTag ? `styled.${target}` : `Styled(${target.displayName})`
     StyledComponent.contextTypes = {
-      broadcasts: PropTypes.object,
+      [CHANNEL]: PropTypes.func,
     }
     return StyledComponent
   }

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -3,6 +3,7 @@ import isFunction from 'lodash/isFunction'
 import isPlainObject from 'lodash/isPlainObject'
 import createBroadcast from '../utils/create-broadcast'
 
+// NOTE: DO NOT CHANGE, changing this is a semver major change!
 export const CHANNEL = '__styled-components__'
 
 /**
@@ -13,14 +14,13 @@ class ThemeProvider extends Component {
   constructor() {
     super()
     this.getTheme = this.getTheme.bind(this)
-    this.getBroadcastsContext = this.getBroadcastsContext.bind(this)
   }
 
   componentWillMount() {
     // If there is a ThemeProvider wrapper anywhere around this theme provider, merge this theme
     // with the outer theme
-    if (this.context.broadcasts && this.context.broadcasts[CHANNEL]) {
-      const subscribe = this.context.broadcasts[CHANNEL]
+    if (this.context[CHANNEL]) {
+      const subscribe = this.context[CHANNEL]
       this.unsubscribeToOuter = subscribe(theme => {
         this.outerTheme = theme
       })
@@ -29,9 +29,7 @@ class ThemeProvider extends Component {
   }
 
   getChildContext() {
-    return {
-      broadcasts: this.getBroadcastsContext(),
-    }
+    return Object.assign({}, this.context, { [CHANNEL]: this.broadcast.subscribe })
   }
 
   componentWillReceiveProps(nextProps) {
@@ -40,11 +38,6 @@ class ThemeProvider extends Component {
 
   componentWillUnmount() {
     this.unsubscribeToOuter()
-  }
-
-  // Merge new broadcast with existing ones
-  getBroadcastsContext() {
-    return Object.assign({}, this.context.broadcasts, { [CHANNEL]: this.broadcast.subscribe })
   }
 
   // Get the theme from the props, supporting both (outerTheme) => {} as well as object notation
@@ -79,10 +72,10 @@ ThemeProvider.propTypes = {
   ]),
 }
 ThemeProvider.childContextTypes = {
-  broadcasts: PropTypes.object.isRequired,
+  [CHANNEL]: PropTypes.func.isRequired,
 }
 ThemeProvider.contextTypes = {
-  broadcasts: PropTypes.object,
+  [CHANNEL]: PropTypes.func,
 }
 
 export default ThemeProvider

--- a/src/models/test/ThemeProvider.test.js
+++ b/src/models/test/ThemeProvider.test.js
@@ -30,7 +30,7 @@ describe('ThemeProvider', () => {
     // Setup Child
     class Child extends React.Component {
       componentWillMount() {
-        this.context.broadcasts[CHANNEL](theme => {
+        this.context[CHANNEL](theme => {
           expect(theme).toEqual(Object.assign({}, outerTheme, innerTheme))
           done()
         })
@@ -38,7 +38,7 @@ describe('ThemeProvider', () => {
       render() { return null }
     }
     Child.contextTypes = {
-      broadcasts: React.PropTypes.object,
+      [CHANNEL]: React.PropTypes.object,
     }
 
     render(
@@ -57,7 +57,7 @@ describe('ThemeProvider', () => {
     // Setup Child
     class Child extends React.Component {
       componentWillMount() {
-        this.context.broadcasts[CHANNEL](theme => {
+        this.context[CHANNEL](theme => {
           expect(theme).toEqual(Object.assign({}, outerestTheme, outerTheme, innerTheme))
           done()
         })
@@ -65,7 +65,7 @@ describe('ThemeProvider', () => {
       render() { return null }
     }
     Child.contextTypes = {
-      broadcasts: React.PropTypes.object,
+      [CHANNEL]: React.PropTypes.object,
     }
 
     render(
@@ -88,7 +88,7 @@ describe('ThemeProvider', () => {
     // Setup Child
     class Child extends React.Component {
       componentWillMount() {
-        this.context.broadcasts[CHANNEL](theme => {
+        this.context[CHANNEL](theme => {
           // eslint-disable-next-line react/prop-types
           expect(theme).toEqual(themes[this.props.shouldHaveTheme])
           childRendered++ // eslint-disable-line no-plusplus
@@ -100,7 +100,7 @@ describe('ThemeProvider', () => {
       render() { return null }
     }
     Child.contextTypes = {
-      broadcasts: React.PropTypes.object,
+      [CHANNEL]: React.PropTypes.object,
     }
 
     render(


### PR DESCRIPTION
react-router uses react-broadcast to handle context updates. We do too,
except I inlined the implementation to avoid multiple wrapper
components. That would totally be fine, except I also slightly adapted
the implementation – and that broke anything else using react-broadcast,
including react-router v4.

This PR fixes that by instead attaching our theme to this.context
directly, not to this.context.broadcasts. This avoids overlap and fixes
the bug. (manually verified)

Closes #75