### PR TITLE
Fix undefined sheet error when SSR without rendering any styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. If a contri
 ### Added
 
 ### Changed
+- Fix SSR when no `styled-components` are rendered, mentioned in [#124](https://github.com/styled-components/styled-components/issues/124). - [@kristojorg](https://github.com/kristojorg)
 
 ## [v1.3.1] - 2017-01-18
 

--- a/src/vendor/glamor/sheet.js
+++ b/src/vendor/glamor/sheet.js
@@ -160,7 +160,7 @@ export class StyleSheet {
   }
   rules() {
     if(!isBrowser) {
-      return this.sheet.cssRules
+      return this.sheet ? this.sheet.cssRules : []
     }
     let arr = []
     this.tags.forEach(tag => arr.splice(arr.length, 0, ...Array.from(


### PR DESCRIPTION
When SSR without any styles, StyleSheet.sheet returned by glamor is
undefined, and thus the cssRules property is undefined. I have
substituted this with an empty array instead, and it is now working in
my case. This should solve one of the issues mentioned multiple times in
[#124](https://github.com/styled-components/styled-components/issues/124
).

Side note: this is my first ever PR anywhere... please let me know if I'm doing something dumb