### PR TITLE
[Doc] Fix doc regarding ES6 tagged template literals

### DIFF
--- a/docs/tagged-template-literals.md
+++ b/docs/tagged-template-literals.md
@@ -4,7 +4,7 @@
 
 Tagged Template Literals are a new feature in ES6 that lets you define _custom string interpolation_ rules, which is how we're able to create styled components.
 
-If you have no interpolations, they're the same. This:
+If you have no interpolations, they're very similar. This:
 
 ```js
 myFunction`some string here`
@@ -13,7 +13,7 @@ myFunction`some string here`
 is equivalent to this:
 
 ```js
-myFunction('some string here')
+myFunction(['some string here'])
 ```
 
 When you use interpolations, a normal template string simply calls toString() on each interpolation and joins the string together:


### PR DESCRIPTION
There was a mistake in docs regarding ES6 tagged template literals.

Let me know if I missed something.