### PR TITLE
Use em in Media Templates example

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -150,8 +150,11 @@ const sizes = {
 
 // iterate through the sizes and create a media template
 export const media = Object.keys(sizes).reduce((accumulator, label) => {
+  // use em in breakpoints to work properly cross-browser and support users
+  // changing their browsers font-size: https://zellwk.com/blog/media-query-units/
+  const emSize = sizes[label] / 16
   accumulator[label] = (...args) => css`
-    @media (max-width: ${sizes[label]}px) {
+    @media (max-width: ${emSize}em) {
       ${css(...args)}
     }
   `


### PR DESCRIPTION
As per https://github.com/styled-components/styled-components/issues/182#issuecomment-260122678, this changes the Media Templates example to use `em` as the breakpoint unit to work properly cross-browser whilst supporting users who change their browser's `font-size`.

I'm a bit torn by this change, though, as it does add some complexity to the example. I glanced at the other examples that used an example of a breakpoint of `420px`, and I didn't want to go touching them, at least not yet. It is arguably a lot more difficult to think of what `26.25em` means in real world, compared to `420px`.

Source for choosing `em` over `px`: https://zellwk.com/blog/media-query-units/