### PR TITLE
Fix 1.4.0 breaking native require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. If a contri
 ### Added
 
 ### Changed
+- Fix breaking native require in 1.4.0
 
 ## [v1.4.0] - 2017-01-25
 

--- a/native/index.js
+++ b/native/index.js
@@ -1,2 +1,2 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-module.exports = require('../lib/native')
+module.exports = require('../src/native')


### PR DESCRIPTION
Took me a while to find, but I believe this will fix following errors in react native that occurred after updating to 1.4.0

```
Cannot read property 'indexOf' of undefined
Module AppRegistry is not a registered callable module (calling runApplication)
```

Note: it seems like with every new release something breaks in react-naive, is it not tested well compared to styled components for react?