### PR TITLE
pass props to interpolations in StyledNativeComponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Added
 
-- N/A
+- Fixed props that are passed to interpolations in `StyledNativeComponent`. Now, they get `theme` and component props, thanks to [@haikyuu][https://github.com/haikyuu]. (see [#190](https://github.com/styled-components/styled-components/pull/190))
 
 ### Changed
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -49,13 +49,16 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
       }
     }
 
+    generateAndInjectStyles(theme: any, props: any) {
+      const executionContext = Object.assign({}, props, { theme })
+      return inlineStyle.generateStyleObject(executionContext)
+    }
     /* eslint-disable react/prop-types */
     render() {
       const { style, children, innerRef } = this.props
       const theme = this.state.theme || this.props.theme || {}
 
-      const executionContext = Object.assign({}, this.props, { theme })
-      const generatedStyles = inlineStyle.generateStyleObject(executionContext)
+      const generatedStyles = this.generateAndInjectStyles(theme, this.props)
 
       const propsForElement = Object.assign({}, this.props)
       propsForElement.style = [generatedStyles, style]

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -54,7 +54,8 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
       const { style, children, innerRef } = this.props
       const theme = this.state.theme || this.props.theme || {}
 
-      const generatedStyles = inlineStyle.generateStyleObject({ theme, ...this.props })
+      const executionContext = Object.assign({}, this.props, { theme })
+      const generatedStyles = inlineStyle.generateStyleObject(executionContext)
 
       const propsForElement = Object.assign({}, this.props)
       propsForElement.style = [generatedStyles, style]

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -54,7 +54,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
       const { style, children, innerRef } = this.props
       const theme = this.state.theme || this.props.theme || {}
 
-      const generatedStyles = inlineStyle.generateStyleObject({ theme })
+      const generatedStyles = inlineStyle.generateStyleObject({ theme, ...this.props })
 
       const propsForElement = Object.assign({}, this.props)
       propsForElement.style = [generatedStyles, style]


### PR DESCRIPTION
In react native, interpolations had access to the theme object only. This pull request fixes that. #138