### PR TITLE
Use `innerRef` to get DOM node in the example code

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -155,7 +155,7 @@ class Form extends Component {
 
   render() {
     return (
-      <StyledInput ref={(comp) => { this.input = comp }} />
+      <StyledInput innerRef={(comp) => { this.input = comp }} />
     )
   }
 }


### PR DESCRIPTION
The doc says to use `innerRef` on a styled component to get its DOM node, but the code example uses `ref`. This change updates the code example to be consistent with the docs.