### PR TITLE
fix: prevent leaking the innerRef prop to wrapped components

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -98,7 +98,7 @@ export default (ComponentStyle: Function) => {
         propsForElement.className = [className, generatedClassName].filter(x => x).join(' ')
         if (innerRef) {
           propsForElement.ref = innerRef
-          if (isTag(target)) delete propsForElement.innerRef
+          delete propsForElement.innerRef
         }
 
         return createElement(target, propsForElement, children)

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -127,5 +127,28 @@ describe('basic', () => {
       // $FlowFixMe
       expect(wrapper.node.ref).toNotExist()
     })
+
+    it('should not leak the innerRef prop to the wrapped child', () => {
+      const StyledComp = styled.div``
+      class WrappedStyledComp extends React.Component {
+        render() {
+          return (
+            <StyledComp {...this.props} />
+          )
+        }
+      }
+      const ChildComp = styled(WrappedStyledComp)``
+      const WrapperComp = class extends Component {
+        testRef: any;
+        render() {
+          return <ChildComp innerRef={(comp) => { this.testRef = comp }} />
+        }
+      }
+      const wrapper = mount(<WrapperComp />)
+
+      // $FlowFixMe
+      expect(wrapper.node.testRef).toExist()
+      expect(wrapper.find('WrappedStyledComp').prop('innerRef')).toNotExist()
+    })
   })
 })


### PR DESCRIPTION
As you can see, this doesn't break `innerRef` - it just doesn't leak the prop.

Closes #592 