### PR TITLE
AsyncStyleSheet and auto removing of unused styles

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,45 +1,86 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Basic Example</title>
-  </head>
-  <body>
-    <h1>Basic Example</h1>
-    <div id="container"></div>
-    <script src="https://unpkg.com/react@15.3.2/dist/react.min.js"></script>
-    <script src="https://unpkg.com/react-dom@15.3.2/dist/react-dom.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
-    <script src="/styled-components.js"></script>
-    <script type="text/babel">
-    // Create a <Title> react component that renders an <h1> which is
-    // centered, palevioletred and sized at 1.5em
-    const Title = styled.default.h1`
+<head>
+  <meta charset="utf-8">
+  <title>Basic Example</title>
+</head>
+<body>
+<h1>Basic Example</h1>
+<div id="container"></div>
+<script src="https://unpkg.com/react@15.3.2/dist/react.min.js"></script>
+<script src="https://unpkg.com/react-dom@15.3.2/dist/react-dom.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
+<script src="/styled-components.js"></script>
+<script type="text/babel">
+  // Create a <Title> react component that renders an <h1> which is
+  // centered, palevioletred and sized at 1.5em
+  const Title = styled.default.h1`
       font-size: 1.5em;
       text-align: center;
       color: palevioletred;
+      opacity: ${props => Math.abs(Math.cos(props.opacity / 100))}
     `;
 
-    // Create a <Wrapper> react component that renders a <section> with
-    // some padding and a papayawhip background
-    const Wrapper = styled.default.section`
+  const WillNotBeUsed = styled.default.div`
+      font-size: 1.5em;
+    `;
+
+  // Create a <Wrapper> react component that renders a <section> with
+  // some padding and a papayawhip background
+  const Wrapper = styled.default.section`
       padding: 4em;
       background: papayawhip;
     `;
-      class Example extends React.Component {
-        render() {
-          return (
-            <Wrapper>
-              <Title>Hello World, this is my first styled component!</Title>
-            </Wrapper>
-          )
-        }
-      }
 
-      ReactDOM.render(
-        <Example />,
-        document.getElementById('container')
-      );
-    </script>
-  </body>
+  const Comp1 = styled.default.div`
+      color: ${props => props.theme.color};
+    `
+  const Comp2 = styled.default.div`
+      background: ${props => props.theme.color};
+    `
+
+  const ThemeProvider = styled.ThemeProvider;
+
+  const theme = { color: 'black' }
+
+  class Example extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        opacity: 0
+      };
+    }
+
+    componentWillMount() {
+      let value = 0;
+      setInterval(()=> this.setState({ opacity: value++ }), 16);
+    }
+
+    render() {
+      return (
+        <Wrapper>
+          <Title opacity={1}>Hello World, this is my first styled component!</Title>
+          <Title opacity={this.state.opacity}>Hello World, this is my first styled component!</Title>
+          <Title opacity={0.5}>Hello World, this is my first styled component!</Title>
+          <Title opacity={1}>Hello World, this is my first styled component!</Title>
+
+          <div>
+            <ThemeProvider theme={theme}>
+              <div>
+                <Comp1 />
+              </div>
+            </ThemeProvider>
+            <Comp2 />
+          </div>
+        </Wrapper>
+      )
+    }
+  }
+
+  ReactDOM.render(
+    <Example />,
+    document.getElementById('container')
+  );
+</script>
+</body>
 </html>

--- a/src/constructors/test/injectGlobal.test.js
+++ b/src/constructors/test/injectGlobal.test.js
@@ -4,7 +4,7 @@ import expect from 'expect'
 import { shallow } from 'enzyme'
 
 import injectGlobal from '../injectGlobal'
-import styleSheet from '../../models/StyleSheet'
+import styleSheet from '../../models/AsyncStyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 let styled = resetStyled()
@@ -23,7 +23,9 @@ describe('injectGlobal', () => {
         ${rule1}
       }
     `
-    expect(styleSheet.injected).toBe(true)
+    expect(styleSheet.injected).toBe(false);
+    styleSheet.forceFlush();
+    expect(styleSheet.injected).toBe(true);
   })
 
   it(`should non-destructively inject styles when called repeatedly`, () => {
@@ -46,30 +48,5 @@ describe('injectGlobal', () => {
         ${rule2}
       }
     `, { styleSheet })
