### PR TITLE
Remove duplicate lib in flow-support's examples

### DIFF
--- a/docs/flow-support.md
+++ b/docs/flow-support.md
@@ -64,7 +64,6 @@ flow-typed
 node_modules/styled-components/flow-typed/react-native.js
 node_modules/styled-components/flow-typed/glamor_vx.x.x.js
 node_modules/styled-components/flow-typed/lodash_v4.x.x.js
-node_modules/styled-components/flow-typed/react-native.js
 node_modules/styled-components/flow-typed/inline-style-prefixer_vx.x.x.js
 
 [options]


### PR DESCRIPTION
Remove the duplicate `react-native.js` flow-typed file reference in the flow-support's example section.