### PR TITLE
replace filter-forEach combo in favor for single forEach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ### Changed
 
+- Exchanged filter-forEach combo in favor of single forEach.
 - Migrated from the deprecated `React.PropTypes` to the `prop-types` package, thanks to [@YasserKaddour](https://github.com/YasserKaddour). (see [#668](https://github.com/styled-components/styled-components/pull/668))
 - Removed dependency on `glamor` and migrated remaining references to the internval vendored `glamor` module. (see [#663](https://github.com/styled-components/styled-components/pull/663))
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -88,12 +88,13 @@ export default (ComponentStyle: Function) => {
         const { className, children, innerRef } = this.props
         const { generatedClassName } = this.state
 
-        const propsForElement = {}
         /* Don't pass through non HTML tags through to HTML elements */
+        const propsForElement = {}
         Object.keys(this.props)
-          .filter(propName => !isTag(target) || validAttr(propName))
           .forEach(propName => {
-            propsForElement[propName] = this.props[propName]
+            if (!isTag(target) || validAttr(propName)) {
+              propsForElement[propName] = this.props[propName]
+            }
           })
         propsForElement.className = [className, generatedClassName].filter(x => x).join(' ')
         if (innerRef) {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -92,9 +92,8 @@ export default (ComponentStyle: Function) => {
         const propsForElement = {}
         Object.keys(this.props)
           .forEach(propName => {
-            if (!isTag(target) || validAttr(propName)) {
-              propsForElement[propName] = this.props[propName]
-            }
+            if (isTag(target) || !validAttr(propName)) return
+            propsForElement[propName] = this.props[propName]
           })
         propsForElement.className = [className, generatedClassName].filter(x => x).join(' ')
         if (innerRef) {


### PR DESCRIPTION
When checking for valid props I think it's more efficient to keep the number of iterations to a minimum. There could potentially be a lot of props passed to a styled component. Therefore I replaced
```javascript
  Object.keys(this.props)
          .filter(propName => !isTag(target) || validAttr(propName))
          .forEach(propName => {
            propsForElement[propName] = this.props[propName]
          })
```

with
```javascript
Object.keys(this.props)
          .forEach(propName => {
            if (isTag(target) || !validAttr(propName)) return
            propsForElement[propName] = this.props[propName]
          })
```

I would have actually liked to use reduce here but your eslint rules forbid assigning props to the accumulator. Anyway, thanks for considering this change :)

