### PR TITLE
adds simple ssr example

### DIFF
--- a/example/ssr.js
+++ b/example/ssr.js
@@ -1,0 +1,44 @@
+import Express from 'express'
+import React from 'react'
+import {renderToString} from  'react-dom/server'
+import styled, {styleSheet} from '../dist/styled-components'
+
+const Heading = styled.h1`
+  color: red;
+`
+
+const app = new Express()
+const port = 8080
+
+app.get('*', (req, res) => {
+  const componentHTML = renderToString(<Heading>Hello SSR!</Heading>)
+  
+  const css = styleSheet.getCSS()
+
+  res.status(200).send(`
+    <!doctype html>
+    <html>
+      <head>
+        <style>
+          ${css}
+        </style>
+      </head>
+      <body>
+        ${componentHTML}
+      </body>
+  </html>`)
+})
+
+app.listen(port, error => {
+  /* eslint-disable no-console */
+  if (error) {
+    console.error(error)
+  } else {
+    console.info(
+      '🌎 Listening on port %s. Open up http://localhost:%s/ in your browser.',
+      port,
+      port
+    )
+  }
+  /* eslint-enable no-console */
+})

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint src",
     "prepublish": "npm run build",
     "lint-staged": "lint-staged",
-    "dev": "node example/devServer.js"
+    "dev": "node example/devServer.js",
+    "example:ssr": "babel-node example/ssr"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a super simple ssr example. Not sure if this is something you want, but I was testing out so I figured i might as well send it as a PR since there is no docs/examples for this yet AFAICT.

_This needs to be run with `babel-node example/ssr`_