### PR TITLE
Update demo links in readme to examples with v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Updated all dependencies to latest semver, thanks [@amilajack](https://github.com/amilajack). (see [#324](https://github.com/styled-components/styled-components/pull/324))
 - Fixed defaultProps theme overriding ThemeProvider theme, thanks to [@diegohaz](https://github.com/diegohaz). (see [#345](https://github.com/styled-components/styled-components/pull/345))
 - Removed custom flowtype supressor in favour of default $FlowFixMe [@relekang](https://github.com/relekang). (see [#335](https://github.com/styled-components/styled-components/pull/335))
+- Updated all demos to link to latest version [@relekang](https://github.com/relekang)
 
 ## [v1.2.1]
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You render them like so:
 ```
 
 <div align="center">
-  <a href="http://www.webpackbin.com/VkbO4mdR-">
+  <a href="http://www.webpackbin.com/4kejp0ESz">
     <img alt="Screenshot of the above code ran in a browser" src="http://i.imgur.com/wUJpcjY.jpg" />
     <div><em>Live demo</em></div>
   </a>
@@ -99,7 +99,7 @@ You can just pass a `placeholder` prop into the `styled-component`. It will pass
 Here is one input without any content showing the placeholder, and one with some content:
 
 <div align="center">
-  <a href="http://www.webpackbin.com/VJSbrmOA-">
+  <a href="http://www.webpackbin.com/4k47p0VHG">
     <img alt="Screenshot of the above code ran in a browser" src="http://imgur.com/QoQiSui.jpg" />
     <div><em>Live demo</em></div>
   </a>
@@ -133,7 +133,7 @@ export default Button;
 ```
 
 <div align="center">
-  <a href="http://www.webpackbin.com/VkFaQgtA-">
+  <a href="http://www.webpackbin.com/Eyod0ANSM">
     <img alt="Screenshot of the above code ran in a browser" src="http://imgur.com/4qlEdsx.jpg" />
     <div><em>Live demo</em></div>
   </a>
@@ -182,7 +182,7 @@ export default TomatoButton;
 This is what our `TomatoButton` looks like, even though we have only specified the `color` and the `border-color`. Instead of copy and pasting or factoring out the styles into a separate function we've now reused them.
 
 <div align="center">
-  <a href="http://www.webpackbin.com/4yOENXOCZ">
+  <a href="http://www.webpackbin.com/4y-sCCVrM">
     <img alt="Screenshot of the above code ran in a browser" src="http://imgur.com/LZZ3h5i.jpg" />
     <div><em>Live demo</em></div>
   </a>
@@ -218,7 +218,7 @@ const StyledLink = styled(Link)`
 ```
 
 <div align="center">
-  <a href="http://www.webpackbin.com/NyCcBm_C-">
+  <a href="http://www.webpackbin.com/NJFAAC4SM">
     <img alt="Screenshot of the above code ran in a browser" src="http://imgur.com/JJw4MdX.jpg" />
     <div><em>Live demo</em></div>
   </a>
@@ -260,7 +260,7 @@ This will now rotate it's children over and over again, for example our logo:
 ```
 
 <div align="center">
-  <a href="http://www.webpackbin.com/EJjD8QdCZ">
+  <a href="http://www.webpackbin.com/4k4WyJrSM">
     <img alt="Animated GIF of the above code ran in a browser" height="100px" src="http://imgur.com/I7Sobjv.gif" />
     <div><em>Live demo</em></div>
   </a>
@@ -366,7 +366,7 @@ Now, when we render the `Button` inside a `GreenSection`, it'll be green!
 ```
 
 <div align="center">
-  <a href="http://www.webpackbin.com/4ypo8QORb">
+  <a href="http://www.webpackbin.com/EJPNk1SSz">
     <img alt="Screenshot of the above code ran in a browser" src="http://imgur.com/XfkzxqV.jpg" />
     <div><em>Live demo</em></div>
   </a>


### PR DESCRIPTION
Related to #342 

[Link to updated rendered readme](https://github.com/styled-components/styled-components/blob/update-demo-links/README.md)