### PR TITLE
Fix themes in IE <= 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+- Fix themes support in IE <= 10, thanks to [@saschagehlich](https://github.com/saschagehlich). (see [#379](https://github.com/styled-components/styled-components/pull/379))
+
 ## [v1.3.0]
 
 ### Added

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -26,6 +26,7 @@ export default (ComponentStyle: Function) => {
     class StyledComponent extends ParentComponent {
       static rules: RuleSet
       static target: Target
+      static contextTypes = ParentComponent.contextTypes
 
       constructor() {
         super()


### PR DESCRIPTION
This makes sure `StyledComponent` inherits `ParentComponent`'s `contextTypes`. See this information on BabelJS's docs: https://babeljs.io/docs/usage/caveats/#internet-explorer-classes-10-and-below-