### PR TITLE
Bug Report: failing test case for using props with multiple same components

### DIFF
--- a/src/test/props.test.js
+++ b/src/test/props.test.js
@@ -25,4 +25,15 @@ describe('props', () => {
     shallow(<Comp fg="red"/>)
     expectCSSMatches('.a { color: red; }')
   })
+
+  it('should execute interpolations and inject props for multiple same components', () => {
+    const Comp = styled.div`
+      color: ${props => props.fg || 'black'};
+    `
+
+    shallow(<Comp fg="red"/>)
+    shallow(<Comp fg="green"/>)
+
+    expectCSSMatches('.a { color: red; } .b { color: green; }')
+  })
 })


### PR DESCRIPTION
Hi,
  
  I ran into an issue when trying to use a component with a dynamic prop multiple times in the same parent.
  I didn't fully understand your test setup, and had difficulty reproducing exactly my situation, but I did come up with this failing test case (see PR), which might be related to my problem.

The bug seems to be a missing space:
```
-.a { color: red; }.b { color: green; }
+.a { color: red; } .b { color: green; }

```
  My situation is (simplified) as follows:

**index.js**
```
<Items>
  <Item x={5}>bla</Item>
  <Item x={6}>bla</Item>
  <Item x={7}>bla</Item>
  <Item x={8}>bla</Item>
</Items>
```

**Item.js**
```
export const someDynamicWidth = (x) => x * 2;

const Item = styled('div')`
  ${(props) => css`width: ${someDynamicWidth(props.x)}%;`}
  border: 1px solid black;
}`;

```

here the first item is styled as expected, but the following items have no styling. They have a class name assigned, but I can't find actual css rules.
