### PR TITLE
Add support for numbers in objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Added
 
-- Added support for media queries, pseudo selectors and nesting in styles-as-objects. (see [#280](https://github.com/styled-components/styled-components/pull/280))
+- Added support for media queries, pseudo selectors, numbers and nesting in styles-as-objects. (see [#280](https://github.com/styled-components/styled-components/pull/280) and [#317](https://github.com/styled-components/styled-components/pull/317))
 - Added [`withTheme`](docs/api.md#withtheme) higher order component; thanks [@brunolemos](https://twitter.com/brunolemos). (see [#312] (https://github.com/styled-components/styled-components/pull/312))
 - Fixed prop changes not updating style on react native; thanks [@brunolemos](https://twitter.com/brunolemos). (see [#311](https://github.com/styled-components/styled-components/pull/311))
 

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -4,10 +4,9 @@ import isPlainObject from 'is-plain-object'
 
 import type { Interpolation } from '../types'
 
-// A list of properties that need a unit other than px appended
-// Thanks to jss-default-unit for this list
-// https://github.com/cssinjs/jss-default-unit
 const nonPixelProperties = {
+  // A list of properties that need a unit other than px appended
+  // Taken from jss-default-unit
   'animation-delay': 'ms',
   'animation-duration': 'ms',
   'perspective-origin-x': '%',
@@ -19,15 +18,54 @@ const nonPixelProperties = {
   'transition-delay': 'ms',
   'transition-duration': 'ms',
 }
+const unitlessProperties = [
+  // CSS properties which accept numbers but are not in units of "px".
+  // Taken from aphrodite, who took it from React's CSSProperty.js
+  'animation-iteration-count',
+  'border-image-outset',
+  'border-image-slice',
+  'border-image-width',
+  'box-flex',
+  'box-flex-group',
+  'box-ordinal-group',
+  'column-count',
+  'flex',
+  'flex-grow',
+  'flex-positive',
+  'flex-shrink',
+  'flex-negative',
+  'flex-order',
+  'grid-row',
+  'grid-column',
+  'font-weight',
+  'line-clamp',
+  'line-height',
+  'opacity',
+  'order',
+  'orphans',
+  'tab-size',
+  'widows',
+  'z-index',
+  'zoom',
+  'fill-opacity',
+  'flood-opacity',
+  'stop-opacity',
+  'stroke-dasharray',
+  'stroke-dashoffset',
+  'stroke-miterlimit',
+  'stroke-opacity',
+  'stroke-width',
+]
 
-const getUnit = (prop: string): string => nonPixelProperties[hyphenate(prop)] || 'px'
+const getUnit = (prop: string): string => nonPixelProperties[prop] || 'px'
 
 export const objToCss = (obj: Object, prevKey?: string): string => {
-  const css = Object.keys(obj).map(prop => {
-    let value = obj[prop]
-    if (isPlainObject(value)) return objToCss(value, prop)
-    if (typeof value === 'number') value = `${value}${getUnit(prop)}`
-    return `${hyphenate(prop)}: ${value};`
+  const css = Object.keys(obj).map(originalProp => {
+    let value = obj[originalProp]
+    const cssProp = hyphenate(originalProp)
+    if (isPlainObject(value)) return objToCss(value, cssProp)
+    if (typeof value === 'number' && unitlessProperties.indexOf(cssProp) === -1) value = `${value}${getUnit(cssProp)}`
+    return `${cssProp}: ${value};`
   }).join(' ')
   return prevKey ? `${prevKey} {
   ${css}

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -4,10 +4,30 @@ import isPlainObject from 'is-plain-object'
 
 import type { Interpolation } from '../types'
 
+// A list of properties that need a unit other than px appended
+// Thanks to jss-default-unit for this list
+// https://github.com/cssinjs/jss-default-unit
+const nonPixelProperties = {
+  'animation-delay': 'ms',
+  'animation-duration': 'ms',
+  'perspective-origin-x': '%',
+  'perspective-origin-y': '%',
+  'transform-origin': '%',
+  'transform-origin-x': '%',
+  'transform-origin-y': '%',
+  'transform-origin-z': '%',
+  'transition-delay': 'ms',
+  'transition-duration': 'ms',
+}
+
+const getUnit = (prop: string): string => nonPixelProperties[hyphenate(prop)] || 'px'
+
 export const objToCss = (obj: Object, prevKey?: string): string => {
-  const css = Object.keys(obj).map(key => {
-    if (isPlainObject(obj[key])) return objToCss(obj[key], key)
-    return `${hyphenate(key)}: ${obj[key]};`
+  const css = Object.keys(obj).map(prop => {
+    let value = obj[prop]
+    if (isPlainObject(value)) return objToCss(value, prop)
+    if (typeof value === 'number') value = `${value}${getUnit(prop)}`
+    return `${hyphenate(prop)}: ${value};`
   }).join(' ')
   return prevKey ? `${prevKey} {
   ${css}

--- a/src/utils/test/flatten.test.js
+++ b/src/utils/test/flatten.test.js
@@ -58,6 +58,49 @@ describe('flatten', () => {
     // $FlowIssue
     expect(flatten(['some:thing;', obj, 'something: else;'])).toEqual(['some:thing;', css, 'something: else;'])
   })
+  it('handles numbers in objects that should\'t get anything appended', () => {
+    const obj = {
+      'animation-iteration-count': 10,
+      'border-image-outset': 10,
+      'border-image-slice': 10,
+      'border-image-width': 10,
+      'box-flex': 10,
+      'box-flex-group': 10,
+      'box-ordinal-group': 10,
+      'column-count': 10,
+      flex: 10,
+      'flex-grow': 10,
+      'flex-positive': 10,
+      'flex-shrink': 10,
+      'flex-negative': 10,
+      'flex-order': 10,
+      'grid-row': 10,
+      'grid-column': 10,
+      'font-weight': 10,
+      'line-clamp': 10,
+      'line-height': 10,
+      opacity: 10,
+      order: 10,
+      orphans: 10,
+      'tab-size': 10,
+      widows: 10,
+      'z-index': 10,
+      zoom: 10,
+      'fill-opacity': 10,
+      'flood-opacity': 10,
+      'stop-opacity': 10,
+      'stroke-dasharray': 10,
+      'stroke-dashoffset': 10,
+      'stroke-miterlimit': 10,
+      'stroke-opacity': 10,
+      'stroke-width': 10,
+    }
+    const css = 'animation-iteration-count: 10; border-image-outset: 10; border-image-slice: 10; border-image-width: 10; box-flex: 10; box-flex-group: 10; box-ordinal-group: 10; column-count: 10; flex: 10; flex-grow: 10; flex-positive: 10; flex-shrink: 10; flex-negative: 10; flex-order: 10; grid-row: 10; grid-column: 10; font-weight: 10; line-clamp: 10; line-height: 10; opacity: 10; order: 10; orphans: 10; tab-size: 10; widows: 10; z-index: 10; zoom: 10; fill-opacity: 10; flood-opacity: 10; stop-opacity: 10; stroke-dasharray: 10; stroke-dashoffset: 10; stroke-miterlimit: 10; stroke-opacity: 10; stroke-width: 10;'
+    // $FlowIssue
+    expect(flatten([obj])).toEqual([css])
+    // $FlowIssue
+    expect(flatten(['some:thing;', obj, 'something: else;'])).toEqual(['some:thing;', css, 'something: else;'])
+  })
   it('handles nested objects', () => {
     const obj = {
       fontSize: '14px',

--- a/src/utils/test/flatten.test.js
+++ b/src/utils/test/flatten.test.js
@@ -28,6 +28,36 @@ describe('flatten', () => {
     // $FlowIssue
     expect(flatten(['some:thing;', obj, 'something: else;'])).toEqual(['some:thing;', css, 'something: else;'])
   })
+  it('adds px to numbers in objects', () => {
+    const obj = {
+      fontSize: 14,
+      height: 100,
+    }
+    const css = 'font-size: 14px; height: 100px;'
+    // $FlowIssue
+    expect(flatten([obj])).toEqual([css])
+    // $FlowIssue
+    expect(flatten(['some:thing;', obj, 'something: else;'])).toEqual(['some:thing;', css, 'something: else;'])
+  })
+  it('handles numbers in objects that shouldn\'t get px appended', () => {
+    const obj = {
+      'animation-delay': 10,
+      'animation-duration': 10,
+      'perspective-origin-x': 10,
+      'perspective-origin-y': 10,
+      'transform-origin': 10,
+      'transform-origin-x': 10,
+      'transform-origin-y': 10,
+      'transform-origin-z': 10,
+      'transition-delay': 10,
+      'transition-duration': 10,
+    }
+    const css = 'animation-delay: 10ms; animation-duration: 10ms; perspective-origin-x: 10%; perspective-origin-y: 10%; transform-origin: 10%; transform-origin-x: 10%; transform-origin-y: 10%; transform-origin-z: 10%; transition-delay: 10ms; transition-duration: 10ms;'
+    // $FlowIssue
+    expect(flatten([obj])).toEqual([css])
+    // $FlowIssue
+    expect(flatten(['some:thing;', obj, 'something: else;'])).toEqual(['some:thing;', css, 'something: else;'])
+  })
   it('handles nested objects', () => {
     const obj = {
       fontSize: '14px',


### PR DESCRIPTION
This is necessary for an easier transition from other styles in JS
libraries that let you write styles as objects. All of them support the
following:

```JS
const styles = {
  fontSize: 14,
}
```

This commit adds support for this in styled-components. There is a
handful of properties where appending `px` doesn't make sense, I stole
the list of non-pixel-properties from JSS (thanks @kof) and simply
append their unit.

Closes #283