### PR TITLE
TypeScript: Improve typings of interpolations

### DIFF
--- a/typings/styled-components-test.tsx
+++ b/typings/styled-components-test.tsx
@@ -110,3 +110,42 @@ class Example extends React.Component<{}, {}> {
     </ThemeProvider>;
   }
 }
+
+// css which only uses simple interpolations without functions
+const cssWithValues1 = css`
+  font-size: ${14}${'pt'};
+`;
+// css which uses other simple interpolations without functions
+const cssWithValues2 = css`
+  ${cssWithValues1}
+  ${[cssWithValues1, cssWithValues1]}
+  font-weight: ${'bold'};
+`;
+// injectGlobal accepts simple interpolations if they're not using functions
+injectGlobal`
+  ${'font-size'}: ${10}pt;
+  ${cssWithValues1}
+  ${[cssWithValues1, cssWithValues2]}
+`;
+
+// css which uses function interpolations with common props
+const cssWithFunc1 = css`
+  font-size: ${(props) => props.theme.fontSizePt}pt;
+`;
+const cssWithFunc2 = css`
+  ${cssWithFunc1}
+  ${props => cssWithFunc2}
+  ${[cssWithFunc1, cssWithValues1]}
+`;
+// such css can be used in styled components
+const styledButton = styled.button`
+  ${cssWithValues1} ${[cssWithValues1, cssWithValues2]}
+  ${cssWithFunc1} ${[cssWithFunc1, cssWithFunc2]}
+  ${() => [cssWithFunc1, cssWithFunc2]}
+`;
+// css with function interpolations cannot be used in injectGlobal
+/*
+injectGlobal`
+  ${cssWithFunc1}
+`;
+*/

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -13,10 +13,12 @@ export type OuterStyledProps<P> = P & {
   innerRef?: (instance: any) => void;
 };
 
-export type Interpolation<P> = InterpolationValue | InterpolationFunction<P> | ReadonlyArray<InterpolationValue | InterpolationFunction<P>>;
+export type Interpolation<P> = FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P>>>;
+export type FlattenInterpolation<P> = InterpolationValue | InterpolationFunction<P>;
 export type InterpolationValue = string | number;
+export type SimpleInterpolation = InterpolationValue | ReadonlyArray<InterpolationValue | ReadonlyArray<InterpolationValue>>;
 export interface InterpolationFunction<P> {
-  (props: StyledProps<P>): InterpolationValue | ReadonlyArray<Interpolation<P>>;
+  (props: StyledProps<P>): Interpolation<P>;
 }
 
 export interface StyledFunction<P> {
@@ -170,9 +172,10 @@ export interface StyledInterface extends BaseStyledInterface {
 
 declare const styled: StyledInterface;
 
-export function css<P>(strings: TemplateStringsArray, ...interpolations: Interpolation<P>[]): Interpolation<P>[];
-export function keyframes(strings: TemplateStringsArray, ...interpolations: (string | number)[]): string;
-export function injectGlobal(strings: TemplateStringsArray, ...interpolations: (string | number)[]): void;
+export function css(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): InterpolationValue[];
+export function css<P>(strings: TemplateStringsArray, ...interpolations: Interpolation<P>[]): FlattenInterpolation<P>[];
+export function keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
+export function injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;
 
 export const ThemeProvider: ComponentClass<ThemeProps>;
 


### PR DESCRIPTION
This PR slightly improves TypeScript support (typings) of interpolations.

### Rationale

There're two very different contexts where styles are being created: global (`injectGlobal`, `keyframes` functions) and component (`styled` function). In the global contexts, functions as interpolations are not accepted. Indeed, there's nothing to use - no props available.
So the typings of these functions already make this distinctions, `injectGlobal` and `keyframes` do not accept functions as interpolations.
The issue comes up when `css` needs to be used. Since it is meant to be composable and can be used inside both contexts, we need to know what types of interpolations are hidden inside.

### Changes

- an overload of `css` has been introduced which only takes simple interpolations
- introduced 'flatten' interpolation type to use as a result of `css` (which flattens passed array interpolations)
- also made possible to pass arrays as interpolations which wasn't working before
  - Note, that due to TypeScript's circular-reference restrictions, deeper nesting of arrays isn't allowed

Now using function interpolations that came from `css` is also restricted:
![css-with-function-interpolation](https://cloud.githubusercontent.com/assets/1929486/22407816/cbf48df2-e622-11e6-8b68-df1c9e7035a6.gif)

### Upcoming

I'm going to make another PR with better theme support in TypeScript. So you could bundle all the changes in the next release.