### PR TITLE
Add "styled-components" to package.json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "keywords": [
     "react",
     "css",
-    "css-in-js"
+    "css-in-js",
+    "styled-components"
   ],
   "author": "Glen Maddern",
   "license": "MIT",


### PR DESCRIPTION
There are lots of interesting packages related to styled-components on NPM. Many of them are using the "styled-components" keyword so you can find them more easily.

Let's add that keyword to styled-components' package.json so it is easy to navigate from https://www.npmjs.com/package/styled-components to https://www.npmjs.com/browse/keyword/styled-components using the "keywords" links in the sidebar.

![screen shot 2017-03-27 at 16 23 58](https://cloud.githubusercontent.com/assets/33429/24347230/30107f58-130a-11e7-8a67-a320c187d7be.png)