-  })
-
-  it(`should inject styles in a separate sheet from a component`, () => {
-    const Comp = styled.div`
-      ${rule3}
-    `
-    shallow(<Comp />)
-
-    injectGlobal`
-      html {
-        ${rule1}
-      }
-    `
-    // Test the component sheet
-    expectCSSMatches(`
-      .a {
-        ${rule3}
-      }
-    `, { styleSheet: styleSheet.componentStyleSheet })
-    // Test the global sheet
-    expectCSSMatches(`
-      html {
-        ${rule1}
-      }
-    `, { styleSheet: styleSheet.globalStyleSheet })
   })
 });

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -2,7 +2,7 @@
 import expect from 'expect'
 
 import _keyframes from '../keyframes'
-import styleSheet from '../../models/StyleSheet'
+import styleSheet from '../../models/AsyncStyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 /**

--- a/src/models/AsyncStyleSheet.js
+++ b/src/models/AsyncStyleSheet.js
@@ -1,0 +1,149 @@
+const COMPACT_TIMEOUT = 15000
+
+function Deffered() {
+  this.promise = new Promise((resolve) => {
+    this.resolve = resolve
+  })
+  this.then = this.promise.then.bind(this.promise)
+}
+const isBrowser = typeof document !== 'undefined'
+const generateCssText = rules => Object.keys(rules).map(rule => rules[rule].cssText).join('\n')
+
+function addCssPayload(tag, cssText) {
+  if (!isBrowser) {
+    return true
+  }
+  if (!tag) {
+    tag = document.createElement('style')
+    tag.type = 'text/css'
+    tag.rel = 'stylesheet'
+  }
+
+  if (tag.styleSheet) {
+    tag.styleSheet.cssText += cssText
+  } else {
+    tag.appendChild(document.createTextNode(cssText))
+  }
+
+  if (!tag.parentNode) {
+    (document.head || document.getElementsByTagName('head')[0]).appendChild(tag)
+  }
+  return tag
+}
+
+class AsyncStyleSheet {
+  inserted = {}
+  _cssText = []
+  _counter = 0
+  _rules = {}
+  _rulesHash = {}
+  _waitForNextTick = 0
+  _currentPromise = 0
+  _globalTag = 0
+  _activeTag = 0
+
+  constructor() {
+    this.clear()
+  }
+
+  addStyle(key, cssText) {
+    if (!this._rulesHash[key]) {
+      const _counter = this._counter++
+      this._rules[_counter] = {
+        key, cssText,
+      }
+      this._rulesHash[key] = this._createRule(_counter)
+      this._cssText.push(cssText)
+
+      this._triggerUpdate()
+    }
+    return this._rulesHash[key]
+  }
+
+  _createRule(ruleNumber) {
+    return {
+      promise: this._currentPromise.promise,
+      remove: () => {
+        delete this._rulesHash[this._rules[ruleNumber].key]
+        delete this._rules[ruleNumber]
+        this._triggerUpdate()
+      },
+    }
+  }
+
+  _triggerUpdate() {
+    if (!this._waitForNextTick) {
+      this._waitForNextTick = 1
+      // TODO: should be replaced by setImmediate
+      setTimeout(() => this._update(), 0)
+    }
+  }
+
+  _flushStyles() {
+    const tags = []
+    tags.push(this._activeTag)
+    tags.push(this._globalTag)
+
+    this._cssText = []
+    this._activeTag = 0
+    this._globalTag = addCssPayload(0, generateCssText(this._rules))
+
+    setTimeout(() => tags.forEach(tag => tag && tag.parentNode && tag.parentNode.removeChild(tag)), 0)
+  }
+
+  _compactStyles() {
+    if (!this.compactTimeout) {
+      this.compactTimeout = setTimeout(() => {
+        this.compactTimeout = 0
+        this._flushStyles()
+      }, COMPACT_TIMEOUT)
+    }
+  }
+
+  _update() {
+    this._waitForNextTick = 0
+    const lastPromise = this._currentPromise
+    this._currentPromise = new Deffered()
+
+    if (this._cssText) {
+      this._activeTag = addCssPayload(this._activeTag, this._cssText.join('\n'))
+      this._cssText = []
+    }
+
+    this._compactStyles()
+
+    setTimeout(() => lastPromise.resolve(), 0)
+  }
+
+  forceFlush() {
+    // flush NEVER means clear
+    this._update()
+  }
+
+  clear() {
+    this.inserted = {}
+    this._cssText = []
+    this._counter = 0
+    this._rules = {}
+    this._rulesHash = {}
+    this._waitForNextTick = 0
+
+    this._globalTag = 0
+    this._activeTag = 0
+    this._currentPromise = new Deffered()
+  }
+
+  rules() {
+    const rules = this._rules
+    return Object.keys(rules).sort((a, b) => a - b).map(rule => ({
+      cssText: rules[rule].cssText,
+    }))
+  }
+
+  get injected(): boolean {
+    return !!((this._globalTag || this._activeTag))
+  }
+
+}
+
+export default new AsyncStyleSheet()

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -5,7 +5,9 @@ import postcssNested from '../vendor/postcss-nested'
 import type { RuleSet } from '../types'
 import flatten from '../utils/flatten'
 
