### PR TITLE
Improve StyledComponent performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Standardised `styled(Comp)` to work the same in all cases, rather than a special extension case where `Comp` is another Styled Component. `Comp.extend` now covers that case. (see [#518](https://github.com/styled-components/styled-components/pull/518)).
 - Added a separate `no-parser` entrypoint for preprocessed CSS, which doesn't depend on stylis. The preprocessing is part of our babel plugin. (see [babel-plugin-styled-components/#26](https://github.com/styled-components/babel-plugin-styled-components/pull/26))
 - Fix defaultProps used instead of ThemeProvider on first render [@k15a](https://github.com/k15a), restored.
+- Refactor StyledComponent for performance optimization.
 
 ## [Unreleased]
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -138,7 +138,8 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
           if (
             !isTargetTag || (
               validAttr(propName) &&
-              propName !== 'className'
+              propName !== 'className' &&
+              propName !== 'innerRef'
             )
           ) {
             // eslint-disable-next-line no-param-reassign

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -39,8 +39,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     }
 
     buildExecutionContext(theme: any, props: any) {
-      const { attrs = {} } = this.constructor
+      const { attrs } = this.constructor
       const context = { ...props, theme }
+      if (attrs === undefined) {
+        return context
+      }
 
       this.attrs = Object.keys(attrs).reduce((acc, key) => {
         const attr = attrs[key]
@@ -156,7 +159,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       componentId = generateId(options.displayName || 'sc'),
       ParentComponent = BaseStyledComponent,
       rules: extendingRules,
-      attrs = {},
+      attrs,
     } = options
 
     const warnTooManyClasses = createWarnTooManyClasses(displayName)

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -16,11 +16,14 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
   /* We depend on components having unique IDs */
   const identifiers = {}
   const generateId = (_displayName: string) => {
-    const displayName = _displayName
-      .replace(/[[\].#*$><+~=|^:(),"'`]/g, '-') // Replace all possible CSS selectors
-      .replace(/--+/g, '-') // Replace multiple -- with single -
+    const displayName = typeof _displayName !== 'string' ?
+      'sc' : _displayName
+        .replace(/[[\].#*$><+~=|^:(),"'`]/g, '-') // Replace all possible CSS selectors
+        .replace(/--+/g, '-') // Replace multiple -- with single -
+
     const nr = (identifiers[displayName] || 0) + 1
     identifiers[displayName] = nr
+
     const hash = ComponentStyle.generateName(displayName + nr)
     return `${displayName}-${hash}`
   }
@@ -156,7 +159,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
   ) => {
     const {
       displayName = isTag(target) ? `styled.${target}` : `Styled(${target.displayName})`,
-      componentId = generateId(options.displayName || 'sc'),
+      componentId = generateId(options.displayName),
       ParentComponent = BaseStyledComponent,
       rules: extendingRules,
       attrs,

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -25,127 +25,144 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     return `${displayName}-${hash}`
   }
 
-  const createStyledComponent = (target: Target,
-                                 options: Object,
-                                 rules: RuleSet) => {
+  class BaseStyledComponent extends AbstractStyledComponent {
+    static target: Target
+    static styledComponentId: string
+    static attrs: Object
+    static componentStyle: Object
+    static warnTooManyClasses: Function
+
+    attrs = {}
+    state = {
+      theme: null,
+      generatedClassName: '',
+    }
+
+    buildExecutionContext(theme: any, props: any) {
+      const { attrs = {} } = this.constructor
+      const context = { ...props, theme }
+
+      this.attrs = Object.keys(attrs).reduce((accum, key) => (
+        { ...accum, [key]: typeof attrs[key] === 'function' ? attrs[key](context) : attrs[key] }
+      ), {})
+
+      return { ...context, ...this.attrs }
+    }
+
+    generateAndInjectStyles(theme: any, props: any) {
+      const { componentStyle } = this.constructor
+      const executionContext = this.buildExecutionContext(theme, props)
+      const className = componentStyle.generateAndInjectStyles(executionContext)
+
+      if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+        const { warnTooManyClasses } = this.constructor
+        warnTooManyClasses(className)
+      }
+
+      return className
+    }
+
+    componentWillMount() {
+      // If there is a theme in the context, subscribe to the event emitter. This
+      // is necessary due to pure components blocking context updates, this circumvents
+      // that by updating when an event is emitted
+      if (this.context[CHANNEL]) {
+        const subscribe = this.context[CHANNEL]
+        this.unsubscribe = subscribe(nextTheme => {
+          // This will be called once immediately
+
+          // Props should take precedence over ThemeProvider, which should take precedence over
+          // defaultProps, but React automatically puts defaultProps on props.
+          const { defaultProps } = this.constructor
+          const isDefaultTheme = defaultProps && this.props.theme === defaultProps.theme
+          const theme = this.props.theme && !isDefaultTheme ? this.props.theme : nextTheme
+          const generatedClassName = this.generateAndInjectStyles(theme, this.props)
+          this.setState({ theme, generatedClassName })
+        })
+      } else {
+        const theme = this.props.theme || {}
+        const generatedClassName = this.generateAndInjectStyles(
+          theme,
+          this.props,
+        )
+        this.setState({ theme, generatedClassName })
+      }
+    }
+
+    componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
+      this.setState((oldState) => {
+        // Props should take precedence over ThemeProvider, which should take precedence over
+        // defaultProps, but React automatically puts defaultProps on props.
+        const { defaultProps } = this.constructor
+        const isDefaultTheme = defaultProps && nextProps.theme === defaultProps.theme
+        const theme = nextProps.theme && !isDefaultTheme ? nextProps.theme : oldState.theme
+        const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
+
+        return { theme, generatedClassName }
+      })
+    }
+
+    componentWillUnmount() {
+      if (this.unsubscribe) {
+        this.unsubscribe()
+      }
+    }
+
+    render() {
+      const { className, children, innerRef } = this.props
+      const { generatedClassName } = this.state
+      const { styledComponentId, target } = this.constructor
+
+      const propsForElement = { ...this.attrs }
+      /* Don't pass through non HTML tags through to HTML elements */
+      Object.keys(this.props)
+        .filter(propName => !isTag(target) || validAttr(propName))
+        .forEach(propName => {
+          propsForElement[propName] = this.props[propName]
+        })
+      propsForElement.className = [className, styledComponentId, this.attrs.className, generatedClassName].filter(x => x).join(' ')
+      if (innerRef) {
+        propsForElement.ref = innerRef
+        delete propsForElement.innerRef
+      }
+
+      return createElement(target, propsForElement, children)
+    }
+  }
+
+  const createStyledComponent = (
+    target: Target,
+    options: Object,
+    rules: RuleSet,
+  ) => {
     const {
       displayName = isTag(target) ? `styled.${target}` : `Styled(${target.displayName})`,
       componentId = generateId(options.displayName || 'sc'),
       attrs = {},
       rules: extendingRules = [],
-      ParentComponent = AbstractStyledComponent,
+      ParentComponent = BaseStyledComponent,
     } = options
-    const componentStyle = new ComponentStyle([...extendingRules, ...rules], componentId)
 
-    let warnTooManyClasses
-    if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
-      warnTooManyClasses = createWarnTooManyClasses()
-    }
+    const warnTooManyClasses = createWarnTooManyClasses(displayName)
+    const componentStyle = new ComponentStyle(extendingRules.concat(rules), componentId)
 
     class StyledComponent extends ParentComponent {
-      static styledComponentId: string
-      static extend: Function
-      static extendWith: Function
+      static displayName = displayName
+      static styledComponentId = componentId
+      static attrs = attrs
+      static componentStyle = componentStyle
+      static warnTooManyClasses = warnTooManyClasses
+      static target = target
 
-      attrs = {}
-      state = {
-        theme: null,
-        generatedClassName: '',
-      }
-
-      buildExecutionContext(theme: any, props: any) {
-        const context = { ...props, theme }
-        this.attrs = Object.keys(attrs).reduce((accum, key) => (
-          { ...accum, [key]: typeof attrs[key] === 'function' ? attrs[key](context) : attrs[key] }
-        ), {})
-        return { ...context, ...this.attrs }
-      }
-
-      generateAndInjectStyles(theme: any, props: any) {
-        const executionContext = this.buildExecutionContext(theme, props)
-        return componentStyle.generateAndInjectStyles(executionContext)
-      }
-
-      componentWillMount() {
-        // If there is a theme in the context, subscribe to the event emitter. This
-        // is necessary due to pure components blocking context updates, this circumvents
-        // that by updating when an event is emitted
-        if (this.context[CHANNEL]) {
-          const subscribe = this.context[CHANNEL]
-          this.unsubscribe = subscribe(nextTheme => {
-            // This will be called once immediately
-
-            // Props should take precedence over ThemeProvider, which should take precedence over
-            // defaultProps, but React automatically puts defaultProps on props.
-            const { defaultProps } = this.constructor
-            const isDefaultTheme = defaultProps && this.props.theme === defaultProps.theme
-            const theme = this.props.theme && !isDefaultTheme ? this.props.theme : nextTheme
-            const generatedClassName = this.generateAndInjectStyles(theme, this.props)
-            this.setState({ theme, generatedClassName })
-          })
-        } else {
-          const theme = this.props.theme || {}
-          const generatedClassName = this.generateAndInjectStyles(
-            theme,
-            this.props,
-          )
-          this.setState({ theme, generatedClassName })
-        }
-      }
-
-      componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
-        this.setState((oldState) => {
-          // Props should take precedence over ThemeProvider, which should take precedence over
-          // defaultProps, but React automatically puts defaultProps on props.
-          const { defaultProps } = this.constructor
-          const isDefaultTheme = defaultProps && nextProps.theme === defaultProps.theme
-          const theme = nextProps.theme && !isDefaultTheme ? nextProps.theme : oldState.theme
-          const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
-
-          return { theme, generatedClassName }
-        })
-      }
-
-      componentWillUnmount() {
-        if (this.unsubscribe) {
-          this.unsubscribe()
-        }
-      }
-
-      render() {
-        const { className, children, innerRef } = this.props
-        const { generatedClassName } = this.state
-
-        const propsForElement = { ...this.attrs }
-        /* Don't pass through non HTML tags through to HTML elements */
-        Object.keys(this.props)
-          .filter(propName => !isTag(target) || validAttr(propName))
-          .forEach(propName => {
-            propsForElement[propName] = this.props[propName]
-          })
-        propsForElement.className = [className, componentId, this.attrs.className, generatedClassName].filter(x => x).join(' ')
-        if (innerRef) {
-          propsForElement.ref = innerRef
-          delete propsForElement.innerRef
-        }
-
-        if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production' && generatedClassName) {
-          warnTooManyClasses(generatedClassName, StyledComponent.displayName)
-        }
-        return createElement(target, propsForElement, children)
+      static extendWith(tag) {
+        const { displayName: _, componentId: __, ...optionsToCopy } = options
+        const newOptions = { ...optionsToCopy, rules, ParentComponent: StyledComponent }
+        return constructWithOptions(createStyledComponent, tag, newOptions)
       }
 
       static get extend() {
         return StyledComponent.extendWith(target)
       }
-    }
-
-    StyledComponent.displayName = displayName
-    StyledComponent.styledComponentId = componentId
-    StyledComponent.extendWith = tag => {
-      const { displayName: _, componentId: __, ...optionsToCopy } = options
-      return constructWithOptions(createStyledComponent, tag,
-        { ...optionsToCopy, rules, ParentComponent: StyledComponent })
     }
 
     return StyledComponent

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -12,14 +12,17 @@ import type { RuleSet, Target } from '../types'
 import AbstractStyledComponent from './AbstractStyledComponent'
 import { CHANNEL } from './ThemeProvider'
 
+const escapeRegex = /[[\].#*$><+~=|^:(),"'`]/g
+const multiDashRegex = /--+/g
+
 export default (ComponentStyle: Function, constructWithOptions: Function) => {
   /* We depend on components having unique IDs */
   const identifiers = {}
   const generateId = (_displayName: string) => {
     const displayName = typeof _displayName !== 'string' ?
       'sc' : _displayName
-        .replace(/[[\].#*$><+~=|^:(),"'`]/g, '-') // Replace all possible CSS selectors
-        .replace(/--+/g, '-') // Replace multiple -- with single -
+        .replace(escapeRegex, '-') // Replace all possible CSS selectors
+        .replace(multiDashRegex, '-') // Replace multiple -- with single -
 
     const nr = (identifiers[displayName] || 0) + 1
     identifiers[displayName] = nr

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -62,12 +62,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     }
 
     generateAndInjectStyles(theme: any, props: any) {
-      const { componentStyle } = this.constructor
+      const { componentStyle, warnTooManyClasses } = this.constructor
       const executionContext = this.buildExecutionContext(theme, props)
       const className = componentStyle.generateAndInjectStyles(executionContext)
 
-      if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
-        const { warnTooManyClasses } = this.constructor
+      if (warnTooManyClasses !== undefined) {
         warnTooManyClasses(className)
       }
 
@@ -174,7 +173,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       attrs,
     } = options
 
-    const warnTooManyClasses = createWarnTooManyClasses(displayName)
+    let warnTooManyClasses
+    if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+      warnTooManyClasses = createWarnTooManyClasses(displayName)
+    }
+
     const componentStyle = new ComponentStyle(
       extendingRules === undefined ? rules : extendingRules.concat(rules),
       componentId,

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -135,7 +135,12 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         .keys(this.props)
         .reduce((acc, propName) => {
           // Don't pass through non HTML tags through to HTML elements
-          if (!isTargetTag || validAttr(propName)) {
+          if (
+            !isTargetTag || (
+              validAttr(propName) &&
+              propName !== 'className'
+            )
+          ) {
             // eslint-disable-next-line no-param-reassign
             acc[propName] = this.props[propName]
           }

--- a/src/utils/createWarnTooManyClasses.js
+++ b/src/utils/createWarnTooManyClasses.js
@@ -4,11 +4,11 @@ import styleSheet from '../models/StyleSheet'
 
 const LIMIT = 200
 
-export default () => {
+export default (displayName: string) => {
   let generatedClasses = {}
   let warningSeen = false
 
-  return (className: string, displayName: string) => {
+  return (className: string) => {
     if (!warningSeen) {
       generatedClasses[className] = true
       if (Object.keys(generatedClasses).length >= LIMIT) {

--- a/src/utils/generateAlphabeticName.js
+++ b/src/utils/generateAlphabeticName.js
@@ -1,12 +1,21 @@
 // @flow
 const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+const charsLength = chars.length
 
 /* Some high number, usually 9-digit base-10. Map it to base-😎 */
 const generateAlphabeticName = (code: number): string => {
-  const lastDigit = chars[code % chars.length]
-  return code > chars.length
-    ? `${generateAlphabeticName(Math.floor(code / chars.length))}${lastDigit}`
-    : lastDigit
+  let name = ''
+  let x
+
+  for (
+    x = code;
+    x > charsLength;
+    x = Math.floor(x / chars.length)
+  ) {
+    name = chars[x % charsLength] + name
+  }
+
+  return chars[x % charsLength] + name
 }
 
 export default generateAlphabeticName


### PR DESCRIPTION
#583

- Add second `BaseStyledComponent` class to not repeat methods
- Improve `propsForElement` and `this.attrs` creation
- Stop creating `this.attrs` if `attrs` doesn't exist
- Rewrite `generateAlphabeticName` to be iterative instead of recursive

### Before

```
simple component (construction)     0.019±0.003ms
simple component (first render)     0.132±0.027ms
simple component (repeated render)  0.014±0.001ms
prop changes                        0.309±0.054ms
prop shorthands (first render)      0.175±0.071ms
prop shorthands with prop changes   0.377±0.093ms
```


### After

```
simple component (construction)     0.013±0.002ms
simple component (first render)     0.121±0.026ms
simple component (repeated render)  0.015±0.004ms
prop changes                        0.311±0.101ms
prop shorthands (first render)      0.155±0.052ms
prop shorthands with prop changes   0.344±0.038ms
```

Edit:

### After with preprocessing

```
simple component (construction)     0.011±0.002ms
simple component (first render)     0.090±0.018ms
simple component (repeated render)  0.014±0.001ms
prop changes                        0.195±0.030ms
prop shorthands (first render)      0.095±0.030ms
prop shorthands with prop changes   0.208±0.051ms
```
