### PR TITLE
Travis: Removed sudo for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ script:
 notifications:
   email:
     on_failure: change
+cache:
+  bundler: true
+  directories:
+    - node_modules


### PR DESCRIPTION
1. You don't need sudo
2. Builds will start faster with [travis's container based infra](https://docs.travis-ci.com/user/trusty-ci-environment/#Container-based-with-sudo%3A-false)