### PR TITLE
More documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ const StyledLink = styled(Link)`
   </a>
 </div>
 
+> **Note:** `styled-components` generates a real stylesheet with classes. It attaches those classes to styled components via the `className` prop. If a third-party (or any non-styled react component really) isn't styleable with the `styled(MyComponent)` notation, it's likely because that component does not attach the passed-in `className` prop to a DOM node! (see the ["Using `styled-components` with existing CSS"](./docs/existing-css.md)) doc for more information!)
+
 ### Animations
 
 CSS animations with `@keyframes` aren't scoped to a single component but you still don't want them to be global. This is why we export a `keyframes` helper which will generate a unique name for your keyframes. You can then use that unique name throughout your app.

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ See [the documentation](./docs) for more information about using `styled-compone
 - [API Reference](./docs/api.md)
 - [Tips and Tricks](./docs/tips-and-tricks.md)
 - [Tagged Template Literals](./docs/tagged-template-literals.md): How do they work?
+- [Using `styled-components` with existing CSS](./docs/existing-css.md): Some edge cases you should be aware of when using `styled-components` with an existing CSS codebase
 - [What CSS we support](./docs/css-we-support.md): What parts & extensions of CSS can you use within a component?
 - [Theming](./docs/theming.md): How to work with themes
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ const StyledLink = styled(Link)`
   </a>
 </div>
 
-> **Note:** `styled-components` generates a real stylesheet with classes. It attaches those classes to styled components via the `className` prop. If a third-party (or any non-styled react component really) isn't styleable with the `styled(MyComponent)` notation, it's likely because that component does not attach the passed-in `className` prop to a DOM node! (see the ["Using `styled-components` with existing CSS"](./docs/existing-css.md)) doc for more information!)
+> **Note:** `styled-components` generate a real stylesheet with classes. The class names are then passed to the react component (including third party components) via the `className` prop. For the styles to be applied, third-party components must attach the passed-in `className` prop to a DOM node. See [Using `styled-components` with existing CSS](./docs/existing-css.md) for more information!
 
 ### Animations
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ See [the documentation](./docs) for more information about using `styled-compone
 - [Tips and Tricks](./docs/tips-and-tricks.md)
 - [Tagged Template Literals](./docs/tagged-template-literals.md): How do they work?
 - [Using `styled-components` with existing CSS](./docs/existing-css.md): Some edge cases you should be aware of when using `styled-components` with an existing CSS codebase
