### PR TITLE
[v2] Restore setNativeProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Switch to babel-preset-env. (see [#717](https://github.com/styled-components/styled-components/pull/717))
 - Update StyledNativeComponent to match StyledComponent implementation.
 - Fix Theme context for StyledComponent for IE <10. (see [#807](https://github.com/styled-components/styled-components/pull/807))
+- Restore `setNativeProps` in StyledNativeComponent, thanks to [@MatthieuLemoine](https://github.com/MatthieuLemoine). (see [#764](https://github.com/styled-components/styled-components/pull/764))
 
 ## [v1.4.6] - 2017-05-02
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -24,6 +24,7 @@ export default (constructWithOptions: Function) => {
       theme: null,
       generatedStyles: undefined,
     }
+    root: Object
 
     buildExecutionContext(theme: any, props: any) {
       const { attrs } = this.constructor
@@ -96,12 +97,22 @@ export default (constructWithOptions: Function) => {
     }
 
     setNativeProps(nativeProps: Object) {
+      this.root.setNativeProps(nativeProps)
+    }
+
+    generateRef() {
       const { innerRef } = this.props
-      innerRef.setNativeProps(nativeProps)
+      return (component: any) => {
+        this.root = component
+
+        if (innerRef) {
+          innerRef(component)
+        }
+      }
     }
 
     render() {
-      const { children, style, innerRef } = this.props
+      const { children, style } = this.props
       const { generatedStyles } = this.state
       const { target } = this.constructor
 
@@ -112,7 +123,7 @@ export default (constructWithOptions: Function) => {
       }
 
       if (!isStyledComponent(target)) {
-        propsForElement.ref = innerRef
+        propsForElement.ref = this.generateRef()
         delete propsForElement.innerRef
       }
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -100,14 +100,12 @@ export default (constructWithOptions: Function) => {
       this.root.setNativeProps(nativeProps)
     }
 
-    generateRef() {
+    getRef(node: any) {
       const { innerRef } = this.props
-      return (component: any) => {
-        this.root = component
+      this.root = node
 
-        if (innerRef) {
-          innerRef(component)
-        }
+      if (typeof innerRef === 'function') {
+        innerRef(node)
       }
     }
 
@@ -123,7 +121,7 @@ export default (constructWithOptions: Function) => {
       }
 
       if (!isStyledComponent(target)) {
-        propsForElement.ref = this.generateRef()
+        propsForElement.ref = this.getRef
         delete propsForElement.innerRef
       }
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -100,13 +100,17 @@ export default (constructWithOptions: Function) => {
       this.root.setNativeProps(nativeProps)
     }
 
-    getRef(node: any) {
+    onRef(node: any) {
       const { innerRef } = this.props
       this.root = node
 
       if (typeof innerRef === 'function') {
         innerRef(node)
       }
+    }
+
+    onStyledRef(node: any) {
+      this.root = node
     }
 
     render() {
@@ -121,8 +125,10 @@ export default (constructWithOptions: Function) => {
       }
 
       if (!isStyledComponent(target)) {
-        propsForElement.ref = this.getRef
+        propsForElement.ref = this.onRef
         delete propsForElement.innerRef
+      } else {
+        propsForElement.ref = this.onStyledRef
       }
 
       return createElement(target, propsForElement, children)

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -18,13 +18,13 @@ export default (constructWithOptions: Function) => {
     static styledComponentId: string
     static attrs: Object
     static inlineStyle: Object
+    root: Object
 
     attrs = {}
     state = {
       theme: null,
       generatedStyles: undefined,
     }
-    root: Object
 
     buildExecutionContext(theme: any, props: any) {
       const { attrs } = this.constructor

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -100,7 +100,7 @@ export default (constructWithOptions: Function) => {
       this.root.setNativeProps(nativeProps)
     }
 
-    onRef(node: any) {
+    onRef = (node: any) => {
       const { innerRef } = this.props
       this.root = node
 
@@ -121,10 +121,10 @@ export default (constructWithOptions: Function) => {
       }
 
       if (!isStyledComponent(target)) {
-        propsForElement.ref = this.onRef.bind(this)
+        propsForElement.ref = this.onRef
         delete propsForElement.innerRef
       } else {
-        propsForElement.innerRef = this.onRef.bind(this)
+        propsForElement.innerRef = this.onRef
       }
 
       return createElement(target, propsForElement, children)

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -109,10 +109,6 @@ export default (constructWithOptions: Function) => {
       }
     }
 
-    onStyledRef(node: any) {
-      this.root = node
-    }
-
     render() {
       const { children, style } = this.props
       const { generatedStyles } = this.state
@@ -125,10 +121,10 @@ export default (constructWithOptions: Function) => {
       }
 
       if (!isStyledComponent(target)) {
-        propsForElement.ref = this.onRef
+        propsForElement.ref = this.onRef.bind(this)
         delete propsForElement.innerRef
       } else {
-        propsForElement.ref = this.onStyledRef
+        propsForElement.innerRef = this.onRef.bind(this)
       }
 
       return createElement(target, propsForElement, children)

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -95,6 +95,11 @@ export default (constructWithOptions: Function) => {
       }
     }
 
+    setNativeProps(nativeProps: Object) {
+      const { innerRef } = this.props
+      innerRef.setNativeProps(nativeProps)
+    }
+
     render() {
       const { children, style, innerRef } = this.props
       const { generatedStyles } = this.state

--- a/src/native/test/native.test.js
+++ b/src/native/test/native.test.js
@@ -199,7 +199,6 @@ describe('native', () => {
 
       // $FlowFixMe
       expect(ref).toHaveBeenCalledWith(view.node)
-      expect(innerComponent.prop('innerRef')).toBe(ref)
     })
   })
 })


### PR DESCRIPTION
In ```StyledNativeComponent```, ```setNativeProps``` has been deleted between v1 and v2.

This PR restores it to allow forwarding of native props to the inner component.

Fix #763.