### PR TITLE
Fix component constructors not passing through arguments to React.Component (V2)

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -47,14 +47,11 @@ export default (ComponentStyle: Function) => {
       static styledComponentId: string
       static extend: Function
       static extendWith: Function
-      attrs = {}
 
-      constructor() {
-        super()
-        this.state = {
-          theme: null,
-          generatedClassName: '',
-        }
+      attrs = {}
+      state = {
+        theme: null,
+        generatedClassName: '',
       }
 
       buildExecutionContext(theme: any, props: any) {

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -25,11 +25,9 @@ const createStyledNativeComponent = (target: Target,
     static extend: Function
     static extendWith: Function
 
-    constructor() {
-      super()
-      this.state = {
-        theme: {},
-      }
+    state = {
+      theme: {},
+      generatedStyles: undefined,
     }
 
     componentWillMount() {


### PR DESCRIPTION
Fix #600

The constructors weren't passing through their arguments to React.Component, which causes Rapscallion to fail.