### PR TITLE
Fix overriding theme with props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. If a contri
 ### Changed
 
 - Fixed theme changes using `<ThemeProvider />` where classNames didn't changed at the component [@k15a](https://github.com/k15a)
+- Fixed overriding theme through props [@k15a](https://github.com/k15a)
 
 ## [v1.1.2]
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -46,8 +46,9 @@ export default (ComponentStyle: Function) => {
         // that by updating when an event is emitted
         if (this.context[CHANNEL]) {
           const subscribe = this.context[CHANNEL]
-          this.unsubscribe = subscribe(theme => {
+          this.unsubscribe = subscribe(nextTheme => {
             // This will be called once immediately
+            const theme = this.props.theme || nextTheme
             const generatedClassName = this.generateAndInjectStyles(theme, this.props)
             this.setState({ theme, generatedClassName })
           })

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -38,8 +38,9 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
       // that by updating when an event is emitted
       if (this.context[CHANNEL]) {
         const subscribe = this.context[CHANNEL]
-        this.unsubscribe = subscribe(theme => {
+        this.unsubscribe = subscribe(nextTheme => {
           // This will be called once immediately
+          const theme = this.props.theme || nextTheme
           const generatedStyles = this.generateAndInjectStyles(theme, this.props)
           this.setState({ generatedStyles, theme })
         })

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -64,6 +64,25 @@ describe('theming', () => {
     expectCSSMatches(`.a { color: purple; }`)
   })
 
+  it('should properly allow a component to override the theme with a prop', () => {
+    const Comp = styled.div`
+      color: ${props => props.theme.color};
+    `
+
+    const theme = {
+      color: 'purple',
+    }
+
+    render(
+      <div>
+        <ThemeProvider theme={theme}>
+          <Comp theme={{ color: 'red' }}/>
+        </ThemeProvider>
+      </div>
+    )
+    expectCSSMatches(`.a { color: red; }`)
+  })
+
   it('should properly set the theme with an empty object when no teme is provided and no defaults are set', () => {
     const Comp1 = styled.div`
       color: ${props => props.theme.color};


### PR DESCRIPTION
At the initial render styled-components was taking the theme from ThemeProvider even the component had an own theme prop.