### PR TITLE
Add return to React Native example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,11 @@ const StyledText = styled.Text`
 
 class MyReactNativeComponent extends React.Component {
   render() {
-    <StyledView>
-      <StyledText>Hello World!</StyledText>
-    </StyledView>
+    return (
+      <StyledView>
+        <StyledText>Hello World!</StyledText>
+      </StyledView>
+    )
   }
 }
 ```


### PR DESCRIPTION
Seems there is just a simple typo in the example which causes nothing to be returned from render. This adds a return.