### PR TITLE
Fix component constructors not passing through arguments to React.Component (V1)

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -28,12 +28,9 @@ export default (ComponentStyle: Function) => {
       static target: Target
       static contextTypes = ParentComponent.contextTypes
 
-      constructor() {
-        super()
-        this.state = {
-          theme: null,
-          generatedClassName: '',
-        }
+      state = {
+        theme: null,
+        generatedClassName: '',
       }
 
       generateAndInjectStyles(theme: any, props: any) {

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -26,11 +26,9 @@ const createStyledNativeComponent = (target: Target, rules: RuleSet, parent?: Ta
     static target: Target
     root: any
 
-    constructor() {
-      super()
-      this.state = {
-        theme: {},
-      }
+    state = {
+      theme: {},
+      generatedStyles: undefined,
     }
 
     componentWillMount() {


### PR DESCRIPTION
The constructors weren't passing through their arguments to React.Component, which causes Rapscallion to fail.

Backport of https://github.com/styled-components/styled-components/pull/601