### PR TITLE
Fix <Styled(undefined)> in React Developer Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+- Fix `<Styled(undefined)>` in React Developer Tools. (see [#383](https://github.com/styled-components/styled-components/pull/383))
 - Fix themes support in IE <= 10, thanks to [@saschagehlich](https://github.com/saschagehlich). (see [#379](https://github.com/styled-components/styled-components/pull/379))
 
 ## [v1.3.0]

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -105,7 +105,7 @@ export default (ComponentStyle: Function) => {
     StyledComponent.target = target
     StyledComponent.rules = rules
 
-    StyledComponent.displayName = isTag(target) ? `styled.${target}` : `Styled(${target.displayName})`
+    StyledComponent.displayName = isTag(target) ? `styled.${target}` : `Styled(${(target.displayName || target.name)})`
 
     return StyledComponent
   }


### PR DESCRIPTION
Fix StyledComponent.displayName is displayed as Styled(undefined) when using Stateless Component. (Using Component.name when Component.displayName is undefined)