### PR TITLE
switch startsWith to normal regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Added
 
-- Pass props to interpolated functions in ReactNatvie, thanks to [@haikyuu](https://github.com/haikyuu). (see [#190](https://github.com/styled-components/styled-components/pull/190))
+- Pass props to interpolated functions in React Native, thanks to [@haikyuu](https://github.com/haikyuu). (see [#190](https://github.com/styled-components/styled-components/pull/190))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Converted Object.assign to spread operator, thanks to [@thisguychris](https://github.com/thisguychris). (see [#201](https://github.com/styled-components/styled-components/pull/201), fixes [#196](https://github.com/styled-components/styled-components/issues/196))
 - Switched to using [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer) for our autoprefixing needs.
+- Switched to using regex instead of startsWith for IE10 compat, thanks to [@thisguychris](https://github.com/thisguychris). (see [#217](https://github.com/styled-components/styled-components/pull/217), fixes [#212](https://github.com/styled-components/styled-components/issues/212)
 
 ## [v1.0.11] - 2016-11-14
 

--- a/src/utils/autoprefix.js
+++ b/src/utils/autoprefix.js
@@ -9,7 +9,7 @@ import type Container from '../vendor/postcss/container'
 export default (root: Container) => {
   root.walkDecls(decl => {
     /* No point even checking custom props */
-    if (decl.prop.startsWith('--')) return
+    if (/^--/.test(decl.prop)) return
 
     const objStyle = { [camelizeStyleName(decl.prop)]: decl.value }
     const prefixed = prefixAll(objStyle)


### PR DESCRIPTION
- fixes #212
- uses regex instead of es2015 startsWith for IE10 compat