### PR TITLE
css`something` returns commas

### DIFF
--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -9,6 +9,14 @@ describe('css', () => {
     const expected = `There should not be commas around me`
     expect(cssResult).toEqual(expected)
   })
+  it('properly handles nested functions with returns', () => {
+    const func = (...args) => css`
+      ${css(...args)}
+    `;
+    const cssResult = `${func`There should not be commas around me`}`;
+    const expected = `There should not be commas around me`
+    expect(cssResult).toEqual(expected)
+  })
   it('properly handles nested functions other styles', () => {
     const func = (...args) => css`display: flex; ${css(...args)}`;
     const cssResult = `${func`There should not be commas around me`}`;

--- a/src/constructors/test/css.test.js
+++ b/src/constructors/test/css.test.js
@@ -1,1 +1,18 @@
 // @flow
+import expect from 'expect'
+import css from '../css'
+
+describe('css', () => {
+  it('properly handles nested functions', () => {
+    const func = (...args) => css`${css(...args)}`;
+    const cssResult = `${func`There should not be commas around me`}`;
+    const expected = `There should not be commas around me`
+    expect(cssResult).toEqual(expected)
+  })
+  it('properly handles nested functions other styles', () => {
+    const func = (...args) => css`display: flex; ${css(...args)}`;
+    const cssResult = `${func`There should not be commas around me`}`;
+    const expected = `display: flex; There should not be commas around me`
+    expect(cssResult).toEqual(expected)
+  })
+})


### PR DESCRIPTION
I was trying to replicate the example [here](https://github.com/styled-components/styled-components/blob/master/docs/tips-and-tricks.md#more-powerful-example) and it wasn’t working.

I wasn’t getting any error messages, but had empty styles. 

It looks like there is incorrect css being generated when you use one of these functions alongside other styles or when there are newlines in the template string. 

Not quite sure how to fix, but could look into it if you give me some direction.