### PR TITLE
Change default displayName to `Styled(Component)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Improve TypeScript typings, thanks to [@igorbek](https://github.com/igorbek). (see [#428](https://github.com/styled-components/styled-components/pull/428) and [#432](https://github.com/styled-components/styled-components/pull/432))
 - Fix SSR bug introduced in v1.4.2, thanks to [@xcoderzach](https://github.com/xcoderzach). (see [#440](https://github.com/styled-components/styled-components/pull/440))
 - Fix defaultProps used instead of ThemeProvider on first render [@k15a](https://github.com/k15a). ([#450](https://github.com/styled-components/styled-components/pull/450))
+- displayName will now default to `Styled(Component)` [@k15a](https://github.com/k15a)
 
 ## [v1.4.2] - 2017-01-28
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -111,7 +111,7 @@ export default (ComponentStyle: Function) => {
     StyledComponent.target = target
     StyledComponent.rules = rules
 
-    StyledComponent.displayName = isTag(target) ? `styled.${target}` : `Styled(${(target.displayName || target.name)})`
+    StyledComponent.displayName = isTag(target) ? `styled.${target}` : `Styled(${(target.displayName || target.name || 'Component')})`
 
     return StyledComponent
   }

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -52,6 +52,37 @@ describe('basic', () => {
     expectCSSMatches('.a {  }')
   })
 
+  it('Should have the correct styled(component) displayName', () => {
+    const CompWithoutName = () => () => <div />
+
+    const StyledTag = styled.div``
+    expect(StyledTag.displayName).toBe('styled.div')
+
+
+    const CompWithName = () => <div />
+    CompWithName.displayName = null
+    const StyledCompWithName = styled(CompWithName)``
+    expect(StyledCompWithName.displayName).toBe('Styled(CompWithName)')
+
+
+    const CompWithDisplayName = CompWithoutName()
+    CompWithDisplayName.displayName = 'displayName'
+    const StyledCompWithDisplayName = styled(CompWithDisplayName)``
+    expect(StyledCompWithDisplayName.displayName).toBe('Styled(displayName)')
+
+
+    const CompWithBoth = () => <div />
+    CompWithBoth.displayName = 'displayName'
+    const StyledCompWithBoth = styled(CompWithBoth)``
+    expect(StyledCompWithBoth.displayName).toBe('Styled(displayName)')
+
+
+    const CompWithNothing = CompWithoutName()
+    CompWithNothing.displayName = null
+    const StyledCompWithNothing = styled(CompWithNothing)``
+    expect(StyledCompWithNothing.displayName).toBe('Styled(Component)')
+  })
+
   describe('innerRef', () => {
     jsdom()
 


### PR DESCRIPTION
The target.name option was already on master. I was looking on Glens PR because I thought he missed something in the classname PR and it was still unfixed there. This PR only adds tests for the displayname and changes the default displayname. Sorry for the inconvenience. 😥