### PR TITLE
README: update syntax highlighting status for Sublime

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ See the [`stylelint-processor-styled-components`](https://github.com/styled-comp
 
 ## Syntax highlighting
 
-The one thing you lose when writing CSS in template literals is syntax highlighting. We're working hard on making proper syntax highlighting happening in all editors. We currently have support for Atom, Visual Studio Code, and soon Sublime Text.
+The one thing you lose when writing CSS in template literals is syntax highlighting. We're working hard on making proper syntax highlighting happening in all editors. We currently have support for Atom, Sublime Text, Visual Studio Code, and VIM.
 
 This is what it looks like when properly highlighted:
 
@@ -444,9 +444,9 @@ To get proper syntax highlighting, all you have to do is install and use the `la
 
 ### Sublime Text
 
-There is an [open PR](https://github.com/babel/babel-sublime/pull/289) by [@garetmckinley](https://github.com/garetmckinley) to add support for `styled-components` to `babel-sublime`! (if you want the PR to land, feel free to 👍 the initial comment to let the maintainers know there's a need for this!)
+[@garetmckinley](https://github.com/garetmckinley) has added support for `styled-components` to `babel-sublime`!
 
-As soon as that PR is merged and a new version released, all you'll have to do is install and use `babel-sublime` to highlight your JavaScript files!
+All you'll have to do is install and use `babel-sublime` to highlight your JavaScript files!
 
 ### Visual Studio Code
 


### PR DESCRIPTION
https://github.com/babel/babel-sublime/pull/289 got merged some time back, but the README didn't reflect that.