### PR TITLE
Add nested `innerRef` for Styled Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Fix defaultProps used instead of ThemeProvider on first render [@k15a](https://github.com/k15a), restored.
 - Refactor StyledComponent for performance optimization.
 - Prevent leakage of the `innerRef` prop to wrapped child; under the hood it is converted into a normal React `ref`. (see [#592](https://github.com/styled-components/styled-components/issues/592))
+- Pass `innerRef` through to wrapped Styled Components, so that it refers to the actual DOM node. (see [#629](https://github.com/styled-components/styled-components/issues/629))
 
 ## [Unreleased]
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -7,6 +7,7 @@ import createWarnTooManyClasses from '../utils/createWarnTooManyClasses'
 
 import validAttr from '../utils/validAttr'
 import isTag from '../utils/isTag'
+import isStyledComponent from '../utils/isStyledComponent'
 import type { RuleSet, Target } from '../types'
 
 import AbstractStyledComponent from './AbstractStyledComponent'
@@ -133,6 +134,17 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         generatedClassName,
       ].filter(Boolean).join(' ')
 
+      const baseProps = {
+        ...this.attrs,
+        className,
+      }
+
+      if (isStyledComponent(target)) {
+        baseProps.innerRef = innerRef
+      } else {
+        baseProps.ref = innerRef
+      }
+
       const propsForElement = Object
         .keys(this.props)
         .reduce((acc, propName) => {
@@ -148,11 +160,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
           }
 
           return acc
-        }, {
-          ...this.attrs,
-          className,
-          ref: innerRef,
-        })
+        }, baseProps)
 
       return createElement(target, propsForElement, children)
     }

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -58,30 +58,24 @@ describe('basic', () => {
   describe('jsdom tests', () => {
     jsdom()
 
-    let Comp
-    let WrapperComp
-    let wrapper
+    it('should pass the ref to the component', () => {
+      const Comp = styled.div``
 
-    beforeEach(() => {
-      Comp = styled.div``
-      WrapperComp = class extends Component {
+      class Wrapper extends Component {
         testRef: any;
+        innerRef = (comp) => { this.testRef = comp }
+
         render() {
-          return <Comp innerRef={(comp) => { this.testRef = comp }} />
+          return <Comp innerRef={this.innerRef} />
         }
       }
 
-      wrapper = mount(<WrapperComp />)
-    })
+      const wrapper = mount(<Wrapper />)
+      const component = wrapper.find(Comp).first()
 
-    it('should pass ref to the component', () => {
       // $FlowFixMe
-      expect(wrapper.node.testRef).toExist()
-    })
-
-    it('should not pass innerRef to the component', () => {
-      // $FlowFixMe
-      expect(wrapper.node.ref).toNotExist()
+      expect(wrapper.node.testRef).toBe(component.getDOMNode())
+      expect(component.find('div').prop('innerRef')).toNotExist()
     })
 
     class InnerComponent extends Component {
@@ -120,11 +114,12 @@ describe('basic', () => {
 
       const wrapper = mount(<Wrapper />)
       expect(wrapper.find(InnerComponent).prop('className'))
-        .toBe('test sc-c d')
+        .toBe('test sc-a b')
     })
 
     it('should pass the innerRef to the wrapped styled component', () => {
-      const OuterComponent = styled(Comp)``
+      const InnerComponent = styled.div``
+      const OuterComponent = styled(InnerComponent)``
 
       class Wrapper extends Component {
         testRef: any;
@@ -136,7 +131,7 @@ describe('basic', () => {
       }
 
       const wrapper = mount(<Wrapper />)
-      const innerComponent = wrapper.find(Comp).first()
+      const innerComponent = wrapper.find(InnerComponent).first()
       const outerComponent = wrapper.find(OuterComponent).first()
 
       // $FlowFixMe

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -122,5 +122,28 @@ describe('basic', () => {
       expect(wrapper.find(InnerComponent).prop('className'))
         .toBe('test sc-c d')
     })
+
+    it('should pass the innerRef to the wrapped styled component', () => {
+      const OuterComponent = styled(Comp)``
+
+      class Wrapper extends Component {
+        testRef: any;
+        innerRef = (comp) => { this.testRef = comp }
+
+        render() {
+          return <OuterComponent innerRef={this.innerRef} />
+        }
+      }
+
+      const wrapper = mount(<Wrapper />)
+      const innerComponent = wrapper.find(Comp).first()
+      const outerComponent = wrapper.find(OuterComponent).first()
+
+      // $FlowFixMe
+      expect(wrapper.node.testRef).toBe(innerComponent.getDOMNode())
+
+      // $FlowFixMe
+      expect(innerComponent.prop('innerRef')).toBe(wrapper.node.innerRef)
+    })
   })
 })

--- a/src/utils/isStyledComponent.js
+++ b/src/utils/isStyledComponent.js
@@ -1,0 +1,9 @@
+// @flow
+import type { Target } from '../types'
+
+export default function isStyledComponent(target: Target)/* : %checks */ {
+  return (
+    typeof target === 'function' &&
+    typeof target.styledComponentId === 'string'
+  )
+}


### PR DESCRIPTION
As a continuation of #639 
Fix #629 

- Pass the `innerRef` to the nested target if said target is a Styled Component.
- Replace the old `innerRef` tests that weren't actually doing much