### PR TITLE
Add "Using styled-components with webpack 2" to the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,41 @@ Button.defaultProps = {
 
 See [the documentation](./docs) for more information about using `styled-components`.
 
+### Using styled-components with webpack 2
+
+If you're using `styled-components` with webpack 2 and you use the babel-loader you need to turn of `babel-plugin-transform-es2015-modules-commonjs`. You can do this with a configuration object passed to the es2015 or latest preset.
+
+For `babel-preset-es2015`:
+```JS
+  presets: [
+    ['es2015', {
+      modules: false
+    }]
+  ]
+```
+
+For `babel-preset-latest`:
+```JS
+  presets: [
+    ['latest': {
+      es2015: {
+        modules: false
+      }
+    }]
+  ]
+```
+
+If you can't do this for whatever reason you have to hint webpack to load the commonjs bundle of `style-components`. You can do this by adding this to you webpack configuration:
+
+```JS
+alias: {
+  // Use styled-components commonjs bundle instead of the es modules bundle
+  'styled-components$': 'styled-components/lib/index.js',
+}
+```
+
+In a future version of webpack this bug should be fixed. See [issue#115](https://github.com/styled-components/styled-components/issues/115), [issue#157](https://github.com/styled-components/styled-components/issues/157) and [webpack-issue#3168](https://github.com/webpack/webpack/issues/3168) for further information.
+
 ### Table of Contents
 
 - [API Reference](./docs/api.md)

--- a/README.md
+++ b/README.md
@@ -394,41 +394,6 @@ Button.defaultProps = {
 
 See [the documentation](./docs) for more information about using `styled-components`.
 
-### Using styled-components with webpack 2
-
-If you're using `styled-components` with webpack 2 and you use the babel-loader you need to turn of `babel-plugin-transform-es2015-modules-commonjs`. You can do this with a configuration object passed to the es2015 or latest preset.
-
-For `babel-preset-es2015`:
-```JS
-  presets: [
-    ['es2015', {
-      modules: false
-    }]
-  ]
-```
-
-For `babel-preset-latest`:
-```JS
-  presets: [
-    ['latest': {
-      es2015: {
-        modules: false
-      }
-    }]
-  ]
-```
-
-If you can't do this for whatever reason you have to hint webpack to load the commonjs bundle of `style-components`. You can do this by adding this to you webpack configuration:
-
-```JS
-alias: {
-  // Use styled-components commonjs bundle instead of the es modules bundle
-  'styled-components$': 'styled-components/lib/index.js',
-}
-```
-
-In a future version of webpack this bug should be fixed. See [issue#115](https://github.com/styled-components/styled-components/issues/115), [issue#157](https://github.com/styled-components/styled-components/issues/157) and [webpack-issue#3168](https://github.com/webpack/webpack/issues/3168) for further information.
-
 ### Table of Contents
 
 - [API Reference](./docs/api.md)
@@ -437,6 +402,7 @@ In a future version of webpack this bug should be fixed. See [issue#115](https:/
 - [Using `styled-components` with existing CSS](./docs/existing-css.md): Some edge cases you should be aware of when using `styled-components` with an existing CSS codebase
 - [What CSS we support](./docs/css-we-support.md): What parts & extensions of CSS can you use within a component? *(Spoiler: all of CSS plus even more)*
 - [Theming](./docs/theming.md): How to work with themes
+- [FAQ](./docs/faq.md): Frequently Asked Questions
 
 ## Linting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ This is the `styled-components` documentation.
 - [Using `styled-components` with existing CSS](./existing-css.md): Some edge cases you should be aware of when using `styled-components` with an existing CSS codebase
 - [What CSS we support](./css-we-support.md): What parts & extensions of CSS can you use within a component?
 - [Theming](./theming.md): How to work with themes
+- [FAQ](./faq.md): Frequently Asked Questions

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,36 @@
+# FAQ
+
+### Using styled-components with webpack 2
+
+If you're using `styled-components` with webpack 2 and you use the babel-loader you need to turn of `babel-plugin-transform-es2015-modules-commonjs`. You can do this with a configuration object passed to the es2015 or latest preset.
+
+For `babel-preset-es2015`:
+```JS
+  presets: [
+    ['es2015', {
+      modules: false
+    }]
+  ]
+```
+
+For `babel-preset-latest`:
+```JS
+  presets: [
+    ['latest': {
+      es2015: {
+        modules: false
+      }
+    }]
+  ]
+```
+
+If you can't do this for whatever reason you have to hint webpack to load the commonjs bundle of `style-components`. You can do this by adding this to you webpack configuration:
+
+```JS
+alias: {
+  // Use styled-components commonjs bundle instead of the es modules bundle
+  'styled-components$': 'styled-components/lib/index.js',
+}
+```
+
+In a future version of webpack this bug should be fixed. See [issue#115](https://github.com/styled-components/styled-components/issues/115), [issue#157](https://github.com/styled-components/styled-components/issues/157) and [webpack-issue#3168](https://github.com/webpack/webpack/issues/3168) for further information.


### PR DESCRIPTION
Some people had problems with styled-components in connection with webpack 2 and babel.
This adds an instruction how to solve the problem to the readme.md