### PR TITLE
withTheme Higher Order Component (fix #272)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
     "flow-react-proptypes",
     "add-module-exports",
     "transform-flow-strip-types",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Added
 
+- Added [`withTheme`](docs/api.md#withtheme) higher order component; thanks [@brunolemos](https://twitter.com/brunolemos). (see [#312] (https://github.com/styled-components/styled-components/pull/312))
 - Fixed prop changes not updating style on react native; thanks [@brunolemos](https://twitter.com/brunolemos). (see [#311](https://github.com/styled-components/styled-components/pull/311))
 
 ### Changed

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,7 +66,7 @@ This can take any combination of
 
 > **Note**: You can also pass an Object as an interpolation, and we will treat it like inline styles. This is highly discouraged, as the CSS syntax has support for media queries, nesting, etc., which the object syntax doesn't.
 
-The properties that are passed into an interpolated function get attached a special property, `theme`, which is injected by a higher level [`ThemeProvider`](#theme-provider) component.
+The properties that are passed into an interpolated function get attached a special property, `theme`, which is injected by a higher level [`ThemeProvider`](#themeprovider) component.
 
 #### Examples
 
@@ -258,3 +258,38 @@ injectGlobal`
 	}
 `;
 ```
+
+### `withTheme`
+
+`web`, `native`.
+
+This is a `higher order component` to get the current theme from [`ThemeProvider`](#themeprovider) and pass it to another component as a `theme` prop.
+
+#### Arguments
+
+1. `component` _(Function|class)_: Any valid react component that can handle a `theme` prop.
+
+#### Returns
+
+(`component`): The passed component inside a wrapper. The passed component will receive a `theme` prop with the current theme object.
+
+#### Example
+
+```JS
+import { withTheme } from 'styled-components'
+
+class MyComponent extends React.Component {
+  render() {
+    const { theme } = this.props
+
+    console.log('Current theme: ', theme);
+    // ...
+  }
+}
+
+export default withTheme(MyComponent)
+```
+
+#### Tips
+
+- Only use this if you need to get the theme as a prop. If you just need to set a valid stylesheet property, you can use normal [theming](./theming.md) for this.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -55,3 +55,22 @@ const InvertColors = ({children}) => (
   </ThemeProvider>
 )
 ```
+
+## Getting the theme outside styled components
+
+If you ever need to get the current `theme` outside styled components (e.g. inside big components), you can use the `withTheme` Higher Order Component:
+
+```JS
+import { withTheme } from 'styled-components'
+
+class MyComponent extends React.Component {
+  render() {
+    const { theme } = this.props
+
+    console.log('Current theme: ', theme);
+    // ...
+  }
+}
+
+export default withTheme(MyComponent)
+```

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-external-helpers": "^6.8.0",
     "babel-plugin-flow-react-proptypes": "^0.17.2",
+    "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-latest": "^6.14.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,6 +58,7 @@ const plugins = [
       'transform-flow-strip-types',
       'external-helpers',
       'transform-object-rest-spread',
+      'transform-class-properties',
     ],
   }),
   json(),

--- a/src/hoc/withTheme.js
+++ b/src/hoc/withTheme.js
@@ -1,0 +1,36 @@
+// @flow
+
+import React from 'react'
+import { CHANNEL } from '../models/ThemeProvider'
+
+export default Component => class extends React.Component {
+  static contextTypes = {
+    [CHANNEL]: React.PropTypes.func,
+  };
+
+  state = ({
+  }: {
+    theme?: ?Object,
+  });
+
+  componentWillMount() {
+    if (!this.context[CHANNEL]) {
+      throw new Error('[withTheme] Please use ThemeProvider to be able to use withTheme')
+    }
+
+    const subscribe = this.context[CHANNEL]
+    this.unsubscribe = subscribe(theme => {
+      this.setState({ theme })
+    })
+  }
+
+  componentWillUnmount() {
+    if (typeof this.unsubscribe === 'function') this.unsubscribe()
+  }
+
+  render() {
+    const { theme } = this.state
+
+    return <Component theme={theme} {...this.props} />
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,13 @@ import _ComponentStyle from './models/ComponentStyle'
 /* Import components */
 import ThemeProvider from './models/ThemeProvider'
 
+/* Import Higher Order Components */
+import withTheme from './hoc/withTheme'
+
 /* Instantiate singletons */
 const keyframes = _keyframes(generateAlphabeticName)
 const styled = _styled(_styledComponent(_ComponentStyle(generateAlphabeticName)))
 
 /* Export everything */
 export default styled
-export { css, keyframes, injectGlobal, ThemeProvider }
+export { css, keyframes, injectGlobal, ThemeProvider, withTheme }

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -7,6 +7,7 @@ import css from '../constructors/css'
 
 import styledNativeComponent from '../models/StyledNativeComponent'
 import ThemeProvider from '../models/ThemeProvider'
+import withTheme from '../hoc/withTheme'
 import type { Interpolation, Target } from '../types'
 
 const styled = (tag: Target) =>
@@ -33,5 +34,5 @@ aliases.split(/\s+/m).forEach(alias => Object.defineProperty(styled, alias, {
   },
 }))
 
-export { css, ThemeProvider }
+export { css, ThemeProvider, withTheme }
 export default styled

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -6,6 +6,7 @@ import { mount, render } from 'enzyme'
 
 import { resetStyled, expectCSSMatches } from './utils'
 import ThemeProvider from '../models/ThemeProvider'
+import withTheme from '../hoc/withTheme'
 
 let styled
 
@@ -83,7 +84,7 @@ describe('theming', () => {
     expectCSSMatches(`.a { color: red; }`)
   })
 
-  it('should properly set the theme with an empty object when no teme is provided and no defaults are set', () => {
+  it('should properly set the theme with an empty object when no theme is provided and no defaults are set', () => {
     const Comp1 = styled.div`
       color: ${props => props.theme.color};
     `
@@ -260,5 +261,45 @@ describe('theming (jsdom)', () => {
 
     expectCSSMatches(`.a { color: ${originalTheme.color}; }.b { color: ${newTheme.color}; }`)
     expect(wrapper.find('div').prop('className')).toBe('b')
+  })
+
+  it('should inject props.theme into a component that uses withTheme hoc', () => {
+    const originalTheme = { color: 'black' }
+
+    const MyDiv = ({ theme }) => <div>{theme.color}</div>
+    const MyDivWithTheme = withTheme(MyDiv);
+
+    const wrapper = mount(
+      <ThemeProvider theme={originalTheme}>
+        <MyDivWithTheme />
+      </ThemeProvider>
+    )
+
+    expect(wrapper.find('div').text()).toBe('black')
+  })
+
+  it('should properly update theme prop on hoc component when theme is changed', () => {
+    const MyDiv = ({ theme }) => <div>{theme.color}</div>
+    const MyDivWithTheme = withTheme(MyDiv);
+
+    const originalTheme = { color: 'black' }
+    const newTheme = { color: 'blue' }
+
+    const Theme = ({ theme }) => (
+      <ThemeProvider theme={theme}>
+        <MyDivWithTheme />
+      </ThemeProvider>
+    )
+
+    const wrapper = mount(
+      <Theme theme={originalTheme} />
+    )
+
+    expect(wrapper.find('div').text()).toBe('black')
+
+    // Change theme
+    wrapper.setProps({ theme: newTheme })
+
+    expect(wrapper.find('div').text()).toBe('blue')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,6 +305,16 @@ babel-helper-explode-assignable-expression@^6.8.0:
     babel-traverse "^6.8.0"
     babel-types "^6.8.0"
 
+babel-helper-function-name@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz#68ec71aeba1f3e28b2a6f0730190b754a9bf30e6"
+  dependencies:
+    babel-helper-get-function-arity "^6.18.0"
+    babel-runtime "^6.0.0"
+    babel-template "^6.8.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+
 babel-helper-function-name@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz#a0336ba14526a075cdf502fc52d3fe84b12f7a34"
@@ -314,6 +324,13 @@ babel-helper-function-name@^6.8.0:
     babel-template "^6.8.0"
     babel-traverse "^6.8.0"
     babel-types "^6.8.0"
+
+babel-helper-get-function-arity@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz#a5b19695fd3f9cdfc328398b47dafcd7094f9f24"
+  dependencies:
+    babel-runtime "^6.0.0"
+    babel-types "^6.18.0"
 
 babel-helper-get-function-arity@^6.8.0:
   version "6.8.0"
@@ -414,6 +431,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -441,6 +462,15 @@ babel-plugin-transform-async-to-generator@^6.16.0:
     babel-helper-remap-async-to-generator "^6.16.0"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.0.0"
+
+babel-plugin-transform-class-properties@^6.19.0:
+  version "6.19.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.19.0.tgz#1274b349abaadc835164e2004f4a2444a2788d5f"
+  dependencies:
+    babel-helper-function-name "^6.18.0"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.9.1"
+    babel-template "^6.15.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.3.13:
   version "6.8.0"


### PR DESCRIPTION
Fix #272.

Add the possibility to get the current theme using `withTheme(component)` syntax. The theme will be passed as a `theme` prop to the child component.