### PR TITLE
Add dangerfile.js to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,5 +6,6 @@ rollup.config.js
 .eslintrc
 .eslintignore
 .babelrc
+dangerfile.js
 example/
 src/**/*test.js


### PR DESCRIPTION
This file doesn't seem useful to publish. Also, it messes up support for Flow, which complains about not finding the `danger` module unless `dangerfile.js` is explicitly added to the `[ignore]` section of `.flowconfig`.