### PR TITLE
[Typescript] Fix ThemedStyledInterface

### DIFF
--- a/typings/styled-components-test.tsx
+++ b/typings/styled-components-test.tsx
@@ -113,17 +113,17 @@ class Example extends React.Component<{}, {}> {
 
 // css which only uses simple interpolations without functions
 const cssWithValues1 = css`
-  font-size: ${14}${'pt'};
+  font-size: ${14}${"pt"};
 `;
 // css which uses other simple interpolations without functions
 const cssWithValues2 = css`
   ${cssWithValues1}
   ${[cssWithValues1, cssWithValues1]}
-  font-weight: ${'bold'};
+  font-weight: ${"bold"};
 `;
 // injectGlobal accepts simple interpolations if they're not using functions
 injectGlobal`
-  ${'font-size'}: ${10}pt;
+  ${"font-size"}: ${10}pt;
   ${cssWithValues1}
   ${[cssWithValues1, cssWithValues2]}
 `;

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -42,7 +42,7 @@ export interface ThemedBaseStyledInterface<T> {
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
 
 export type StyledInterface = ThemedStyledInterface<any>;
-export interface ThemedStyledInterface<T> extends BaseStyledInterface {
+export interface ThemedStyledInterface<T> extends ThemedBaseStyledInterface<T> {
   a: ThemedHtmlStyledFunction<HTMLAnchorElement, T>;
   abbr: ThemedHtmlStyledFunction<HTMLElement, T>;
   address: ThemedHtmlStyledFunction<HTMLElement, T>;

--- a/typings/themed-tests/mytheme-styled-components-test.tsx
+++ b/typings/themed-tests/mytheme-styled-components-test.tsx
@@ -33,7 +33,6 @@ const Input = styled.input`
 interface ButtonProps {
   name: string;
   primary?: boolean;
-  theme?: MyTheme;
 }
 
 class MyButton extends React.Component<ButtonProps, {}> {
@@ -55,7 +54,7 @@ const CustomizableButton = styled(MyButton)`
   font-size: 1em;
   margin: 1em;
   padding: 0.25em 1em;
-  border: 2px solid ${props => props.theme.primary};
+  border: 2px solid ${props => props.theme.primaryColor};
   border-radius: 3px;
 `;
 


### PR DESCRIPTION
This small fix allows to not declare the theme prop to custom components when reexporting the styled function with a custom theme interface.


```ts
import * as React from "react";

import styled, { ThemeInterface } from "my-themed-components";

interface BoxProps {
    borderBottom?: boolean;
    className?: string;
}

const Box:React.StatelessComponent<BoxProps> = (props) =>
    <div className={props.className}>{props.children}</div>;

const StyledBox = styled(Box)`
    padding: ${props => props.theme.lateralPadding}; // <-- this gets the correct interface now
    ${props => props.borderBottom && `
        border-bottom: 1px solid #ccc;
    `}
`;

export default StyledBox;
```

/cc @Igorbek 

PS. I'll add some docs for the re-exporting styled components thing after lunch :)
