### PR TITLE
Accept preprocessed CSS from babel plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Added `attrs` constructor for passing extra attributes to the underlying element
 - Added warnings for components generating a lot of classes, thanks to [@vdanchenkov](https://github.com/vdanchenkov). (see [#268](https://github.com/styled-components/styled-components/pull/268))
 - Standardised `styled(Comp)` to work the same in all cases, rather than a special extension case where `Comp` is another Styled Component. `Comp.extend` now covers that case. (see [#518](https://github.com/styled-components/styled-components/pull/518)).
+- Added a separate `no-parser` entrypoint for preprocessed CSS, which doesn't depend on stylis. The preprocessing is part of our babel plugin. (see [babel-plugin-styled-components/#26](https://github.com/styled-components/babel-plugin-styled-components/pull/26))
 
 ## [Unreleased]
 

--- a/no-parser.js
+++ b/no-parser.js
@@ -1,0 +1,2 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+module.exports = require('./lib/no-parser')

--- a/src/constructors/constructWithOptions.js
+++ b/src/constructors/constructWithOptions.js
@@ -1,23 +1,24 @@
 // @flow
-import css from './css'
 import type { Interpolation, Target } from '../types'
 
-const constructWithOptions = (componentConstructor: Function,
-                              tag: Target,
-                              options: Object = {}) => {
-  /* This is callable directly as a template function */
-  const templateFunction =
-    (strings: Array<string>, ...interpolations: Array<Interpolation>) =>
-      componentConstructor(tag, options, css(strings, ...interpolations), templateFunction)
+export default (css: Function) => {
+  const constructWithOptions = (componentConstructor: Function,
+                                tag: Target,
+                                options: Object = {}) => {
+    /* This is callable directly as a template function */
+    const templateFunction =
+      (strings: Array<string>, ...interpolations: Array<Interpolation>) =>
+        componentConstructor(tag, options, css(strings, ...interpolations), templateFunction)
 
-  /* If config methods are called, wrap up a new template function and merge options */
-  templateFunction.withConfig = config =>
-    constructWithOptions(componentConstructor, tag, { ...options, ...config })
-  templateFunction.attrs = attrs =>
-    constructWithOptions(componentConstructor, tag, { ...options,
-      attrs: { ...(options.attrs || {}), ...attrs } })
+    /* If config methods are called, wrap up a new template function and merge options */
+    templateFunction.withConfig = config =>
+      constructWithOptions(componentConstructor, tag, { ...options, ...config })
+    templateFunction.attrs = attrs =>
+      constructWithOptions(componentConstructor, tag, { ...options,
+        attrs: { ...(options.attrs || {}), ...attrs } })
 
-  return templateFunction
+    return templateFunction
+  }
+
+  return constructWithOptions
 }
-
-export default constructWithOptions

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -1,11 +1,12 @@
 // @flow
 import css from './css'
-import GlobalStyle from '../models/GlobalStyle'
 import type { Interpolation } from '../types'
 
-const injectGlobal = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
-  const globalStyle = new GlobalStyle(css(strings, ...interpolations))
-  globalStyle.generateAndInject()
-}
+export default (GlobalStyle: Function) => {
+  const injectGlobal = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
+    const globalStyle = new GlobalStyle(css(strings, ...interpolations))
+    globalStyle.generateAndInject()
+  }
 
-export default injectGlobal
+  return injectGlobal
+}

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -1,8 +1,7 @@
 // @flow
-import css from './css'
 import type { Interpolation } from '../types'
 
-export default (GlobalStyle: Function) => {
+export default (GlobalStyle: Function, css: Function) => {
   const injectGlobal = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
     const globalStyle = new GlobalStyle(css(strings, ...interpolations))
     globalStyle.generateAndInject()

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,11 +1,10 @@
 // @flow
 import hashStr from 'glamor/lib/hash'
-import css from './css'
 import type { Interpolation, NameGenerator } from '../types'
 
 const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 
-export default (nameGenerator: NameGenerator, GlobalStyle: Function) =>
+export default (nameGenerator: NameGenerator, GlobalStyle: Function, css: Function) =>
   (strings: Array<string>, ...interpolations: Array<Interpolation>): string => {
     const rules = css(strings, ...interpolations)
     const hash = hashStr(replaceWhitespace(JSON.stringify(rules)))

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,12 +1,11 @@
 // @flow
 import hashStr from 'glamor/lib/hash'
 import css from './css'
-import GlobalStyle from '../models/GlobalStyle'
 import type { Interpolation, NameGenerator } from '../types'
 
 const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 
-export default (nameGenerator: NameGenerator) =>
+export default (nameGenerator: NameGenerator, GlobalStyle: Function) =>
   (strings: Array<string>, ...interpolations: Array<Interpolation>): string => {
     const rules = css(strings, ...interpolations)
     const hash = hashStr(replaceWhitespace(JSON.stringify(rules)))

--- a/src/constructors/styled.js
+++ b/src/constructors/styled.js
@@ -1,9 +1,8 @@
 // @flow
-import constructWithOptions from './constructWithOptions'
 import type { Target } from '../types'
 import domElements from '../utils/domElements'
 
-export default (styledComponent: Function) => {
+export default (styledComponent: Function, constructWithOptions: Function) => {
   const styled = (tag: Target) => constructWithOptions(styledComponent, tag)
 
   // Shorthands for all valid HTML Elements

--- a/src/constructors/test/injectGlobal.test.js
+++ b/src/constructors/test/injectGlobal.test.js
@@ -7,9 +7,11 @@ import _injectGlobal from '../injectGlobal'
 import styleSheet from '../../models/StyleSheet'
 import _GlobalStyle from '../../models/GlobalStyle'
 import flatten from '../../utils/flatten'
+import stringifyRules from '../../utils/stringifyRules'
+import css from '../css'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
-const injectGlobal = _injectGlobal(_GlobalStyle(flatten))
+const injectGlobal = _injectGlobal(_GlobalStyle(flatten, stringifyRules), css)
 
 let styled = resetStyled()
 const rule1 = 'width: 100%;'

--- a/src/constructors/test/injectGlobal.test.js
+++ b/src/constructors/test/injectGlobal.test.js
@@ -3,9 +3,13 @@ import React, { Component } from 'react'
 import expect from 'expect'
 import { shallow } from 'enzyme'
 
-import injectGlobal from '../injectGlobal'
+import _injectGlobal from '../injectGlobal'
 import styleSheet from '../../models/StyleSheet'
+import _GlobalStyle from '../../models/GlobalStyle'
+import flatten from '../../utils/flatten'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
+
+const injectGlobal = _injectGlobal(_GlobalStyle(flatten))
 
 let styled = resetStyled()
 const rule1 = 'width: 100%;'

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -4,13 +4,14 @@ import expect from 'expect'
 import _keyframes from '../keyframes'
 import _GlobalStyle from '../../models/GlobalStyle'
 import flatten from '../../utils/flatten'
+import stringifyRules from '../../utils/stringifyRules'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 /**
  * Setup
  */
 let index = 0
-const keyframes = _keyframes(() => `keyframe_${index++}`, _GlobalStyle(flatten))
+const keyframes = _keyframes(() => `keyframe_${index++}`, _GlobalStyle(flatten, stringifyRules))
 
 describe('keyframes', () => {
   beforeEach(() => {

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -2,13 +2,15 @@
 import expect from 'expect'
 
 import _keyframes from '../keyframes'
+import _GlobalStyle from '../../models/GlobalStyle'
+import flatten from '../../utils/flatten'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 /**
  * Setup
  */
 let index = 0
-const keyframes = _keyframes(() => `keyframe_${index++}`)
+const keyframes = _keyframes(() => `keyframe_${index++}`, _GlobalStyle(flatten))
 
 describe('keyframes', () => {
   beforeEach(() => {

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -5,13 +5,14 @@ import _keyframes from '../keyframes'
 import _GlobalStyle from '../../models/GlobalStyle'
 import flatten from '../../utils/flatten'
 import stringifyRules from '../../utils/stringifyRules'
+import css from '../css'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
 /**
  * Setup
  */
 let index = 0
-const keyframes = _keyframes(() => `keyframe_${index++}`, _GlobalStyle(flatten, stringifyRules))
+const keyframes = _keyframes(() => `keyframe_${index++}`, _GlobalStyle(flatten, stringifyRules), css)
 
 describe('keyframes', () => {
   beforeEach(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,18 @@
 // @flow
 
 /* Import singletons */
+import flatten from './utils/flatten'
 import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
-import injectGlobal from './constructors/injectGlobal'
 import styleSheet from './models/StyleSheet'
 
 /* Import singleton constructors */
 import _styledComponent from './models/StyledComponent'
+import _ComponentStyle from './models/ComponentStyle'
+import _GlobalStyle from './models/GlobalStyle'
 import _styled from './constructors/styled'
 import _keyframes from './constructors/keyframes'
-import _ComponentStyle from './models/ComponentStyle'
+import _injectGlobal from './constructors/injectGlobal'
 
 /* Import components */
 import ThemeProvider from './models/ThemeProvider'
@@ -19,8 +21,10 @@ import ThemeProvider from './models/ThemeProvider'
 import withTheme from './hoc/withTheme'
 
 /* Instantiate singletons */
-const keyframes = _keyframes(generateAlphabeticName)
-const styled = _styled(_styledComponent(_ComponentStyle(generateAlphabeticName)))
+const GlobalStyle = _GlobalStyle(flatten)
+const keyframes = _keyframes(generateAlphabeticName, GlobalStyle)
+const injectGlobal = _injectGlobal(GlobalStyle)
+const styled = _styled(_styledComponent(_ComponentStyle(generateAlphabeticName, flatten)))
 
 /* Export everything */
 export default styled

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,13 @@ import css from './constructors/css'
 import styleSheet from './models/StyleSheet'
 
 /* Import singleton constructors */
-import _styledComponent from './models/StyledComponent'
+import _StyledComponent from './models/StyledComponent'
 import _ComponentStyle from './models/ComponentStyle'
 import _GlobalStyle from './models/GlobalStyle'
 import _styled from './constructors/styled'
 import _keyframes from './constructors/keyframes'
 import _injectGlobal from './constructors/injectGlobal'
+import _constructWithOptions from './constructors/constructWithOptions'
 
 /* Import components */
 import ThemeProvider from './models/ThemeProvider'
@@ -23,11 +24,14 @@ import withTheme from './hoc/withTheme'
 
 /* Instantiate singletons */
 const GlobalStyle = _GlobalStyle(flatten, stringifyRules)
+const ComponentStyle = _ComponentStyle(generateAlphabeticName, flatten, stringifyRules)
+const constructWithOptions = _constructWithOptions(css)
+const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)
+
+/* Instantiate exported singletons */
 const keyframes = _keyframes(generateAlphabeticName, GlobalStyle, css)
 const injectGlobal = _injectGlobal(GlobalStyle, css)
-const styled = _styled(_styledComponent(
-  _ComponentStyle(generateAlphabeticName, flatten, stringifyRules),
-))
+const styled = _styled(StyledComponent, constructWithOptions)
 
 /* Export everything */
 export default styled

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 /* Import singletons */
 import flatten from './utils/flatten'
+import stringifyRules from './utils/stringifyRules'
 import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
 import styleSheet from './models/StyleSheet'
@@ -21,10 +22,12 @@ import ThemeProvider from './models/ThemeProvider'
 import withTheme from './hoc/withTheme'
 
 /* Instantiate singletons */
-const GlobalStyle = _GlobalStyle(flatten)
+const GlobalStyle = _GlobalStyle(flatten, stringifyRules)
 const keyframes = _keyframes(generateAlphabeticName, GlobalStyle)
 const injectGlobal = _injectGlobal(GlobalStyle)
-const styled = _styled(_styledComponent(_ComponentStyle(generateAlphabeticName, flatten)))
+const styled = _styled(_styledComponent(
+  _ComponentStyle(generateAlphabeticName, flatten, stringifyRules),
+))
 
 /* Export everything */
 export default styled

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ import withTheme from './hoc/withTheme'
 
 /* Instantiate singletons */
 const GlobalStyle = _GlobalStyle(flatten, stringifyRules)
-const keyframes = _keyframes(generateAlphabeticName, GlobalStyle)
-const injectGlobal = _injectGlobal(GlobalStyle)
+const keyframes = _keyframes(generateAlphabeticName, GlobalStyle, css)
+const injectGlobal = _injectGlobal(GlobalStyle, css)
 const styled = _styled(_styledComponent(
   _ComponentStyle(generateAlphabeticName, flatten, stringifyRules),
 ))

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -1,15 +1,14 @@
 // @flow
 import hashStr from 'glamor/lib/hash'
-import stylis from 'stylis'
 
-import type { RuleSet, NameGenerator, Flattener } from '../types'
+import type { RuleSet, NameGenerator, Flattener, Stringifier } from '../types'
 import styleSheet from './StyleSheet'
 
 /*
  ComponentStyle is all the CSS-specific stuff, not
  the React-specific stuff.
  */
-export default (nameGenerator: NameGenerator, flatten: Flattener) => {
+export default (nameGenerator: NameGenerator, flatten: Flattener, stringifyRules: Stringifier) => {
   const inserted = {}
 
   class ComponentStyle {
@@ -41,7 +40,7 @@ export default (nameGenerator: NameGenerator, flatten: Flattener) => {
       if (!inserted[hash]) {
         const selector = nameGenerator(hash)
         inserted[hash] = selector
-        const css = stylis(`.${selector}`, flatCSS, false, false)
+        const css = stringifyRules(flatCSS, selector, false)
         this.insertedRule.appendRule(css)
       }
       return inserted[hash]

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -2,15 +2,14 @@
 import hashStr from 'glamor/lib/hash'
 import stylis from 'stylis'
 
-import type { RuleSet, NameGenerator } from '../types'
-import flatten from '../utils/flatten'
+import type { RuleSet, NameGenerator, Flattener } from '../types'
 import styleSheet from './StyleSheet'
 
 /*
  ComponentStyle is all the CSS-specific stuff, not
  the React-specific stuff.
  */
-export default (nameGenerator: NameGenerator) => {
+export default (nameGenerator: NameGenerator, flatten: Flattener) => {
   const inserted = {}
 
   class ComponentStyle {

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -34,14 +34,14 @@ export default (nameGenerator: NameGenerator, flatten: Flattener, stringifyRules
      * Returns the hash to be injected on render()
      * */
     generateAndInjectStyles(executionContext: Object) {
-      const flatCSS = flatten(this.rules, executionContext).join('')
-      const hash = hashStr(this.componentId + flatCSS)
+      const flatCSS = flatten(this.rules, executionContext)
+      const hash = hashStr(this.componentId + flatCSS.join(''))
 
       if (!inserted[hash]) {
         const selector = nameGenerator(hash)
         inserted[hash] = selector
 
-        const css = stringifyRules(this.rules, selector, false)
+        const css = stringifyRules(flatCSS, selector, false)
         this.insertedRule.appendRule(css)
       }
 

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -35,14 +35,16 @@ export default (nameGenerator: NameGenerator, flatten: Flattener, stringifyRules
      * */
     generateAndInjectStyles(executionContext: Object) {
       const flatCSS = flatten(this.rules, executionContext).join('')
-        .replace(/^\s*\/\/.*$/gm, '') // replace JS comments
       const hash = hashStr(this.componentId + flatCSS)
+
       if (!inserted[hash]) {
         const selector = nameGenerator(hash)
         inserted[hash] = selector
-        const css = stringifyRules(flatCSS, selector, false)
+
+        const css = stringifyRules(this.rules, selector, false)
         this.insertedRule.appendRule(css)
       }
+
       return inserted[hash]
     }
   }

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -15,7 +15,7 @@ export default (flatten: Flattener, stringifyRules: Stringifier) => {
     generateAndInject() {
       if (!styleSheet.injected) styleSheet.inject()
       const flatRules = flatten(this.rules)
-      const css = stringifyRules(flatRules, this.selector)
+      const css = stringifyRules(flatRules, this.selector, true)
       styleSheet.insert(css)
     }
   }

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -1,10 +1,8 @@
 // @flow
-import stylis from 'stylis'
-
-import type { RuleSet, Flattener } from '../types'
+import type { RuleSet, Flattener, Stringifier } from '../types'
 import styleSheet from './StyleSheet'
 
-export default (flatten: Flattener) => {
+export default (flatten: Flattener, stringifyRules: Stringifier) => {
   class GlobalStyle {
     rules: RuleSet;
     selector: ?string;
@@ -16,9 +14,8 @@ export default (flatten: Flattener) => {
 
     generateAndInject() {
       if (!styleSheet.injected) styleSheet.inject()
-      const flatCSS = flatten(this.rules).join('')
-      const cssString = this.selector ? `${this.selector} { ${flatCSS} }` : flatCSS
-      const css = stylis('', cssString, false, false)
+      const flatRules = flatten(this.rules)
+      const css = stringifyRules(flatRules, this.selector)
       styleSheet.insert(css)
     }
   }

--- a/src/models/GlobalStyle.js
+++ b/src/models/GlobalStyle.js
@@ -1,24 +1,27 @@
 // @flow
 import stylis from 'stylis'
 
-import type { RuleSet } from '../types'
-import flatten from '../utils/flatten'
+import type { RuleSet, Flattener } from '../types'
 import styleSheet from './StyleSheet'
 
-export default class ComponentStyle {
-  rules: RuleSet;
-  selector: ?string;
+export default (flatten: Flattener) => {
+  class GlobalStyle {
+    rules: RuleSet;
+    selector: ?string;
 
-  constructor(rules: RuleSet, selector: ?string) {
-    this.rules = rules
-    this.selector = selector
+    constructor(rules: RuleSet, selector: ?string) {
+      this.rules = rules
+      this.selector = selector
+    }
+
+    generateAndInject() {
+      if (!styleSheet.injected) styleSheet.inject()
+      const flatCSS = flatten(this.rules).join('')
+      const cssString = this.selector ? `${this.selector} { ${flatCSS} }` : flatCSS
+      const css = stylis('', cssString, false, false)
+      styleSheet.insert(css)
+    }
   }
 
-  generateAndInject() {
-    if (!styleSheet.injected) styleSheet.inject()
-    const flatCSS = flatten(this.rules).join('')
-    const cssString = this.selector ? `${this.selector} { ${flatCSS} }` : flatCSS
-    const css = stylis('', cssString, false, false)
-    styleSheet.insert(css)
-  }
+  return GlobalStyle
 }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -11,9 +11,8 @@ import type { RuleSet, Target } from '../types'
 
 import AbstractStyledComponent from './AbstractStyledComponent'
 import { CHANNEL } from './ThemeProvider'
-import constructWithOptions from '../constructors/constructWithOptions'
 
-export default (ComponentStyle: Function) => {
+export default (ComponentStyle: Function, constructWithOptions: Function) => {
   /* We depend on components having unique IDs */
   const identifiers = {}
   const generateId = (_displayName: string) => {

--- a/src/models/test/StyleSheet.test.js
+++ b/src/models/test/StyleSheet.test.js
@@ -3,12 +3,18 @@ import expect from 'expect';
 import { shallow } from 'enzyme'
 import { resetStyled, expectCSSMatches } from '../../test/utils'
 import styleSheet from '../StyleSheet';
-import injectGlobal from '../../constructors/injectGlobal'
+import _GlobalStyle from '../GlobalStyle'
+import _injectGlobal from '../../constructors/injectGlobal'
+import css from '../../constructors/css'
+import flatten from '../../utils/flatten'
+import stringifyRules from '../../utils/stringifyRules'
 
 let styled
 const rule1 = 'width: 100%;'
 const rule2 = 'text-decoration: none;'
 const rule3 = 'color: blue;'
+
+const injectGlobal = _injectGlobal(_GlobalStyle(flatten, stringifyRules), css)
 
 describe('styleSheet', () => {
 

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -3,7 +3,7 @@
 /* eslint-disable import/no-unresolved */
 import reactNative from 'react-native'
 
-import constructWithOptions from '../constructors/constructWithOptions'
+import _constructWithOptions from '../constructors/constructWithOptions'
 import css from '../constructors/css'
 
 import styledNativeComponent from '../models/StyledNativeComponent'
@@ -11,6 +11,7 @@ import ThemeProvider from '../models/ThemeProvider'
 import withTheme from '../hoc/withTheme'
 import type { Target } from '../types'
 
+const constructWithOptions = _constructWithOptions(css)
 const styled = (tag: Target) => constructWithOptions(styledNativeComponent, tag)
 
 /* React native lazy-requires each of these modules for some reason, so let's

--- a/src/no-parser/css.js
+++ b/src/no-parser/css.js
@@ -1,0 +1,5 @@
+// @flow
+import flatten from './flatten'
+import type { Interpolation, RuleSet } from '../types'
+
+export default (interpolations: Array<Interpolation>): RuleSet => flatten(interpolations)

--- a/src/no-parser/flatten.js
+++ b/src/no-parser/flatten.js
@@ -1,0 +1,93 @@
+// @flow
+import isPlainObject from 'is-plain-object'
+import type { Interpolation } from '../types'
+import _flatten, { objToCss } from '../utils/flatten'
+
+const isRuleSet = (interpolation: Interpolation): boolean => !!(
+  interpolation &&
+  Array.isArray(interpolation) &&
+  interpolation.length > 0 &&
+  interpolation[0] &&
+  Array.isArray(interpolation[0])
+)
+
+const flatten = (chunks: Array<Interpolation>, executionContext: ?Object): Array<Interpolation> => {
+  /* Fall back to old flattener for non-rule-set chunks */
+  if (!isRuleSet(chunks)) {
+    return _flatten(chunks, executionContext)
+  }
+
+  return chunks.reduce(
+    (ruleSet: Array<Interpolation>, chunk: ?Interpolation): Array<Interpolation> => {
+      if (!Array.isArray(chunk)) {
+        return ruleSet
+      }
+
+      let appendChunks = []
+
+      const newChunk = chunk.reduce(
+        (rules: Array<Interpolation>, rule: ?Interpolation): Array<Interpolation> => {
+          /* Remove falsey values */
+          if (rule === undefined || rule === null || rule === false || rule === '') {
+            return rules
+          }
+
+          /* Flatten nested rule set */
+          if (isRuleSet(rule)) {
+            // $FlowFixMe Don't know what's wrong here
+            appendChunks = [...appendChunks, ...flatten(rule, executionContext)]
+            return rules
+          }
+
+          /* Stringify unexpected array */
+          if (Array.isArray(rule)) {
+            return [...rules, ..._flatten(rule, executionContext)]
+          }
+
+          /* Either execute or defer the function */
+          if (typeof rule === 'function') {
+            if (executionContext) {
+              const res = rule(executionContext)
+
+              if (isRuleSet(res)) {
+                // $FlowFixMe Don't know what's wrong here
+                appendChunks = [...appendChunks, ...flatten(res, executionContext)]
+                return rules
+              }
+
+              /* Flatten non-ruleset values */
+              return [...rules, ...flatten([res], executionContext)]
+            } else {
+              return [...rules, rule]
+            }
+          }
+
+          /* Handle other components */
+          if (typeof rule === 'object' && rule.hasOwnProperty('styledComponentId')) return [...rules, `.${rule.styledComponentId}`]
+
+          /* Convert object to css string */
+          if (typeof rule === 'object' && isPlainObject(rule)) {
+            return [...rules, objToCss(rule)]
+          }
+
+          return [...rules, rule.toString()]
+        },
+        [],
+      )
+
+      if (executionContext) {
+        const newChunkStr = newChunk.join('')
+        if (appendChunks.length) {
+          const appendChunkStr = appendChunks.join('')
+          return [...ruleSet, newChunkStr, appendChunkStr]
+        }
+
+        return [...ruleSet, newChunkStr]
+      }
+
+      return [...ruleSet, newChunk, ...appendChunks]
+    }, [],
+  )
+}
+
+export default flatten

--- a/src/no-parser/flatten.js
+++ b/src/no-parser/flatten.js
@@ -78,8 +78,7 @@ const flatten = (chunks: Array<Interpolation>, executionContext: ?Object): Array
       if (executionContext) {
         const newChunkStr = newChunk.join('')
         if (appendChunks.length) {
-          const appendChunkStr = appendChunks.join('')
-          return [...ruleSet, newChunkStr, appendChunkStr]
+          return [...ruleSet, newChunkStr, ...appendChunks]
         }
 
         return [...ruleSet, newChunkStr]

--- a/src/no-parser/index.js
+++ b/src/no-parser/index.js
@@ -1,0 +1,36 @@
+// @flow
+
+/* Import no-parser singleton variants */
+import flatten from './flatten'
+import stringifyRules from './stringifyRules'
+
+/* Import singletons */
+import generateAlphabeticName from '../utils/generateAlphabeticName'
+import styleSheet from '../models/StyleSheet'
+import css from '../constructors/css'
+
+/* Import singleton constructors */
+import _styledComponent from '../models/StyledComponent'
+import _ComponentStyle from '../models/ComponentStyle'
+import _GlobalStyle from '../models/GlobalStyle'
+import _styled from '../constructors/styled'
+import _keyframes from '../constructors/keyframes'
+import _injectGlobal from '../constructors/injectGlobal'
+
+/* Import components */
+import ThemeProvider from '../models/ThemeProvider'
+
+/* Import Higher Order Components */
+import withTheme from '../hoc/withTheme'
+
+/* Instantiate singletons */
+const GlobalStyle = _GlobalStyle(flatten, stringifyRules)
+const keyframes = _keyframes(generateAlphabeticName, GlobalStyle)
+const injectGlobal = _injectGlobal(GlobalStyle)
+const styled = _styled(_styledComponent(
+  _ComponentStyle(generateAlphabeticName, flatten, stringifyRules),
+))
+
+/* Export everything */
+export default styled
+export { css, keyframes, injectGlobal, ThemeProvider, withTheme, styleSheet }

--- a/src/no-parser/index.js
+++ b/src/no-parser/index.js
@@ -10,12 +10,13 @@ import generateAlphabeticName from '../utils/generateAlphabeticName'
 import styleSheet from '../models/StyleSheet'
 
 /* Import singleton constructors */
-import _styledComponent from '../models/StyledComponent'
+import _StyledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 import _GlobalStyle from '../models/GlobalStyle'
 import _styled from '../constructors/styled'
 import _keyframes from '../constructors/keyframes'
 import _injectGlobal from '../constructors/injectGlobal'
+import _constructWithOptions from '../constructors/constructWithOptions'
 
 /* Import components */
 import ThemeProvider from '../models/ThemeProvider'
@@ -25,11 +26,14 @@ import withTheme from '../hoc/withTheme'
 
 /* Instantiate singletons */
 const GlobalStyle = _GlobalStyle(flatten, stringifyRules)
+const ComponentStyle = _ComponentStyle(generateAlphabeticName, flatten, stringifyRules)
+const constructWithOptions = _constructWithOptions(css)
+const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)
+
+/* Instantiate exported singletons */
 const keyframes = _keyframes(generateAlphabeticName, GlobalStyle, css)
 const injectGlobal = _injectGlobal(GlobalStyle, css)
-const styled = _styled(_styledComponent(
-  _ComponentStyle(generateAlphabeticName, flatten, stringifyRules),
-))
+const styled = _styled(StyledComponent, constructWithOptions)
 
 /* Export everything */
 export default styled

--- a/src/no-parser/index.js
+++ b/src/no-parser/index.js
@@ -3,11 +3,11 @@
 /* Import no-parser singleton variants */
 import flatten from './flatten'
 import stringifyRules from './stringifyRules'
+import css from './css'
 
 /* Import singletons */
 import generateAlphabeticName from '../utils/generateAlphabeticName'
 import styleSheet from '../models/StyleSheet'
-import css from '../constructors/css'
 
 /* Import singleton constructors */
 import _styledComponent from '../models/StyledComponent'
@@ -25,8 +25,8 @@ import withTheme from '../hoc/withTheme'
 
 /* Instantiate singletons */
 const GlobalStyle = _GlobalStyle(flatten, stringifyRules)
-const keyframes = _keyframes(generateAlphabeticName, GlobalStyle)
-const injectGlobal = _injectGlobal(GlobalStyle)
+const keyframes = _keyframes(generateAlphabeticName, GlobalStyle, css)
+const injectGlobal = _injectGlobal(GlobalStyle, css)
 const styled = _styled(_styledComponent(
   _ComponentStyle(generateAlphabeticName, flatten, stringifyRules),
 ))

--- a/src/no-parser/stringifyRules.js
+++ b/src/no-parser/stringifyRules.js
@@ -2,20 +2,17 @@
 import type { Interpolation } from '../types'
 
 const stringifyRules = (
-  rules: Array<Interpolation> | string,
+  rules: Array<Interpolation>,
   selector: ?string,
   shouldWrap: ?boolean,
 ): string => {
   const className = (selector && !shouldWrap) ? `.${selector}` : null
-  const flatCSS = (
-    typeof rules === 'string' ?
-      rules :
-      rules.reduce((str: string, partial: Interpolation): string => (
-        str + (className || '') + partial.toString()
-      ), '')
-  )
+  const flatCSS = rules
+    .reduce((str: string, partial: Interpolation): string => (
+      str + (className || '') + partial.toString()
+    ), '')
 
-  return (selector && shouldWrap) ? `.${selector} { ${flatCSS} }` : flatCSS
+  return (selector && shouldWrap) ? `${selector} { ${flatCSS} }` : flatCSS
 }
 
 export default stringifyRules

--- a/src/no-parser/stringifyRules.js
+++ b/src/no-parser/stringifyRules.js
@@ -1,0 +1,21 @@
+// @flow
+import type { Interpolation } from '../types'
+
+const stringifyRules = (
+  rules: Array<Interpolation> | string,
+  selector: ?string,
+  shouldWrap: ?boolean,
+): string => {
+  const className = (selector && !shouldWrap) ? `.${selector}` : null
+  const flatCSS = (
+    typeof rules === 'string' ?
+      rules :
+      rules.reduce((str: string, partial: Interpolation): string => (
+        str + (className || '') + partial.toString()
+      ), '')
+  )
+
+  return (selector && shouldWrap) ? `.${selector} { ${flatCSS} }` : flatCSS
+}
+
+export default stringifyRules

--- a/src/no-parser/test/basic.test.js
+++ b/src/no-parser/test/basic.test.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { resetNoParserStyled, expectCSSMatches } from '../../test/utils'
+
+let styled
+
+describe('basic', () => {
+  beforeEach(() => {
+    styled = resetNoParserStyled()
+  })
+
+  it('should correctly assemble preprocessed CSS', () => {
+    // $FlowFixMe
+    const Comp = styled.div([[ '{ color: red; }' ]])
+    shallow(<Comp />)
+    expectCSSMatches('.sc-a {} .b{ color: red; }')
+  })
+
+  it('should correctly execute passed functions and assemble preprocessed CSS', () => {
+    // $FlowFixMe
+    const Comp = styled.div([[ '{ color: ', () => 'red', '; }' ]])
+    shallow(<Comp />)
+    expectCSSMatches('.sc-a {} .b{ color: red; }')
+  })
+})

--- a/src/no-parser/test/basic.test.js
+++ b/src/no-parser/test/basic.test.js
@@ -12,14 +12,12 @@ describe('basic', () => {
   })
 
   it('should correctly assemble preprocessed CSS', () => {
-    // $FlowFixMe
     const Comp = styled.div([[ '{ color: red; }' ]])
     shallow(<Comp />)
     expectCSSMatches('.sc-a {} .b{ color: red; }')
   })
 
   it('should correctly execute passed functions and assemble preprocessed CSS', () => {
-    // $FlowFixMe
     const Comp = styled.div([[ '{ color: ', () => 'red', '; }' ]])
     shallow(<Comp />)
     expectCSSMatches('.sc-a {} .b{ color: red; }')

--- a/src/no-parser/test/flatten.test.js
+++ b/src/no-parser/test/flatten.test.js
@@ -34,7 +34,6 @@ describe('preparsed flatten without executionContext', () => {
   })
 
   it('flattens nested rulesets', () => {
-    // $FlowFixMe
     expect(
       flatten([[
         'a', [[ 'c' ]], 'b'
@@ -43,7 +42,6 @@ describe('preparsed flatten without executionContext', () => {
   })
 
   it('flattens double nested rulesets', () => {
-    // $FlowFixMe
     expect(
       flatten([[
         'a', [[ 'c', [['d']] ]], 'b'
@@ -52,7 +50,6 @@ describe('preparsed flatten without executionContext', () => {
   })
 
   it('flattens subarrays', () => {
-    // $FlowFixMe
     expect(flatten([[1, 2, [3, 4, 5], 'come:on;', 'lets:ride;']]))
       .toEqual([['1', '2', '3', '4', '5', 'come:on;', 'lets:ride;']])
   })
@@ -97,7 +94,6 @@ describe('preparsed flatten with executionContext', () => {
   })
 
   it('flattens nested rulesets', () => {
-    // $FlowFixMe
     expect(
       flatten([[
         'a', [[ 'c' ]], 'b'
@@ -106,7 +102,6 @@ describe('preparsed flatten with executionContext', () => {
   })
 
   it('flattens double nested rulesets', () => {
-    // $FlowFixMe
     expect(
       flatten([[
         'a', [[ 'c', 'd', [['e', 'f'], ['g', 'h']] ]], 'b'
@@ -115,14 +110,12 @@ describe('preparsed flatten with executionContext', () => {
   })
 
   it('flattens subarrays', () => {
-    // $FlowFixMe
     expect(flatten([[1, 2, [3, 4, 5], 'come:on;', 'lets:ride;']], {}))
       .toEqual(['12345come:on;lets:ride;'])
   })
 
   it('executes functions', () => {
     const func = () => 'bar'
-
     expect(flatten([['foo', func, 'baz']], {})).toEqual(['foobarbaz'])
   })
 

--- a/src/no-parser/test/flatten.test.js
+++ b/src/no-parser/test/flatten.test.js
@@ -42,6 +42,15 @@ describe('preparsed flatten without executionContext', () => {
     ).toEqual([['a', 'b'], ['c']])
   })
 
+  it('flattens double nested rulesets', () => {
+    // $FlowFixMe
+    expect(
+      flatten([[
+        'a', [[ 'c', [['d']] ]], 'b'
+      ]])
+    ).toEqual([['a', 'b'], ['c'], ['d']])
+  })
+
   it('flattens subarrays', () => {
     // $FlowFixMe
     expect(flatten([[1, 2, [3, 4, 5], 'come:on;', 'lets:ride;']]))
@@ -96,6 +105,15 @@ describe('preparsed flatten with executionContext', () => {
     ).toEqual(['ab', 'c'])
   })
 
+  it('flattens double nested rulesets', () => {
+    // $FlowFixMe
+    expect(
+      flatten([[
+        'a', [[ 'c', 'd', [['e', 'f'], ['g', 'h']] ]], 'b'
+      ]], {})
+    ).toEqual(['ab', 'cd', 'ef', 'gh'])
+  })
+
   it('flattens subarrays', () => {
     // $FlowFixMe
     expect(flatten([[1, 2, [3, 4, 5], 'come:on;', 'lets:ride;']], {}))
@@ -111,5 +129,10 @@ describe('preparsed flatten with executionContext', () => {
   it('resolves rulesets after executing functions', () => {
     const func = () => [['add me to the end']]
     expect(flatten([['foo', func, 'baz']], {})).toEqual(['foobaz', 'add me to the end'])
+  })
+
+  it('resolves double nested rulesets after executing functions', () => {
+    const func = () => [['a', [['b']]]]
+    expect(flatten([['foo', func, 'baz']], {})).toEqual(['foobaz', 'a', 'b'])
   })
 })

--- a/src/no-parser/test/flatten.test.js
+++ b/src/no-parser/test/flatten.test.js
@@ -1,0 +1,115 @@
+// @flow
+import expect from 'expect'
+import flatten from '../flatten'
+
+describe('preparsed flatten without executionContext', () => {
+  it('doesnt merge strings', () => {
+    expect(flatten([['foo', 'bar', 'baz']])).toEqual([['foo', 'bar', 'baz']])
+  })
+
+  it('drops nulls', () => {
+    // $FlowInvalidInputTest
+    expect(flatten([['foo', false, 'bar', undefined, 'baz', null]])).toEqual([['foo', 'bar', 'baz']])
+  })
+
+  it('doesnt drop any numbers', () => {
+    expect(flatten([['foo', 0, 'bar', NaN, 'baz', -1]])).toEqual([['foo', '0', 'bar', 'NaN', 'baz', '-1']])
+  })
+
+  it('toStrings everything', () => {
+    // $FlowInvalidInputTest
+    expect(flatten([[1, true]])).toEqual([['1', 'true']])
+  })
+
+  it('hypenates objects', () => {
+    const obj = {
+      fontSize: '14px',
+      WebkitFilter: 'blur(2px)',
+    }
+    const css = 'font-size: 14px; -webkit-filter: blur(2px);'
+    // $FlowFixMe
+    expect(flatten([[obj]])).toEqual([[css]])
+    // $FlowFixMe
+    expect(flatten([['some:thing;', obj, 'something: else;']])).toEqual([['some:thing;', css, 'something: else;']])
+  })
+
+  it('flattens nested rulesets', () => {
+    // $FlowFixMe
+    expect(
+      flatten([[
+        'a', [[ 'c' ]], 'b'
+      ]])
+    ).toEqual([['a', 'b'], ['c']])
+  })
+
+  it('flattens subarrays', () => {
+    // $FlowFixMe
+    expect(flatten([[1, 2, [3, 4, 5], 'come:on;', 'lets:ride;']]))
+      .toEqual([['1', '2', '3', '4', '5', 'come:on;', 'lets:ride;']])
+  })
+
+  it('defers functions', () => {
+    const func = () => 'bar'
+
+    expect(flatten([['foo', func, 'baz']])).toEqual([['foo', func, 'baz']])
+  })
+})
+
+describe('preparsed flatten with executionContext', () => {
+  it('merges strings', () => {
+    expect(flatten([['foo', 'bar', 'baz']], {})).toEqual(['foobarbaz'])
+  })
+
+  it('drops nulls', () => {
+    // $FlowInvalidInputTest
+    expect(flatten([['foo', false, 'bar', undefined, 'baz', null]], {})).toEqual(['foobarbaz'])
+  })
+
+  it('doesnt drop any numbers', () => {
+    expect(flatten([['foo', 0, 'bar', NaN, 'baz', -1]], {})).toEqual(['foo0barNaNbaz-1'])
+  })
+
+  it('toStrings everything', () => {
+    // $FlowInvalidInputTest
+    expect(flatten([[1, true]], {})).toEqual(['1true'])
+  })
+
+  it('hypenates objects', () => {
+    const obj = {
+      fontSize: '14px',
+      WebkitFilter: 'blur(2px)',
+    }
+    const css = 'font-size: 14px; -webkit-filter: blur(2px);'
+    // $FlowFixMe
+    expect(flatten([[obj]], {})).toEqual([css])
+    // $FlowFixMe
+    expect(flatten([['some:thing;', obj, 'something: else;']], {}))
+      .toEqual(['some:thing;' + css + 'something: else;'])
+  })
+
+  it('flattens nested rulesets', () => {
+    // $FlowFixMe
+    expect(
+      flatten([[
+        'a', [[ 'c' ]], 'b'
+      ]], {})
+    ).toEqual(['ab', 'c'])
+  })
+
+  it('flattens subarrays', () => {
+    // $FlowFixMe
+    expect(flatten([[1, 2, [3, 4, 5], 'come:on;', 'lets:ride;']], {}))
+      .toEqual(['12345come:on;lets:ride;'])
+  })
+
+  it('executes functions', () => {
+    const func = () => 'bar'
+
+    expect(flatten([['foo', func, 'baz']], {})).toEqual(['foobarbaz'])
+  })
+
+  it('resolves rulesets after executing functions', () => {
+    const func = () => [['add me to the end']]
+    expect(flatten([['foo', func, 'baz']], {})).toEqual(['foobaz', 'add me to the end'])
+  })
+})

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -8,6 +8,7 @@ import expect from 'expect'
 import _styled from '../constructors/styled'
 import styleSheet from '../models/StyleSheet'
 import flatten from '../utils/flatten'
+import stringifyRules from '../utils/stringifyRules'
 import _styledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
@@ -18,7 +19,7 @@ const classNames = () => String.fromCodePoint(97 + index++)
 export const resetStyled = () => {
   styleSheet.reset()
   index = 0
-  return _styled(_styledComponent(_ComponentStyle(classNames, flatten)))
+  return _styled(_styledComponent(_ComponentStyle(classNames, flatten, stringifyRules)))
 }
 
 const stripWhitespace = str => str.trim().replace(/([;\{\}])/g, '$1  ').replace(/\s+/g, ' ')

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -7,6 +7,7 @@ import expect from 'expect'
 
 import _styled from '../constructors/styled'
 import styleSheet from '../models/StyleSheet'
+import flatten from '../utils/flatten'
 import _styledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
@@ -17,7 +18,7 @@ const classNames = () => String.fromCodePoint(97 + index++)
 export const resetStyled = () => {
   styleSheet.reset()
   index = 0
-  return _styled(_styledComponent(_ComponentStyle(classNames)))
+  return _styled(_styledComponent(_ComponentStyle(classNames, flatten)))
 }
 
 const stripWhitespace = str => str.trim().replace(/([;\{\}])/g, '$1  ').replace(/\s+/g, ' ')

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -14,6 +14,10 @@ import stringifyRules from '../utils/stringifyRules'
 import _StyledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
+import noParserCss from '../no-parser/css'
+import noParserFlatten from '../no-parser/flatten'
+import noParserStringifyRules from '../no-parser/stringifyRules'
+
 /* Ignore hashing, just return class names sequentially as .a .b .c etc */
 let index = 0
 const classNames = () => String.fromCodePoint(97 + index++)
@@ -24,6 +28,17 @@ export const resetStyled = () => {
 
   const ComponentStyle = _ComponentStyle(classNames, flatten, stringifyRules)
   const constructWithOptions = _constructWithOptions(css)
+  const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)
+
+  return _styled(StyledComponent, constructWithOptions)
+}
+
+export const resetNoParserStyled = () => {
+  styleSheet.reset()
+  index = 0
+
+  const ComponentStyle = _ComponentStyle(classNames, noParserFlatten, noParserStringifyRules)
+  const constructWithOptions = _constructWithOptions(noParserCss)
   const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)
 
   return _styled(StyledComponent, constructWithOptions)

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -6,10 +6,12 @@
 import expect from 'expect'
 
 import _styled from '../constructors/styled'
+import css from '../constructors/css'
+import _constructWithOptions from '../constructors/constructWithOptions'
 import styleSheet from '../models/StyleSheet'
 import flatten from '../utils/flatten'
 import stringifyRules from '../utils/stringifyRules'
-import _styledComponent from '../models/StyledComponent'
+import _StyledComponent from '../models/StyledComponent'
 import _ComponentStyle from '../models/ComponentStyle'
 
 /* Ignore hashing, just return class names sequentially as .a .b .c etc */
@@ -19,7 +21,12 @@ const classNames = () => String.fromCodePoint(97 + index++)
 export const resetStyled = () => {
   styleSheet.reset()
   index = 0
-  return _styled(_styledComponent(_ComponentStyle(classNames, flatten, stringifyRules)))
+
+  const ComponentStyle = _ComponentStyle(classNames, flatten, stringifyRules)
+  const constructWithOptions = _constructWithOptions(css)
+  const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)
+
+  return _styled(StyledComponent, constructWithOptions)
 }
 
 const stripWhitespace = str => str.trim().replace(/([;\{\}])/g, '$1  ').replace(/\s+/g, ' ')

--- a/src/types.js
+++ b/src/types.js
@@ -7,3 +7,7 @@ export type RuleSet = Array<Interpolation>
 export type Target = string | ReactClass<*>
 
 export type NameGenerator = (hash: number) => string
+
+export type Flattener = (chunks: Array<Interpolation>, executionContext: ?Object) => (
+  Array<Interpolation>
+)

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,9 @@
 // @flow
-export type Interpolation = ((executionContext: Object) => string) | string | number
+export type Interpolation = ((executionContext: Object) => Interpolation) |
+  string |
+  number |
+  Array<Interpolation>
+
 /* todo: I want this to actually be an array of Function | string but that causes errors */
 export type RuleSet = Array<Interpolation>
 

--- a/src/types.js
+++ b/src/types.js
@@ -18,7 +18,7 @@ export type Flattener = (
 ) => Array<Interpolation>
 
 export type Stringifier = (
-  rules: Array<Interpolation> | string,
+  rules: Array<Interpolation>,
   selector: ?string,
   shouldWrap: ?boolean
 ) => string

--- a/src/types.js
+++ b/src/types.js
@@ -8,6 +8,13 @@ export type Target = string | ReactClass<*>
 
 export type NameGenerator = (hash: number) => string
 
-export type Flattener = (chunks: Array<Interpolation>, executionContext: ?Object) => (
-  Array<Interpolation>
-)
+export type Flattener = (
+  chunks: Array<Interpolation>,
+  executionContext: ?Object
+) => Array<Interpolation>
+
+export type Stringifier = (
+  rules: Array<Interpolation> | string,
+  selector: ?string,
+  shouldWrap: ?boolean
+) => string

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -1,0 +1,29 @@
+// @flow
+import stylis from 'stylis'
+import type { Interpolation } from '../types'
+
+const stringifyRules = (
+  rules: Array<Interpolation> | string,
+  selector: ?string,
+  shouldWrap: ?boolean,
+): string => {
+  const flatCSS = (
+    typeof rules === 'string' ?
+      rules :
+      rules.join('')
+        .replace(/^\s*\/\/.*$/gm, '') // replace JS comments
+  )
+
+  const cssString = (selector && shouldWrap) ? `${selector} { ${flatCSS} }` : flatCSS
+
+  const css = stylis(
+    (selector && !shouldWrap) ? `.${selector}` : '',
+    cssString,
+    false,
+    false,
+  )
+
+  return css
+}
+
+export default stringifyRules

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -3,21 +3,18 @@ import stylis from 'stylis'
 import type { Interpolation } from '../types'
 
 const stringifyRules = (
-  rules: Array<Interpolation> | string,
+  rules: Array<Interpolation>,
   selector: ?string,
   shouldWrap: ?boolean,
 ): string => {
-  const flatCSS = (
-    typeof rules === 'string' ?
-      rules :
-      rules.join('')
-        .replace(/^\s*\/\/.*$/gm, '') // replace JS comments
-  )
+  const flatCSS = rules
+    .join('')
+    .replace(/^\s*\/\/.*$/gm, '') // replace JS comments
 
   const cssString = (selector && shouldWrap) ? `${selector} { ${flatCSS} }` : flatCSS
 
   const css = stylis(
-    (selector && !shouldWrap) ? `.${selector}` : '',
+    shouldWrap ? '' : `.${selector || ''}`,
     cssString,
     false,
     false,

--- a/src/utils/test/flatten.test.js
+++ b/src/utils/test/flatten.test.js
@@ -54,12 +54,10 @@ describe('flatten', () => {
     expect(flatten([new SomeClass()])).toEqual(['some: thing;'])
   })
   it('flattens subarrays', () => {
-    // $FlowFixMe
     expect(flatten([1, 2, [3, 4, 5], 'come:on;', 'lets:ride;'])).toEqual(['1', '2', '3', '4', '5', 'come:on;', 'lets:ride;'])
   })
   it('defers functions', () => {
     const func = () => 'bar'
-    // $FlowFixMe
     const funcWFunc = () => ['static', subfunc => subfunc ? 'bar' : 'baz']
     expect(flatten(['foo', func, 'baz'])).toEqual(['foo', func, 'baz'])
     expect(flatten(['foo', funcWFunc, 'baz'])).toEqual(['foo', funcWFunc, 'baz'])
@@ -74,7 +72,6 @@ describe('flatten', () => {
     expect(flatten(['foo', func], { bool: false })).toEqual(['foo', 'baz'])
   })
   it('recursively calls functions', () => {
-    // $FlowFixMe
     const func = () => ['static', ({ bool }) => bool ? 'bar' : 'baz']
     expect(flatten(['foo', func], { bool: true })).toEqual(['foo', 'static', 'bar'])
     expect(flatten(['foo', func], { bool: false })).toEqual(['foo', 'static', 'baz'])


### PR DESCRIPTION
- [x] Refactor singleton factories
- [x] Add `css`, `flatten`, and `GlobalStyle` to singleton factories
- [x] Add `stringifyRules` helper to abstract CSS parsing
- [x] Add separate `no-parser` variants of these helpers
- [x] Test no-parser flattener variant

This adds the entrypoint that accepts the preprocessed CSS from the babel plugin, which has an open PR for the preprocessing here: https://github.com/styled-components/babel-plugin-styled-components/pull/26

It needs to add new singleton factories and new arguments to some other factories, since it now passes in `css`, `flatten`, `stringifyRules` (new), and `GlobalStyle` into some things that need them.

Edit: After fixing everything up, there are still 4 failing unit tests left, which are however failing on v2 as well.