-- [What CSS we support](./docs/css-we-support.md): What parts & extensions of CSS can you use within a component?
+- [What CSS we support](./docs/css-we-support.md): What parts & extensions of CSS can you use within a component? *(Spoiler: all of CSS plus even more)*
 - [Theming](./docs/theming.md): How to work with themes
 
 ## Syntax highlighting

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Utilising [tagged template literals](./docs/tagged-template-literals.md) (a rece
 
 > **Note:** If you're not using `npm` as your package manager, aren't using a module bundler or aren't sure about either of those jump to [Alternative Installation Methods](#alternative-installation-methods).
 
+*Made by [Glen Maddern](https://twitter.com/glenmaddern) and [Max Stoiber](https://twitter.com/mxstbr), supported by [Front End Center](https://frontend.center) and [Thinkmill](http://thinkmill.com.au/). Thank you for making this project possible!*
+
 ## Usage
 
 ### Basic
@@ -443,5 +445,3 @@ See [LICENSE](./LICENSE) for more information.
 This project builds on a long line of earlier work by clever folks all around the world. We'd like to thank Charlie Somerville, Nik Graf, Sunil Pai, Michael Chan, Andrey Popp, Jed Watson & Andrey Sitnik who contributed ideas, code or inspiration.
 
 Special thanks to [@okonet](https://github.com/okonet) for the fantastic logo.
-
-Development supported by [Front End Center](https://frontend.center) and [Thinkmill](http://thinkmill.com.au/)

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ See [the documentation](./docs) for more information about using `styled-compone
 
 ## Syntax highlighting
 
-The one thing you lose when writing CSS in template literals is syntax highlighting. We're working hard on making proper syntax highlighting happening in all editors. We currently have support for Atom.
+The one thing you lose when writing CSS in template literals is syntax highlighting. We're working hard on making proper syntax highlighting happening in all editors. We currently have support for Atom, and soon Sublime Text.
 
 This is what it looks like when properly highlighted:
 
@@ -384,6 +384,12 @@ This is what it looks like when properly highlighted:
 [**@gandm**](https://github.com/gandm), the creator of `language-babel`, has added support for `styled-components` in Atom!
 
 To get proper syntax highlighting, all you have to do is install and use the `language-babel` package for your JavaScript files!
+
+### Sublime Text
+
+There is an [open PR](https://github.com/babel/babel-sublime/pull/289) by [@garetmckinley](https://github.com/garetmckinley) to add support for `styled-components` to `babel-sublime`! (if you want the PR to land, feel free to 👍 the initial comment to let the maintainers know there's a need for this!)
+
+As soon as that PR is merged and a new version released, all you'll have to do is install and use `babel-sublime` to highlight your JavaScript files!
 
 ### Other Editors
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,6 @@ This is the `styled-components` documentation.
 - [API Reference](./api.md): A reference for all APIs that we export or return.
 - [Tips and Tricks](./tips-and-tricks.md): A few handy tips for working with `styled-components`
 - [Tagged Template Literals](./tagged-template-literals.md): How do they work?
+- [Using `styled-components` with existing CSS](./docs/existing-css.md): Some edge cases you should be aware of when using `styled-components` with an existing CSS codebase
 - [What CSS we support](./css-we-support.md): What parts & extensions of CSS can you use within a component?
 - [Theming](./theming.md): How to work with themes
-

--- a/docs/css-we-support.md
+++ b/docs/css-we-support.md
@@ -1,6 +1,6 @@
 # CSS We Support
 
-Within a styled component, we support quite a lot of CSS: (including nesting)
+Within a styled component, we support all of CSS, including nesting – since we generate an actual stylesheet and not inline styles, whatever works in CSS works in a styled component!
 
 ```js
 styled.div`
@@ -22,9 +22,9 @@ styled.div`
 `
 ```
 
-> **Note:** Essentially, all ampersands (`&`) get replaced by our generated, unique classname
+> **Note:** Ampersands (`&`) get replaced by our generated, unique classname for that styled component, making it easy to have complex logic
 
-On top of that you can always use `injectGlobal` for actually global things like `@font-face`:
+On top of that you can always use `injectGlobal` for actually global things, like `@font-face`:
 
 ```js
 import { injectGlobal } from 'styled-components'

--- a/docs/existing-css.md
+++ b/docs/existing-css.md
@@ -1,0 +1,73 @@
+# Using `styled-components` with existing CSS
+
+`styled-components` generates an actual stylesheet with classes, and attaches those classes to the DOM nodes of styled components via the `className` prop. It injects the generated stylesheet at the end of the HEAD of the document.
+
+## Styling normal React components
+
+If you use the `styled(MyNormalComponent)` notation with an existing, non-styled-components react component that doesn't use the passed-in `className` prop the styles won't be applied.
+
+To avoid this issue, make sure your component (in this case `MyNormalComponent`) attaches the passed-in `className` to a DOM node:
+
+```JSX
+class MyNormalComponent extends React.Component {
+  render() {
+    return (
+      // Attach the passed-in className to the DOM node
+      <div className={this.props.className}></div>
+    );
+  }
+}
+```
+
+If you have pre-existing styles with a class, you can combine the global class with the `styled-components` one:
+
+```JSX
+class MyNormalComponent extends React.Component {
+  render() {
+    return (
+      // Use a global class with existing styling in combination with
+      // allowing this component to be styled with styled-components
+      <div className={`some-global-class ${this.props.className}`}></div>
+    );
+  }
+}
+```
+
+## Global class always overridden
+
+The other way around might happen too. You have a styled component, and a standard, global CSS class you're trying to override some styles with. For some reason though, the `styled-components` styles always end up overriding the styles of the global class, no matter what you do!
+
+A contrived example:
+
+```JS
+// MyComponent.js
+const MyComponent = styled.div`background-color: green;`;
+```
+
+```CSS
+/* my-component.css */
+.red-bg {
+  background-color: red;
+}
+```
+
+```JSX
+// For some reason this component still has a green background,
+// even though you're trying to override it with the "red-bg" class!
+<MyComponent className="red-bg" />
+```
+
+This is because `styled-components` injects the stylesheet at the end of the HEAD. If the CSS class you wrote is before the injected styles in the DOM, because of the cascade, the last styles targeting the same element (in this case the `styled-components` ones) will win!
+
+You can easily fix this by moving your CSS class to the beginning of the body in the DOM.
+
+Sadly, some tools (like the webpack `style-loader`) give you no control over the place they inject the CSS into, meaning you cannot move them after the `styled-components` one.
+
+The easy fix for that is bumping up the specificity of the CSS class you're overriding with, by writing it twice:
+
+```CSS
+/* my-component.css */
+.red-bg.red-bg {
+  background-color: red;
+}
+```

--- a/docs/existing-css.md
+++ b/docs/existing-css.md
@@ -1,10 +1,10 @@
 # Using `styled-components` with existing CSS
 
-`styled-components` generates an actual stylesheet with classes, and attaches those classes to the DOM nodes of styled components via the `className` prop. It injects the generated stylesheet at the end of the HEAD of the document.
+`styled-components` generate an actual stylesheet with classes, and attaches those classes to the DOM nodes of styled components via the `className` prop. It injects the generated stylesheet at the end of the HEAD of the document.
 
 ## Styling normal React components
 
-If you use the `styled(MyNormalComponent)` notation with an existing, non-styled-components react component that doesn't use the passed-in `className` prop the styles won't be applied.
+If you use the `styled(MyNormalComponent)` notation and `MyNormalComponent` does not render the passed-in `className` prop the styles will **not** be applied.
 
 To avoid this issue, make sure your component (in this case `MyNormalComponent`) attaches the passed-in `className` to a DOM node:
 
@@ -35,7 +35,7 @@ class MyNormalComponent extends React.Component {
 
 ## Global class always overridden
 
-The other way around might happen too. You have a styled component, and a standard, global CSS class you're trying to override some styles with. For some reason though, the `styled-components` styles always end up overriding the styles of the global class, no matter what you do!
+You can apply a global CSS class to a styled component by adding a `className` prop. This will work, but if a specific CSS property (e.g. `background-color`) is defined in both the global CSS _and_ the styled component the results may not be what your expecting!
 
 A contrived example:
 


### PR DESCRIPTION
- Add section about the Sublime Text PR to the README
- Add "Using styled-components with existing CSS" doc (closes #85)
- Updated css-we-support to be more explicit about the fact that you can use all of CSS
- Move made-and-supported-by section to the top of the README

/cc @geelen and @samit4me for review ([live preview](https://github.com/styled-components/styled-components/blob/more-docs/README.md))