### PR TITLE
Fix theming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+- Fixed theme changes using `<ThemeProvider />` where classNames didn't changed at the component [@k15a](https://github.com/k15a)
+
 ## [v1.1.2]
 
 ### Added

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -48,6 +48,7 @@ export default (ComponentStyle: Function) => {
           const subscribe = this.context[CHANNEL]
           this.unsubscribe = subscribe(theme => {
             // This will be called once immediately
+            this.theme = theme
             const generatedClassName = this.generateAndInjectStyles(theme, this.props)
             this.setState({ theme, generatedClassName })
           })
@@ -62,7 +63,7 @@ export default (ComponentStyle: Function) => {
       }
 
       componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
-        const theme = nextProps.theme || this.state.theme
+        const theme = nextProps.theme || this.theme
 
         const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
         this.setState({ theme, generatedClassName })

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -48,7 +48,6 @@ export default (ComponentStyle: Function) => {
           const subscribe = this.context[CHANNEL]
           this.unsubscribe = subscribe(theme => {
             // This will be called once immediately
-            this.theme = theme
             const generatedClassName = this.generateAndInjectStyles(theme, this.props)
             this.setState({ theme, generatedClassName })
           })
@@ -63,10 +62,12 @@ export default (ComponentStyle: Function) => {
       }
 
       componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
-        const theme = nextProps.theme || this.theme
+        this.setState((oldState) => {
+          const theme = nextProps.theme || oldState.theme
+          const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
 
-        const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
-        this.setState({ theme, generatedClassName })
+          return { theme, generatedClassName }
+        })
       }
 
       componentWillUnmount() {

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -40,6 +40,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
         const subscribe = this.context[CHANNEL]
         this.unsubscribe = subscribe(theme => {
           // This will be called once immediately
+          this.theme = theme
           const generatedStyles = this.generateAndInjectStyles(theme, this.props)
           this.setState({ generatedStyles, theme })
         })
@@ -54,7 +55,7 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
     }
 
     componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
-      const theme = nextProps.theme || this.state.theme
+      const theme = nextProps.theme || this.theme
 
       const generatedStyles = this.generateAndInjectStyles(theme, nextProps)
       this.setState({ generatedStyles, theme })

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -40,7 +40,6 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
         const subscribe = this.context[CHANNEL]
         this.unsubscribe = subscribe(theme => {
           // This will be called once immediately
-          this.theme = theme
           const generatedStyles = this.generateAndInjectStyles(theme, this.props)
           this.setState({ generatedStyles, theme })
         })
@@ -55,10 +54,12 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
     }
 
     componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
-      const theme = nextProps.theme || this.theme
+      this.setState((oldState) => {
+        const theme = nextProps.theme || oldState.theme
+        const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
 
-      const generatedStyles = this.generateAndInjectStyles(theme, nextProps)
-      this.setState({ generatedStyles, theme })
+        return { theme, generatedClassName }
+      })
     }
 
     componentWillUnmount() {

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -1,5 +1,6 @@
 // @flow
-import jsdom from 'mocha-jsdom';
+import expect from 'expect'
+import jsdom from 'mocha-jsdom'
 import React from 'react'
 import { mount, render } from 'enzyme'
 
@@ -211,5 +212,34 @@ describe('theming (jsdom)', () => {
 
     wrapper.setProps({ zIndex: 1 });
     expectCSSMatches(`${expectedStyles}.c { color: pink; z-index: 1px; }`)
-  });
+  })
+
+  it('should change the classnames when the theme changes', () => {
+    const Comp = styled.div`
+      color: ${props => props.theme.color};
+    `
+
+    const originalTheme = { color: 'black' }
+    const newTheme = { color: 'blue' }
+
+    const Theme = ({ theme }) => (
+      <ThemeProvider theme={theme}>
+        <Comp someProps={theme} />
+      </ThemeProvider>
+    )
+
+    const wrapper = mount(
+      <Theme theme={originalTheme} />
+    )
+
+
+    expectCSSMatches(`.a { color: ${originalTheme.color}; }`)
+    expect(wrapper.find('div').prop('className')).toBe('a')
+
+    // Change theme
+    wrapper.setProps({ theme: newTheme })
+
+    expectCSSMatches(`.a { color: ${originalTheme.color}; }.b { color: ${newTheme.color}; }`)
+    expect(wrapper.find('div').prop('className')).toBe('b')
+  })
 })


### PR DESCRIPTION
If the subscribe function triggers a state change the componentWillReceiveProps lifecycle will still have the old state. Setting a property called theme circumvents this. In my opinion this is a React bug because the subscribe function changes the state before the componentWillReceiveProps lifecycle will fire.