### PR TITLE
Get ssr styles as React Element

### DIFF
--- a/src/models/ServerStyleSheet.js
+++ b/src/models/ServerStyleSheet.js
@@ -48,6 +48,18 @@ class ServerTag implements Tag {
     return `<style type="text/css" ${namesAttr} ${localAttr}>\n${css}\n</style>`
   }
 
+  toElement() {
+    const attributes = {
+      [SC_ATTR]: this.names.join(' '),
+      [LOCAL_ATTR]: this.isLocal,
+    }
+    const css = Object.keys(this.components)
+      .map(key => this.components[key].css)
+      .join('')
+
+    return <style key={this.names.join('')} type="text/css" {...attributes} dangerouslySetInnerHTML={{ __html: css }} />
+  }
+
   clone() {
     const copy = new ServerTag(this.isLocal)
     copy.names = [].concat(this.names)
@@ -86,6 +98,15 @@ export default class ServerStyleSheet {
     }
 
     return this.instance.toHTML()
+  }
+
+  getStyleElement() {
+    if (!this.closed) {
+      clones.splice(clones.indexOf(this.instance), 1)
+      this.closed = true
+    }
+
+    return this.instance.toElement()
   }
 
   static create() {

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -1,4 +1,5 @@
 // @flow
+import React from 'react'
 import BrowserStyleSheet from './BrowserStyleSheet'
 import ServerStyleSheet from './ServerStyleSheet'
 
@@ -14,6 +15,7 @@ export interface Tag {
   addComponent(componentId: string): void,
   inject(componentId: string, css: string, name: ?string): void,
   toHTML(): string,
+  toElement(): React.Element<*>,
   clone(): Tag,
 }
 
@@ -103,6 +105,10 @@ export default class StyleSheet {
 
   toHTML() {
     return this.tags.map(tag => tag.toHTML()).join('')
+  }
+
+  toElement() {
+    return this.tags.map(tag => tag.toElement())
   }
 
   getOrCreateTag(componentId: string, isLocal: boolean) {


### PR DESCRIPTION
Proof of concept, would appreciate comments.

Makes it possible to render `{sheet.getStyleElement()}` directly in <head> using React. Current ssr solution requires that the extracted styles are injected into the html outside of React, for instance via Express string substitution. This isn't suitable in for example GatsbyJS.

This needs tests, and proper Flow thingies.

With this change, I can do something like this in Gatsby:

```jsx
class Html extends React.Component {
  render() {
    const helmet = Helmet.renderStatic();

    // 💅
    const sheet = new ServerStyleSheet();
    sheet.collectStyles(this.props.body);

    return (
      <html lang="sv">
        <head>
          <meta charset="utf-8" />
          <meta name="viewport" content="width=device-width, initial-scale=1" />

          {helmet.title.toComponent()}
          {helmet.meta.toComponent()}
          {helmet.link.toComponent()}
          {helmet.style.toComponent()}

          {sheet.getStyleElement()}

        </head>
        <body>
          <div id="react-mount" dangerouslySetInnerHTML={{ __html: this.props.body }} />

          <script async src={prefixLink(`/bundle.js?t=${BUILD_TIME}`)} />
        </body>
      </html>
    );
  }
}
```