### PR TITLE
Put global styles in a separate stylesheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+- Global styles (keyframes and injectGlobal) are now injected into a separate stylesheet, thanks to [xcoderzach](https://github.com/xcoderzach). (see [#415](https://github.com/styled-components/styled-components/pull/415))
+
 ## [v1.4.0] - 2017-01-25
 
 ### Added

--- a/src/constructors/test/injectGlobal.test.js
+++ b/src/constructors/test/injectGlobal.test.js
@@ -4,7 +4,7 @@ import expect from 'expect'
 import { shallow } from 'enzyme'
 
 import injectGlobal from '../injectGlobal'
-import styleSheet from '../../models/StyleSheet'
+import styleSheet from '../../models/GlobalStyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 let styled = resetStyled()
@@ -14,7 +14,7 @@ const rule3 = 'color: blue;'
 
 describe('injectGlobal', () => {
   beforeEach(() => {
-    resetStyled()
+    resetStyled(styleSheet)
   })
 
   it(`should inject rules into the head`, () => {
@@ -45,10 +45,10 @@ describe('injectGlobal', () => {
       a {
         ${rule2}
       }
-    `)
+    `, { styleSheet })
   })
 
-  it(`should non-destructively inject styles when called after a component`, () => {
+  it(`should inject styles in a separate sheet from a component`, () => {
     const Comp = styled.div`
       ${rule3}
     `
@@ -59,14 +59,17 @@ describe('injectGlobal', () => {
         ${rule1}
       }
     `
-
+    // Test the component sheet
     expectCSSMatches(`
       .a {
         ${rule3}
       }
+    `)
+    // Test the global sheet
+    expectCSSMatches(`
       html {
         ${rule1}
       }
-    `)
+    `, { styleSheet })
   })
 });

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -2,6 +2,7 @@
 import expect from 'expect'
 
 import _keyframes from '../keyframes'
+import styleSheet from '../../models/GlobalStyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 /**
@@ -12,7 +13,7 @@ const keyframes = _keyframes(() => `keyframe_${index++}`)
 
 describe('keyframes', () => {
   beforeEach(() => {
-    resetStyled()
+    resetStyled(styleSheet)
     index = 0
   })
 
@@ -47,6 +48,6 @@ describe('keyframes', () => {
           opacity: 1;
         }
       }
-    `)
+    `, { styleSheet })
   })
 })

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -4,7 +4,8 @@ import postcssNested from '../vendor/postcss-nested'
 
 import type { RuleSet } from '../types'
 import flatten from '../utils/flatten'
-import styleSheet from './StyleSheet'
+
+import styleSheet from './GlobalStyleSheet'
 
 export default class ComponentStyle {
   rules: RuleSet;

--- a/src/models/GlobalStyleSheet.js
+++ b/src/models/GlobalStyleSheet.js
@@ -1,0 +1,8 @@
+// @flow
+
+/* Wraps glamor's stylesheet and exports a singleton for global styles. */
+import { StyleSheet } from '../vendor/glamor/sheet'
+
+/* Don't specify a maxLength, since these rules are defined at initialization
+*  and should remain static after that */
+export default new StyleSheet({ speedy: false })

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -1,7 +1,7 @@
 // @flow
 
-/* Wraps glamor's stylesheet and exports a singleton for the rest
-*  of the app to use. */
+/* Wraps glamor's stylesheet and exports a singleton for styled components
+to use. */
 
 import { StyleSheet } from '../vendor/glamor/sheet'
 

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -6,7 +6,7 @@
 import expect from 'expect'
 
 import _styled from '../constructors/styled'
-import styleSheet from '../models/StyleSheet'
+import componentStyleSheet from '../models/StyleSheet'
 import _styledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
@@ -14,7 +14,7 @@ import _ComponentStyle from '../models/ComponentStyle'
 let index = 0
 const classNames = () => String.fromCodePoint(97 + index++)
 
-export const resetStyled = () => {
+export const resetStyled = (styleSheet: Object = componentStyleSheet) => {
   if (styleSheet.sheet) styleSheet.flush()
   index = 0
   return _styled(_styledComponent(_ComponentStyle(classNames)))
@@ -23,10 +23,11 @@ export const resetStyled = () => {
 const stripWhitespace = str => str.trim().replace(/\s+/g, ' ')
 export const expectCSSMatches = (
   expectation: string,
-  opts: { ignoreWhitespace: boolean } = { ignoreWhitespace: true }
+  opts: { ignoreWhitespace?: boolean, styleSheet?: Object } = {}
 ) => {
+  const { ignoreWhitespace = true, styleSheet = componentStyleSheet } = opts
   const css = styleSheet.rules().map(rule => rule.cssText).join('\n')
-  if (opts.ignoreWhitespace) {
+  if (ignoreWhitespace) {
     expect(stripWhitespace(css)).toEqual(stripWhitespace(expectation))
   } else {
     expect(css).toEqual(expectation)


### PR DESCRIPTION
Putting dynamic styled component css rules into the same stylesheet
as global styles can cause global rules such as `@font-face` to be
recomputed.  Instead, create two stylesheets, one for global
styles, and one for styled-components.

Fixes part of #400.