-import styleSheet from './StyleSheet'
+import styleSheet from './AsyncStyleSheet'
+
+let ruleCounter = 0
 
 export default class ComponentStyle {
   rules: RuleSet;
@@ -17,13 +19,12 @@ export default class ComponentStyle {
   }
 
   generateAndInject() {
-    if (!styleSheet.injected) styleSheet.inject()
     let flatCSS = flatten(this.rules).join('')
     if (this.selector) {
       flatCSS = `${this.selector} {${flatCSS}\n}`
     }
     const root = parse(flatCSS)
     postcssNested(root)
-    styleSheet.insert(root.toResult().css, { global: true })
+    styleSheet.addStyle(`global${ruleCounter++}`, root.toResult().css, { global: true })
   }
 }

--- a/src/models/test/StyleSheet.test.js
+++ b/src/models/test/StyleSheet.test.js
@@ -1,4 +1,4 @@
-import styleSheet from '../StyleSheet'
+import styleSheet from '../AsyncStyleSheet'
 import { resetStyled } from '../../test/utils'
 import expect from 'expect'
 
@@ -8,70 +8,28 @@ describe('stylesheet', () => {
   })
 
   describe('inject', () => {
-    beforeEach(() => {
-      styleSheet.inject()
-    })
-    it('should inject the global sheet', () => {
-      expect(styleSheet.globalStyleSheet.injected).toBe(true)
-    })
-    it('should inject the component sheet', () => {
-      expect(styleSheet.componentStyleSheet.injected).toBe(true)
-    })
-    it('should specify that the sheets have been injected', () => {
-      expect(styleSheet.injected).toBe(true)
+    it('should not be injected by default', () => {
+      expect(styleSheet.injected).toBe(false)
     })
   })
 
   describe('flush', () => {
     beforeEach(() => {
-      styleSheet.flush()
-    })
-    it('should flush the global sheet', () => {
-      expect(styleSheet.globalStyleSheet.injected).toBe(false)
-    })
-    it('should flush the component sheet', () => {
-      expect(styleSheet.componentStyleSheet.injected).toBe(false)
+      styleSheet.clear()
     })
     it('should specify that the sheets are no longer injected', () => {
       expect(styleSheet.injected).toBe(false)
     })
   })
 
-  it('should return both rules for both sheets', () => {
-    styleSheet.insert('a { color: green }', { global: true })
-    styleSheet.insert('.hash1234 { color: blue }')
-
-    expect(styleSheet.rules()).toEqual([
-      { cssText: 'a { color: green }' },
-      { cssText: '.hash1234 { color: blue }' }
-    ])
-  })
-
-  describe('insert with the global option', () => {
-    beforeEach(() => {
-      styleSheet.insert('a { color: green }', { global: true })
-    })
-    it('should insert into the global sheet', () => {
-      expect(styleSheet.globalStyleSheet.rules()).toEqual([
-        { cssText: 'a { color: green }' },
-      ])
-    })
-    it('should not inject into the component sheet', () => {
-      expect(styleSheet.componentStyleSheet.rules()).toEqual([])
-    })
-  })
-
   describe('insert without the global option', () => {
     beforeEach(() => {
-      styleSheet.insert('.hash1234 { color: blue }')
+      styleSheet.addStyle('test','.hash1234 { color: blue }')
     })
     it('should inject into the component sheet', () => {
-      expect(styleSheet.componentStyleSheet.rules()).toEqual([
+      expect(styleSheet.rules()).toEqual([
         { cssText: '.hash1234 { color: blue }' },
       ])
-    })
-    it('should not inject into the global sheet', () => {
-      expect(styleSheet.globalStyleSheet.rules()).toEqual([])
     })
   })
 })

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -4,12 +4,13 @@ import expect from 'expect'
 import { shallow, mount } from 'enzyme'
 import jsdom from 'mocha-jsdom'
 
-import styleSheet from '../models/StyleSheet'
+import styleSheet from '../models/AsyncStyleSheet'
 import { resetStyled, expectCSSMatches } from './utils'
 
 let styled
 
 describe('basic', () => {
+  jsdom()
   /**
    * Make sure the setup is the same for every test
    */
@@ -23,8 +24,10 @@ describe('basic', () => {
 
   it('should inject a stylesheet when a component is created', () => {
     const Comp = styled.div``
-    shallow(<Comp />)
-    expect(styleSheet.injected).toBe(true)
+    mount(<Comp />)
+    expect(styleSheet.injected).toBe(false)
+    styleSheet.forceFlush();
+    expect(styleSheet.injected).toBe(true);
   })
 
   it('should not generate any styles by default', () => {
@@ -34,14 +37,14 @@ describe('basic', () => {
 
   it('should generate an empty tag once rendered', () => {
     const Comp = styled.div``
-    shallow(<Comp />)
+    mount(<Comp />)
     expectCSSMatches('.a {  }')
   })
 
   /* TODO: we should probably pretty-format the output so this test might have to change */
   it('should pass through all whitespace', () => {
     const Comp = styled.div`   \n   `
-    shallow(<Comp />)
+    mount(<Comp />)
     expectCSSMatches('.a {    \n    }', { ignoreWhitespace: false })
   })
 
@@ -84,7 +87,6 @@ describe('basic', () => {
   })
 
   describe('innerRef', () => {
-    jsdom()
 
     it('should handle styled-components correctly', () => {
       const Comp = styled.div`

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -131,7 +131,7 @@ describe('with styles', () => {
     expectCSSMatches('.a { background: blue; } .b { background: red; }')
   })
 
-  it('should inject styles of multiple components based on creation, not rendering order', () => {
+  it('should inject styles of multiple components based rendering order, not creation', () => {
     const firstRule = 'content: "first rule";'
     const secondRule = 'content: "second rule";'
     const FirstComp = styled.div`
@@ -146,9 +146,9 @@ describe('with styles', () => {
     shallow(<FirstComp />)
 
     // Classes _do_ get generated in the order of rendering but that's ok
-    expectCSSMatches(`
-        .b { content: "first rule"; }
+    expectCSSMatches(`        
         .a { content: "second rule"; }
+        .b { content: "first rule"; }
       `)
   })
 

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -6,7 +6,7 @@
 import expect from 'expect'
 
 import _styled from '../constructors/styled'
-import mainStyleSheet from '../models/StyleSheet'
+import asyncStyleSheet from '../models/AsyncStyleSheet'
 import _styledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
@@ -15,7 +15,7 @@ let index = 0
 const classNames = () => String.fromCodePoint(97 + index++)
 
 export const resetStyled = () => {
-  mainStyleSheet.flush()
+  asyncStyleSheet.clear();
   index = 0
   return _styled(_styledComponent(_ComponentStyle(classNames)))
 }
@@ -25,7 +25,7 @@ export const expectCSSMatches = (
   expectation: string,
   opts: { ignoreWhitespace?: boolean, styleSheet?: Object } = {}
 ) => {
-  const { ignoreWhitespace = true, styleSheet = mainStyleSheet } = opts
+  const { ignoreWhitespace = true, styleSheet = asyncStyleSheet } = opts
   const css = styleSheet.rules().map(rule => rule.cssText).join('\n')
   if (ignoreWhitespace) {
     expect(stripWhitespace(css)).toEqual(stripWhitespace(expectation))


### PR DESCRIPTION
I come from here https://github.com/styled-components/styled-components/issues/452
This PR not passing all tests(I dont know why), and linting (ok, this is just proof-of-concept)

What is done here:
 1. I replace StyleSheet with very simply AsyncStyleSheet. It just add styles in a bulk, and then compact them in a real huge style.
 2. I add removing of old styles. I was shocked, then I dont find anything about "remove" in Styled. You are very dirty ones. You should clean after you.

What in result
 - there is no need for dirty hacks on stylesheet level to support "millions of rules". You will never have millions of rules. Simultaneously.
 - you can animate your styles. With out penalty.
 - thanks to buck operations everything runs a bit faster
 - (cons) But in a bit different way.