### PR TITLE
Add workaround for React Native border radius property due to issues …

### DIFF
--- a/flow-typed/npm/css-to-react-native_v1.x.x.js
+++ b/flow-typed/npm/css-to-react-native_v1.x.x.js
@@ -1,3 +1,3 @@
 declare module 'css-to-react-native' {
-  declare module.exports: ([string, string])[] => { [key:string]: string }
+  declare module.exports: ([string, string])[] => { [key:string]: any }
 }

--- a/src/models/InlineStyle.js
+++ b/src/models/InlineStyle.js
@@ -26,15 +26,20 @@ export default class InlineStyle {
     if (!generated[hash]) {
       const root = parse(flatCSS)
       const declPairs = []
+      const workaroundValues = {}
       root.each(node => {
         if (node.type === 'decl') {
-          declPairs.push([node.prop, node.value])
+          if (/border-?radius/i.test(node.prop)) {
+            workaroundValues.borderRadius = Number(node.value)
+          } else {
+            declPairs.push([node.prop, node.value])
+          }
         } else {
           /* eslint-disable no-console */
           console.warn(`Node of type ${node.type} not supported as an inline style`)
         }
       })
-      const styleObject = transformDeclPairs(declPairs)
+      const styleObject = Object.assign(transformDeclPairs(declPairs), workaroundValues)
       const styles = StyleSheet.create({
         generated: styleObject,
       })

--- a/src/models/InlineStyle.js
+++ b/src/models/InlineStyle.js
@@ -30,6 +30,10 @@ export default class InlineStyle {
       root.each(node => {
         if (node.type === 'decl') {
           if (/border-?radius/i.test(node.prop)) {
+            // RN currently does not support differing values for the corner radii of Image
+            // components (but does for View). It is almost impossible to tell whether we'll have
+            // support, so we'll just disable multiple values here.
+            // https://github.com/styled-components/css-to-react-native/issues/11
             workaroundValues.borderRadius = Number(node.value)
           } else {
             declPairs.push([node.prop, node.value])


### PR DESCRIPTION
…with Image elements only accepting a single value for all radii