### PR TITLE
Possible performance improvement moving componentStyle.generateAndInjectStyles out of render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. If a contri
 
 - N/A
 
+### Changed
+Performance enhancer: Modified the `StyleComponent.js` so that `generateAndInjectStyles` is called outside of `render`.
+
 ## [v1.0.8] - 2016-10-18
 
 ### Added

--- a/example/devServer.js
+++ b/example/devServer.js
@@ -25,6 +25,10 @@ const port = 3000
 
 app.use(Express.static('dist'))
 
+app.get('/with-perf.html', (req, res) => {
+  res.sendFile(path.join(__dirname, 'with-perf.html'))
+})
+
 app.get('/*', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'))
 })

--- a/example/with-perf.html
+++ b/example/with-perf.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example with Perf logging</title>
+  </head>
+  <body>
+    <h1>Example with Perf logging</h1>
+    <div id="container"></div>
+    <script src="https://unpkg.com/react@15/dist/react-with-addons.js"></script>
+    <script src="https://unpkg.com/react-dom@15.3.2/dist/react-dom.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
+    <script src="/styled-components.js"></script>
+    <script type="text/babel">
+
+    const Perf = React.addons.Perf;
+
+    // Create a <Title> react component that renders an <h1> which is
+    // centered, palevioletred and sized at 1.5em
+    const Title = styled.default.h1`
+      font-size: 1.5em;
+      text-align: center;
+      color: palevioletred;
+    `;
+
+    // Create a <Wrapper> react component that renders a <section> with
+    // some padding and a papayawhip background
+    const Wrapper = styled.default.section`
+      padding: 4em;
+      background: papayawhip;
+    `;
+      class Example extends React.Component {
+        render() {
+          return (
+            <Wrapper {...this.props}>
+              <Title>Hello World, this is my first styled component!</Title>
+            </Wrapper>
+          )
+        }
+      }
+
+
+      class ExampleWithPerf extends React.Component {
+        componentWillMount() {
+          Perf.start();
+        }
+
+				stopProfile() {
+					Perf.stop();
+					const measurements = Perf.getLastMeasurements();
+					Perf.printInclusive(measurements);
+				}
+
+        componentDidMount() {
+					this.stopProfile()
+					let i = 0;
+					setInterval(() => {
+						this.setState({
+							i
+						});
+						// i++
+					}, 1000)
+        }
+
+        componentWillReceiveProps() {
+          Perf.start()
+        }
+
+        componentDidUpdate() {
+        	this.stopProfile()
+        }
+
+        render() {
+          return <Example {...this.state} />
+        }
+      }
+
+      ReactDOM.render(
+        <ExampleWithPerf />,
+        document.getElementById('container')
+      );
+    </script>
+  </body>
+</html>

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -29,6 +29,7 @@ export default (ComponentStyle: any) => {
       static target: Target
       state: {
         theme: any,
+        generatedClassName: string
       }
       unsubscribe: Function
 
@@ -36,10 +37,21 @@ export default (ComponentStyle: any) => {
         super()
         this.state = {
           theme: null,
+          generatedClassName: '',
         }
       }
 
+      generateAndInjectStyles() {
+        const theme = this.state.theme || {}
+        const executionContext = Object.assign({}, this.props, { theme })
+        const generatedClassName = componentStyle.generateAndInjectStyles(executionContext)
+        this.setState({
+          generatedClassName,
+        })
+      }
+
       componentWillMount() {
+        this.generateAndInjectStyles()
         // If there is a theme in the context, subscribe to the event emitter. This
         // is necessary due to pure components blocking context updates, this circumvents
         // that by updating when an event is emitted
@@ -58,13 +70,15 @@ export default (ComponentStyle: any) => {
         }
       }
 
+      componentWillReceiveProps() {
+        this.generateAndInjectStyles()
+      }
+
       /* eslint-disable react/prop-types */
       render() {
         const { className, children, innerRef } = this.props
-        const theme = this.state.theme || {}
-        const executionContext = Object.assign({}, this.props, { theme })
+        const { generatedClassName } = this.state
 
-        const generatedClassName = componentStyle.generateAndInjectStyles(executionContext)
         const propsForElement = {}
         /* Don't pass through non HTML tags through to HTML elements */
         Object.keys(this.props)

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -36,22 +36,17 @@ export default (ComponentStyle: any) => {
       constructor() {
         super()
         this.state = {
-          theme: null,
+          theme: {},
           generatedClassName: '',
         }
       }
 
-      generateAndInjectStyles() {
-        const theme = this.state.theme || {}
-        const executionContext = Object.assign({}, this.props, { theme })
-        const generatedClassName = componentStyle.generateAndInjectStyles(executionContext)
-        this.setState({
-          generatedClassName,
-        })
+      generateAndInjectStyles(theme: any, props: any) {
+        const executionContext = Object.assign({}, props, { theme })
+        return componentStyle.generateAndInjectStyles(executionContext)
       }
 
       componentWillMount() {
-        this.generateAndInjectStyles()
         // If there is a theme in the context, subscribe to the event emitter. This
         // is necessary due to pure components blocking context updates, this circumvents
         // that by updating when an event is emitted
@@ -59,8 +54,12 @@ export default (ComponentStyle: any) => {
           const subscribe = this.context[CHANNEL]
           this.unsubscribe = subscribe(theme => {
             // This will be called once immediately
-            this.setState({ theme })
+            const generatedClassName = this.generateAndInjectStyles(theme, this.props)
+            this.setState({ theme, generatedClassName })
           })
+        } else {
+          const generatedClassName = this.generateAndInjectStyles({}, this.props)
+          this.setState({ generatedClassName })
         }
       }
 
@@ -70,8 +69,9 @@ export default (ComponentStyle: any) => {
         }
       }
 
-      componentWillReceiveProps() {
-        this.generateAndInjectStyles()
+      componentWillReceiveProps(nextProps: any) {
+        const generatedClassName = this.generateAndInjectStyles(this.state.theme, nextProps)
+        this.setState({ generatedClassName })
       }
 
       /* eslint-disable react/prop-types */


### PR DESCRIPTION
My performance testing experience is quite limited and this is the first time I've used `react-addons-perf`.

While we were perusing the styled-components code we got to wondering about the use of `generateAndInjectStyles` in the `render` method of `StyledComponent`. Our first thought was that a side-effecty method-call probably shouldn't happen in the `render` method but rather in one of the lifecycle hooks such as `componentWillReceiveProps`, therefor keeping `render` a pure method.

I wanted to add some benchmarks to see if the change made any difference as well as trying out a few other things that might have improved performance (playing around with `shouldComponentUpdate` etc).

After putting together a benchmark based on the existing example it looks like there may be a performance improvement made by moving `generateAndInjectStyles` out of `render` and into `componentWillReceiveProps`.

Like I say, my perf experience and knowledge is very limited but I ran these stats over and over to make sure the results were consistent and it seems to be the case. It's also very likely that I'm completely missing something so bare with me on this one.

Here's some numbers from before and after the adjustment. The initial times are the first render. The next two metrics are re-renders after the container hosting the `<Example />` component gets re-rendered due to a state change.

**Before:**
 
<img width="702" alt="with-code-in-render" src="https://cloud.githubusercontent.com/assets/1519443/19661582/2f769e44-9a2c-11e6-8cf8-fc44d5d8eb0e.png">

You can see here that the inclusive render time of `Example > styled.section` (index 2) is `6.54ms` and `Example > styled.h1` (index 3) is `0.68ms`.

**After**

<img width="697" alt="with-code-moved" src="https://cloud.githubusercontent.com/assets/1519443/19661667/7d43514e-9a2c-11e6-9e9b-4e5e42198ed8.png">

After I moved `generateAndInjectStyles` and the other code it's reliant on, out of `render` the inclusive render time of `Example > styled.section` (index 2) has dropped to `0.32ms` and `Example > styled.h1` (index 3) is `0.04ms`.

This seems to suggest a fair performance improvement by shifting the code from `render`.

I've included the benchmark example file that I used to create these results. If I've missed something let me know and feel free to ignore this. If this is of some use then great!
