### PR TITLE
fixes #196 Converts Object.assign to spread operator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
   ],
   "plugins": [
     "add-module-exports",
-    "transform-flow-strip-types"
+    "transform-flow-strip-types",
+    "transform-object-rest-spread"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
-- N/A
+- Converted Object.assign to spread operator, thanks to [@thisguychris][https://github.com/hisguychris]. (see [#196](https://github.com/styled-components/styled-components/pull/201))
 
 ## [v1.0.11] - 2016-11-14
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-external-helpers": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-latest": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "chokidar": "^1.6.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,6 +55,7 @@ const plugins = [
     plugins: [
       'transform-flow-strip-types',
       'external-helpers',
+      'transform-object-rest-spread',
     ],
   }),
   json(),

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -34,7 +34,7 @@ export default (ComponentStyle: Function) => {
       }
 
       generateAndInjectStyles(theme: any, props: any) {
-        const executionContext = Object.assign({}, props, { theme })
+        const executionContext = { ...props, ...{ theme } }
         return componentStyle.generateAndInjectStyles(executionContext)
       }
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -34,7 +34,7 @@ export default (ComponentStyle: Function) => {
       }
 
       generateAndInjectStyles(theme: any, props: any) {
-        const executionContext = { ...props, ...{ theme } }
+        const executionContext = { ...props, theme }
         return componentStyle.generateAndInjectStyles(executionContext)
       }
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -50,7 +50,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
     }
 
     generateAndInjectStyles(theme: any, props: any) {
-      const executionContext = { ...props, ...{ theme } }
+      const executionContext = { ...props, theme }
       return inlineStyle.generateStyleObject(executionContext)
     }
     /* eslint-disable react/prop-types */

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -50,7 +50,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
     }
 
     generateAndInjectStyles(theme: any, props: any) {
-      const executionContext = Object.assign({}, props, { theme })
+      const executionContext = { ...props, ...{ theme } }
       return inlineStyle.generateStyleObject(executionContext)
     }
     /* eslint-disable react/prop-types */
@@ -60,7 +60,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
 
       const generatedStyles = this.generateAndInjectStyles(theme, this.props)
 
-      const propsForElement = Object.assign({}, this.props)
+      const propsForElement = { ...this.props }
       propsForElement.style = [generatedStyles, style]
       if (innerRef) {
         propsForElement.ref = innerRef

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -43,7 +43,7 @@ class ThemeProvider extends Component {
   }
 
   getChildContext() {
-    return { ...this.context, ...{ [CHANNEL]: this.broadcast.subscribe } }
+    return { ...this.context, [CHANNEL]: this.broadcast.subscribe }
   }
 
   componentWillReceiveProps(nextProps: ThemeProviderProps) {

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -43,7 +43,7 @@ class ThemeProvider extends Component {
   }
 
   getChildContext() {
-    return Object.assign({}, this.context, { [CHANNEL]: this.broadcast.subscribe })
+    return { ...this.context, ...{ [CHANNEL]: this.broadcast.subscribe } }
   }
 
   componentWillReceiveProps(nextProps: ThemeProviderProps) {
@@ -69,7 +69,7 @@ class ThemeProvider extends Component {
     if (!isPlainObject(theme)) {
       throw new Error('[ThemeProvider] Please make your theme prop a plain object')
     }
-    return Object.assign({}, this.outerTheme, (theme: Object))
+    return { ...this.outerTheme, ...(theme: Object) }
   }
 
   render() {

--- a/src/models/test/ThemeProvider.test.js
+++ b/src/models/test/ThemeProvider.test.js
@@ -31,7 +31,7 @@ describe('ThemeProvider', () => {
     class Child extends React.Component {
       componentWillMount() {
         this.context[CHANNEL](theme => {
-          expect(theme).toEqual(Object.assign({}, outerTheme, innerTheme))
+          expect(theme).toEqual({ ...outerTheme, ...innerTheme })
           done()
         })
       }
@@ -58,7 +58,7 @@ describe('ThemeProvider', () => {
     class Child extends React.Component {
       componentWillMount() {
         this.context[CHANNEL](theme => {
-          expect(theme).toEqual(Object.assign({}, outerestTheme, outerTheme, innerTheme))
+          expect(theme).toEqual({ ...outerestTheme, ...outerTheme, ...innerTheme })
           done()
         })
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.13.0.tgz#e741ff3992c578310be45c571bcd90a2f9c5586e"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz#2b84b7d53dd744f94ff1fad7669406274b23f541"
@@ -610,6 +614,13 @@ babel-plugin-transform-flow-strip-types@^6.14.0, babel-plugin-transform-flow-str
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.14.0.tgz#35ceb03f8770934044bab1a76f7e4ee0aa9220f9"
   dependencies:
     babel-plugin-syntax-flow "^6.8.0"
+    babel-runtime "^6.0.0"
+
+babel-plugin-transform-object-rest-spread@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz#db441d56fffc1999052fdebe2e2f25ebd28e36a9"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.0.0"
 
 babel-plugin-transform-react-display-name@^6.3.13:


### PR DESCRIPTION
- switch Object.assign to spread operator
- rationale: babel transforms this to Object assign / or a polyfill equivalent
this way we won't need to add another module like object-assign
- please take note I don't have experience with flow annotations,
so if this is valid `return Object.assign({}, this.outerTheme, (theme: Object))`
then this PR works.