### PR TITLE
add support to jsdom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. If a contri
 ## [Unreleased]
 
 ### Added
+- Support for jsdom and other browsers that do not implement [ownerNode](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet/ownerNode), thanks to [@zvictor](https://github.com/zvictor)
 
 ### Changed
 

--- a/src/vendor/glamor/sheet.js
+++ b/src/vendor/glamor/sheet.js
@@ -29,6 +29,10 @@ function last(arr) {
 }
 
 function sheetForTag(tag) {
+  if(tag.sheet) {
+    return tag.sheet
+  }
+  
   for(let i = 0; i < document.styleSheets.length; i++) {
     if(document.styleSheets[i].ownerNode === tag) {
       return document.styleSheets[i]


### PR DESCRIPTION
While trying to implement tests for my styled-components I was constantly facing the following error
> TypeError: Cannot read property 'cssRules' of undefined

I then managed to track its root as being the issue https://github.com/tmpvar/jsdom/issues/992.

Other browsers are also affected by this, not only jsdom, as can be seen at https://github.com/threepointone/glamor/issues/58.

Glamor has already fixed this with the commit https://github.com/threepointone/glamor/commit/98d4f44ba4335abd0e63bf946edff04ec51d3a41, and this PR brings the main change to styled-component.

----

This PR should fix https://github.com/styled-components/jest-styled-components/issues/2 and it could also be related to https://github.com/styled-components/styled-components/issues/124#issuecomment-273914589