### PR TITLE
[WIP] Per-component classnames

### DIFF
--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -25,6 +25,10 @@ export default (nameGenerator: NameGenerator) => {
       this.insertedRule = styleSheet.insert('')
     }
 
+    generateName(str: string) {
+      return nameGenerator(hashStr(str))
+    }
+
     /*
      * Flattens a rule set into valid CSS
      * Hashes it, wraps the whole chunk in a ._hashName {}

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -31,10 +31,10 @@ export default (nameGenerator: NameGenerator) => {
      * Parses that with PostCSS then runs PostCSS-Nested on it
      * Returns the hash to be injected on render()
      * */
-    generateAndInjectStyles(executionContext: Object) {
+    generateAndInjectStyles(executionContext: Object, identifier: string) {
       const flatCSS = flatten(this.rules, executionContext).join('')
         .replace(/^\s*\/\/.*$/gm, '') // replace JS comments
-      const hash = hashStr(flatCSS)
+      const hash = hashStr(identifier + flatCSS)
       if (!inserted[hash]) {
         const selector = nameGenerator(hash)
         inserted[hash] = selector

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -102,12 +102,13 @@ export default (ComponentStyle: Function) => {
     }
 
     let displayName = isTag ? `styled.${target}` : `Styled(${target.displayName})`
-    const generateIdentifierFromDisplayName = () => {
+    const generateIdentifierFromDisplayName = (hashOnly: boolean) => {
       const nr = (identifiers[displayName] || 0) + 1
       identifiers[displayName] = nr
-      StyledComponent.identifier = safeDisplayName(`${displayName}-${nr}`)
+      const hash = componentStyle.generateName(displayName + nr)
+      StyledComponent.identifier = hashOnly ? hash : safeDisplayName(`${displayName}-${hash}`)
     }
-    generateIdentifierFromDisplayName()
+    generateIdentifierFromDisplayName(true)
 
     Object.defineProperty(StyledComponent, 'displayName', {
       get() {
@@ -116,7 +117,7 @@ export default (ComponentStyle: Function) => {
       set(newName) {
         console.log('SETTING DISPLAY NAME')
         displayName = newName
-        generateIdentifierFromDisplayName()
+        generateIdentifierFromDisplayName(false)
       },
       enumerable: true,
     })

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -14,6 +14,9 @@ const flatten = (chunks: Array<Interpolation>, executionContext: ?Object): Array
     if (chunk === undefined || chunk === null || chunk === false || chunk === '') return ruleSet
     /* Flatten ruleSet */
     if (Array.isArray(chunk)) return [...ruleSet, ...flatten(chunk, executionContext)]
+
+    if (chunk.identifier !== undefined) return [...ruleSet, `.${chunk.identifier}`]
+
     /* Either execute or defer the function */
     if (typeof chunk === 'function') {
       return executionContext


### PR DESCRIPTION
Super hacky proof of concept, but something's been bugging me for a while about Styled Components — we don't have any classnames that are _always_ going to be attached on a component. This is the key problem with supporting #142 but it also causes a few DX annoyances, prevents an optimisation, and presents one nasty af potential bug that nobody has hit yet...

One annoyance is that, in dev tools, you don't have a single class hook to tweak settings if you have several instances of a component with different props. `<Button primary>` and `<Button>` will generate totally different classnames, so you can't jump in to dev tools and _tweak all the buttons_. If they share a classname, you can.

It also means that #160 is harder than it should be. If there's a unique class for every Styled Component then in dev you can make that whatever you like. 5 internet high fives for the person who implements BEM-style `.app_components_Logo_Inner` classnames using the directory structure 👍 , ping @markdalgleish.

The performance optimisation has to do with #134. If we had a single shared classname for all instances of a SC then we could potentially lift all the static styles into them. Then, when props change, we're injecting just the styles that depend on props. I'm not convinced this will be a _massive_ gain but it certainly would map better to how people think about their styles.

And finally the nasty af bug. Consider this setup:

```js
const A = styled.div`
  color: blue;
`

injectGlobal`
  /* contrived example, but all you need is a rule with equal specificity
     so source order becomes important */
  .override {
    color: red;
  }
`

const B = styled.div`
  color: ${props => props.selected ? 'blue' : 'green'};
`

<A className="override"/> // red, since .override appears later
<B className="override"/> // green, since it is rendered afterwards
<B selected className="override"/> // red, not blue !!
```

The problem arises from the internal cache about rendered styles. If two components end up producing the exact same CSS, we'll only inject a single class. Which means in cases where source-order is important (two rules applying with equal specificity) the result can be unpredictable. But, without a legitimate per-component identifier, the alternative (render the same selector twice) is actually kinda worse, since it would break components you're not looking at. In the above example, rendering a single  `<B selected>` would change all the  `<A className="override">` on the page to blue!! 😱

So, it's something I've wanted for a while, but the problem is there's no deterministic information from which to derive a per-component identifier. This PR uses a simple counter, so the 5th time you call `styled.div` you'll get a classname based on a hash of `div` and `5` (`.sc-ioLzpW` at the time of writing). If you have two components with `displayName = 'Inner'`, the first will get a classname of `.Inner-jaWsLN` and the second `.Inner-dBMIyz`). Which works really _really_ well, replaces #160 and made #142 a one-line change 😎

![image](https://cloud.githubusercontent.com/assets/23264/20468205/3f5064a4-afe8-11e6-82e0-85d02c250c2f.png)

Note the empty `.Inner-jaWsLN` tag in dev tools. Makes it really to tweak all instances at once 👍 

The only issue is SSR, which we're about to land support for in #214. On the server, components for different pages might all be loaded, and so relying on order-of-instantiation will cause a checksum mismatch on the client. Not good.

So I've built this with a potential babel transform in mind, which would go through all StyledComponents instances and generates a deterministic `identifier`, much the way [babel-plugin-styled-components-named](https://github.com/vdanchenkov/babel-plugin-styled-components-named) generates `displayName`s. If that bundle is sent down to the client the counter won't be used and the checksum will match.

I don't really have any time before CSS Conf AU next week to go any further with this, but as a proof of concept it really does prove the concept. We can bikeshed the generated classnames but I'm pretty convinced per-component classnames are the way to go. Anyone keen to take this and run with it?