### PR TITLE
Add Stylesheet class that proxies methods to two stylesheets

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,3 +15,4 @@ flow-typed
 [options]
 suppress_comment=.*\\$FlowFixMe
 suppress_comment=.*\\$FlowInvalidInputTest
+unsafe.enable_getters_and_setters=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. If a contri
 ### Added
 
 ### Changed
+Fix for global styles not being returned by `StyleSheet.rules()` introduced in v1.4.2, thanks to [@xcoderzach](https://github.com/xcoderzach). (see [#440](https://github.com/styled-components/styled-components/pull/440))
 
 ## [v1.4.2] - 2017-01-28
 

--- a/src/constructors/test/injectGlobal.test.js
+++ b/src/constructors/test/injectGlobal.test.js
@@ -4,7 +4,7 @@ import expect from 'expect'
 import { shallow } from 'enzyme'
 
 import injectGlobal from '../injectGlobal'
-import styleSheet from '../../models/GlobalStyleSheet'
+import styleSheet from '../../models/StyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 let styled = resetStyled()
@@ -14,7 +14,7 @@ const rule3 = 'color: blue;'
 
 describe('injectGlobal', () => {
   beforeEach(() => {
-    resetStyled(styleSheet)
+    resetStyled()
   })
 
   it(`should inject rules into the head`, () => {
@@ -64,12 +64,12 @@ describe('injectGlobal', () => {
       .a {
         ${rule3}
       }
-    `)
+    `, { styleSheet: styleSheet.componentStyleSheet })
     // Test the global sheet
     expectCSSMatches(`
       html {
         ${rule1}
       }
-    `, { styleSheet })
+    `, { styleSheet: styleSheet.globalStyleSheet })
   })
 });

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -2,7 +2,7 @@
 import expect from 'expect'
 
 import _keyframes from '../keyframes'
-import styleSheet from '../../models/GlobalStyleSheet'
+import styleSheet from '../../models/StyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 /**
@@ -13,7 +13,7 @@ const keyframes = _keyframes(() => `keyframe_${index++}`)
 
 describe('keyframes', () => {
   beforeEach(() => {
-    resetStyled(styleSheet)
+    resetStyled()
     index = 0
   })
 

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -1,7 +1,7 @@
 // @flow
 import hashStr from 'glamor/lib/hash'
 
-import type { RuleSet, NameGenerator } from '../types'
+import type { RuleSet, NameGenerator, GlamorInsertedRule } from '../types'
 import flatten from '../utils/flatten'
 import parse from '../vendor/postcss-safe-parser/parse'
 import postcssNested from '../vendor/postcss-nested'
@@ -17,7 +17,7 @@ export default (nameGenerator: NameGenerator) => {
 
   class ComponentStyle {
     rules: RuleSet
-    insertedRule: Object
+    insertedRule: GlamorInsertedRule
 
     constructor(rules: RuleSet) {
       this.rules = rules

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -5,7 +5,7 @@ import postcssNested from '../vendor/postcss-nested'
 import type { RuleSet } from '../types'
 import flatten from '../utils/flatten'
 
-import styleSheet from './GlobalStyleSheet'
+import styleSheet from './StyleSheet'
 
 export default class ComponentStyle {
   rules: RuleSet;
@@ -24,6 +24,6 @@ export default class ComponentStyle {
     }
     const root = parse(flatCSS)
     postcssNested(root)
-    styleSheet.insert(root.toResult().css)
+    styleSheet.insert(root.toResult().css, { global: true })
   }
 }

--- a/src/models/GlobalStyleSheet.js
+++ b/src/models/GlobalStyleSheet.js
@@ -1,8 +1,0 @@
-// @flow
-
-/* Wraps glamor's stylesheet and exports a singleton for global styles. */
-import { StyleSheet } from '../vendor/glamor/sheet'
-
-/* Don't specify a maxLength, since these rules are defined at initialization
-*  and should remain static after that */
-export default new StyleSheet({ speedy: false })

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -2,7 +2,38 @@
 
 /* Wraps glamor's stylesheet and exports a singleton for styled components
 to use. */
+import { StyleSheet as GlamorSheet } from '../vendor/glamor/sheet'
+import type { GlamorRule } from '../types'
 
-import { StyleSheet } from '../vendor/glamor/sheet'
 
-export default new StyleSheet({ speedy: false, maxLength: 40 })
+class StyleSheet {
+  globalStyleSheet: GlamorSheet
+  componentStyleSheet: GlamorSheet
+  constructor() {
+    /* Don't specify a maxLength for the global sheet, since these rules
+     * are defined at initialization and should remain static after that */
+    this.globalStyleSheet = new GlamorSheet({ speedy: false })
+    this.componentStyleSheet = new GlamorSheet({ speedy: false, maxLength: 40 })
+  }
+  get injected(): boolean {
+    return this.globalStyleSheet.injected && this.componentStyleSheet.injected
+  }
+  inject(): void {
+    this.globalStyleSheet.inject()
+    this.componentStyleSheet.inject()
+  }
+  flush(): void {
+    if (this.globalStyleSheet.sheet) this.globalStyleSheet.flush()
+    if (this.componentStyleSheet.sheet) this.componentStyleSheet.flush()
+  }
+  insert(rule: string, opts: { global: boolean } = { global: false }): number {
+    const sheet = opts.global ? this.globalStyleSheet : this.componentStyleSheet
+    return sheet.insert(rule)
+  }
+  rules(): Array<GlamorRule> {
+    return this.globalStyleSheet.rules().concat(this.componentStyleSheet.rules())
+  }
+}
+
+/* Export stylesheet as a singleton class */
+export default new StyleSheet()

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -3,7 +3,7 @@
 /* Wraps glamor's stylesheet and exports a singleton for styled components
 to use. */
 import { StyleSheet as GlamorSheet } from '../vendor/glamor/sheet'
-import type { GlamorRule } from '../types'
+import type { GlamorRule, GlamorInsertedRule } from '../types'
 
 
 class StyleSheet {
@@ -26,7 +26,7 @@ class StyleSheet {
     if (this.globalStyleSheet.sheet) this.globalStyleSheet.flush()
     if (this.componentStyleSheet.sheet) this.componentStyleSheet.flush()
   }
-  insert(rule: string, opts: { global: boolean } = { global: false }): number {
+  insert(rule: string, opts: { global: boolean } = { global: false }): GlamorInsertedRule {
     const sheet = opts.global ? this.globalStyleSheet : this.componentStyleSheet
     return sheet.insert(rule)
   }

--- a/src/models/test/StyleSheet.test.js
+++ b/src/models/test/StyleSheet.test.js
@@ -1,0 +1,77 @@
+import styleSheet from '../StyleSheet'
+import { resetStyled } from '../../test/utils'
+import expect from 'expect'
+
+describe('stylesheet', () => {
+  beforeEach(() => {
+    resetStyled()
+  })
+
+  describe('inject', () => {
+    beforeEach(() => {
+      styleSheet.inject()
+    })
+    it('should inject the global sheet', () => {
+      expect(styleSheet.globalStyleSheet.injected).toBe(true)
+    })
+    it('should inject the component sheet', () => {
+      expect(styleSheet.componentStyleSheet.injected).toBe(true)
+    })
+    it('should specify that the sheets have been injected', () => {
+      expect(styleSheet.injected).toBe(true)
+    })
+  })
+
+  describe('flush', () => {
+    beforeEach(() => {
+      styleSheet.flush()
+    })
+    it('should flush the global sheet', () => {
+      expect(styleSheet.globalStyleSheet.injected).toBe(false)
+    })
+    it('should flush the component sheet', () => {
+      expect(styleSheet.componentStyleSheet.injected).toBe(false)
+    })
+    it('should specify that the sheets are no longer injected', () => {
+      expect(styleSheet.injected).toBe(false)
+    })
+  })
+
+  it('should return both rules for both sheets', () => {
+    styleSheet.insert('a { color: green }', { global: true })
+    styleSheet.insert('.hash1234 { color: blue }')
+
+    expect(styleSheet.rules()).toEqual([
+      { cssText: 'a { color: green }' },
+      { cssText: '.hash1234 { color: blue }' }
+    ])
+  })
+
+  describe('insert with the global option', () => {
+    beforeEach(() => {
+      styleSheet.insert('a { color: green }', { global: true })
+    })
+    it('should insert into the global sheet', () => {
+      expect(styleSheet.globalStyleSheet.rules()).toEqual([
+        { cssText: 'a { color: green }' },
+      ])
+    })
+    it('should not inject into the component sheet', () => {
+      expect(styleSheet.componentStyleSheet.rules()).toEqual([])
+    })
+  })
+
+  describe('insert without the global option', () => {
+    beforeEach(() => {
+      styleSheet.insert('.hash1234 { color: blue }')
+    })
+    it('should inject into the component sheet', () => {
+      expect(styleSheet.componentStyleSheet.rules()).toEqual([
+        { cssText: '.hash1234 { color: blue }' },
+      ])
+    })
+    it('should not inject into the global sheet', () => {
+      expect(styleSheet.globalStyleSheet.rules()).toEqual([])
+    })
+  })
+})

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -6,7 +6,7 @@
 import expect from 'expect'
 
 import _styled from '../constructors/styled'
-import componentStyleSheet from '../models/StyleSheet'
+import mainStyleSheet from '../models/StyleSheet'
 import _styledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
@@ -14,8 +14,8 @@ import _ComponentStyle from '../models/ComponentStyle'
 let index = 0
 const classNames = () => String.fromCodePoint(97 + index++)
 
-export const resetStyled = (styleSheet: Object = componentStyleSheet) => {
-  if (styleSheet.sheet) styleSheet.flush()
+export const resetStyled = () => {
+  mainStyleSheet.flush()
   index = 0
   return _styled(_styledComponent(_ComponentStyle(classNames)))
 }
@@ -25,7 +25,7 @@ export const expectCSSMatches = (
   expectation: string,
   opts: { ignoreWhitespace?: boolean, styleSheet?: Object } = {}
 ) => {
-  const { ignoreWhitespace = true, styleSheet = componentStyleSheet } = opts
+  const { ignoreWhitespace = true, styleSheet = mainStyleSheet } = opts
   const css = styleSheet.rules().map(rule => rule.cssText).join('\n')
   if (ignoreWhitespace) {
     expect(stripWhitespace(css)).toEqual(stripWhitespace(expectation))

--- a/src/types.js
+++ b/src/types.js
@@ -7,3 +7,5 @@ export type RuleSet = Array<Interpolation>
 export type Target = string | ReactClass<*>
 
 export type NameGenerator = (hash: number) => string
+
+export type GlamorRule = { cssText: string }

--- a/src/types.js
+++ b/src/types.js
@@ -9,3 +9,7 @@ export type Target = string | ReactClass<*>
 export type NameGenerator = (hash: number) => string
 
 export type GlamorRule = { cssText: string }
+
+export interface GlamorInsertedRule {
+  appendRule(css: string): void
+}


### PR DESCRIPTION
Adding a separate global stylesheet broke server side rendering,
because stylesheet.rules only returned component styles.  We now
have a single stylesheet class, that inserts into the specified
sheet, and proxies all other methods to both sheets.