### PR TITLE
Custom Properties (CSS Variables) support

### DIFF
--- a/src/test/e2e.test.js
+++ b/src/test/e2e.test.js
@@ -280,13 +280,21 @@ describe('e2e', () => {
     })
   })
 
-  describe('prefixes', () => {
-    it('should add them in the right order', () => {
+  describe('css features', () => {
+    it('should add vendor prefixes in the right order', () => {
       const Comp = styled.div`
         transition: opacity 0.3s;
       `
       shallow(<Comp />)
       expect(toCSS(styleSheet).replace(/\s+/g, ' ')).toEqual('.a { -ms-transition: opacity 0.3s; -moz-transition: opacity 0.3s; -webkit-transition: opacity 0.3s; transition: opacity 0.3s; }')
+    })
+    it('should pass through custom properties', () => {
+      const Comp = styled.div`
+        --custom-prop: some-val;
+      `
+      shallow(<Comp />)
+      expect(toCSS(styleSheet).replace(/\s+/g, ' '))
+        .toEqual('.a { --custom-prop: some-val; }')
     })
   })
 

--- a/src/utils/autoprefix.js
+++ b/src/utils/autoprefix.js
@@ -4,6 +4,9 @@ import { autoprefix } from 'glamor/lib/autoprefix'
 
 export default root => {
   root.walkDecls(decl => {
+    /* No point even checking custom props */
+    if (decl.prop.startsWith('--')) return
+
     const objStyle = { [camelizeStyleName(decl.prop)]: decl.value }
     const prefixed = autoprefix(objStyle)
     Object.keys(prefixed).reverse().forEach(newProp => {


### PR DESCRIPTION
Camelizing and hyphenating breaks custom props, so if we see one of them just skip our janky autoprefixer.