### PR TITLE
Exclude test files from npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ rollup.config.js
 .eslintignore
 .babelrc
 example/
+src/**/*test.js


### PR DESCRIPTION
Noticed that test files were being published to npm, which seems unnecessary to me.