### PR TITLE
[WIP] Setup Danger to check PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - ruby -v
 script:
   - danger
-  - npm run lint && npm run test && npm run flow
+  - npm run lint && npm run test
 notifications:
   email:
     on_failure: change

--- a/Dangerfile
+++ b/Dangerfile
@@ -69,12 +69,6 @@ if github.pr_body.length < 5
 end
 
 
-# Enforce rebases to remove "Merge master into bla" commits
-if git.commits.any? { |c| c.message =~ /^Merge branch/ }
-  fail("Please rebase to get rid of the merge commits in this PR")
-end
-
-
 # Enforce CHANGELOG.md entries for each PR that touches .js files (include src/vendor/**)
 if !git.modified_files.include?("CHANGELOG.md") && has_app_changes
   fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/styled-components/styled-components/blob/master/CHANGELOG.md).")


### PR DESCRIPTION
Hi @mxstbr, I've integrated Danger in the project: 

- Add Dangerfile with basics rules (see #95)
- Add danger command to Travis flow

I've already created a [bot](https://github.com/StylishDangerCI) and you can use this one if you want, I give you the credentials and then you can add the token in Travis ([how to](https://danger.systems/guides/getting_started.html#creating-a-bot-account-for-danger-to-use)).

### Implemented rules

- [x] Enforce CHANGELOG.md entries for each PR that touches .js files
- [x] A change was made in StyledComponent.js that wasn't made in StyledNativeComponent.js – warn that this might have to be done
- [x] Warn that changes to ThemeProvider.js, StyledComponent.js or StyledNativeComponent.js might be semver major changes if they touch the context stuff
- [x] Don't let testing shortcuts be merged into master (fit, fdescribe, it.only, describe.only)
- [x] Enforce rebases to remove "Merge master into bla" commits?
- [x] Enforce that a test must be added for the changes? (not sure if this makes sense for everything, maybe enforce for all .js files in the src/ folder except for src/vendor)
- [ ] Enforce a certain commit style? Not sure if this is really necessary.
Anything else you can come up with that might be an issue with PRs more often than not!


for this one
>  Enforce that a test must be added for the changes? (not sure if this makes sense for everything, maybe enforce for all .js files in the src/ folder except for src/vendor)

Danger print a warning like this:
"There're library changes, but not tests. That's OK as long as you're refactoring existing code."

Because, yeah you could refactoring sometimes :) What do you think?


### Extra rules

- [x] Warn for big PR (> 500 lines)
- [x] Congrats for version bump up :tada:
- [x] Warn if an external contributor (a person who is not part of the organization) changes `package.json`
- [x] Fail if PR body is missing (< 5 lines)

What do you think about these rules? Maybe too many messages can add too much noise in the PR's thread...

You can find some experiments in my [fork](https://github.com/nickgnd/styled-components/pulls), but pay attention, some of them are out of date with the current rules.

Let me know, bye  😄 