### PR TITLE
Only generate styles on mount or props change for StyledNativeComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+- Modify `StyleNativeComponent.js` so that `generateAndInjectStyles` is called outside of `render`, thanks to [@sheepsteak](https://github.com/sheepsteak). (see [#171](https://github.com/styled-components/styled-components/pull/171))
+
 ## [v1.1.1]
 
 ### Changed

--- a/src/models/AbstractStyledComponent.js
+++ b/src/models/AbstractStyledComponent.js
@@ -7,7 +7,8 @@ export default class AbstractStyledComponent extends Component {
   static isPrototypeOf: Function
   state: {
     theme: any,
-    generatedClassName?: string
+    generatedClassName?: string,
+    generatedStyles?: any
   }
   unsubscribe: () => void
 }

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -38,9 +38,24 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
         const subscribe = this.context[CHANNEL]
         this.unsubscribe = subscribe(theme => {
           // This will be called once immediately
-          this.setState({ theme })
+          const generatedStyles = this.generateAndInjectStyles(theme, this.props)
+          this.setState({ generatedStyles, theme })
         })
+      } else {
+        const generatedStyles = this.generateAndInjectStyles(
+          this.props.theme || {},
+          this.props
+        )
+        this.setState({ generatedStyles })
       }
+    }
+
+    componentWillReceiveProps(nextProps: any) {
+      const generatedStyles = this.generateAndInjectStyles(
+        this.state.theme || this.props.theme,
+        nextProps
+      )
+      this.setState({ generatedStyles })
     }
 
     componentWillUnmount() {
@@ -56,9 +71,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
     /* eslint-disable react/prop-types */
     render() {
       const { style, children, innerRef } = this.props
-      const theme = this.state.theme || this.props.theme || {}
-
-      const generatedStyles = this.generateAndInjectStyles(theme, this.props)
+      const { generatedStyles } = this.state
 
       const propsForElement = { ...this.props }
       propsForElement.style = [generatedStyles, style]


### PR DESCRIPTION
This brings the performance improvement in #137 for `StyledComponent` into `StyledNativeComponent` as well.

This also fixes #138 as props are now passed into the rules. 