### PR TITLE
replaced babel-preset-latest with babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "latest",
+    "env",
     "react"
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-flow-strip-types": "^6.21.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
-    "babel-preset-latest": "^6.16.0",
+    "babel-preset-env": "^1.2.1",
     "babel-preset-react": "^6.16.0",
     "chokidar": "^1.6.1",
     "danger": "^0.7.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,7 @@ const plugins = [
   babel({
     babelrc: false,
     presets: [
-      ['latest', { es2015: { modules: false } }],
+      ['env', { modules: false }],
       'react',
     ],
     plugins: [


### PR DESCRIPTION
With the deprecation of babel-preset-latest and the addition of babel-preset-env per [babel-preset-env](https://github.com/babel/babel-preset-env) the babel.rc file as well as the rollup.config.js have been updated to use the env preset.