### PR TITLE
Bump css-to-react-native to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+## [v1.1.1]
+
+### Changed
+
+- Bumped `css-to-react-native` to `v1.0.3` to avoid floating points number bug.
+
 ## [v1.1.0]
 
 ### Added
@@ -100,7 +106,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Fixed compatibility with other react-broadcast-based systems (like `react-router` v4)
 
-[Unreleased]: https://github.com/styled-components/styled-components/compare/v1.1.0...master
+[Unreleased]: https://github.com/styled-components/styled-components/compare/v1.1.1...master
+[v1.1.1]: https://github.com/styled-components/styled-components/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/styled-components/styled-components/compare/v1.0.11...v1.1.0
 [v1.0.11]: https://github.com/styled-components/styled-components/compare/v1.0.10...v1.0.11
 [v1.0.10]: https://github.com/styled-components/styled-components/compare/v1.0.9...v1.0.10

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://styled-components.com",
   "dependencies": {
     "buffer": "^5.0.0",
-    "css-to-react-native": "^1.0.0",
+    "css-to-react-native": "^1.0.3",
     "fbjs": "^0.8.4",
     "glamor": "^2.15.5",
     "inline-style-prefixer": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
   "main": "lib/index.js",
   "jsnext:main": "dist/styled-components.es.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,9 +1162,9 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-to-react-native@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-1.0.2.tgz#0e3d63fa4965895d5fa96c641cb16eb60ed23ab3"
+css-to-react-native@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-1.0.3.tgz#17bd12d334e76023bf3d52fdc093549179f03bee"
   dependencies:
     css-color-list "0.0.1"
     fbjs "^0.8.5"


### PR DESCRIPTION
Bumps `css-to-react-native` to `1.0.3` to fix #231 for everybody installing `styled-components` afresh! /cc @jacobp100 