### PR TITLE
v2: Upgrade stylis, don't bundle external dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "inline-style-prefixer": "^2.0.5",
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
-    "stylis": "0.11.0",
+    "stylis": "^1.0.1",
     "supports-color": "^3.1.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5224,9 +5224,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-0.11.0.tgz#2d62b571b3e799983d91d6005d3a5e454188a9b5"
+stylis@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-1.0.1.tgz#cfe6782443a62c73f0ad7e9ff68eda8a4780de91"
 
 supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
I may be wrong on the bundling thing :)

Fixes #433 

Update: I removed a commit that made all dependencies externals for rollup, that was wrong. 

Instead, I need to convince Webpack to not use the ES build, since it includes bundled deps that should not be bundled when building an app. Perhaps the ES build should not be there at all, browser can use the normal build and for ES you just point to an ES6 transpilation?