### PR TITLE
Add custom classname

### DIFF
--- a/src/constructors/styled.js
+++ b/src/constructors/styled.js
@@ -3,10 +3,22 @@ import css from './css'
 import type { Interpolation, Target } from '../types'
 import domElements from '../utils/domElements'
 
+const classNameRegex = /\.[a-z_-][a-z\d_-]*/g
+
 export default (styledComponent: Function) => {
-  const styled = (tag: Target) =>
-    (strings: Array<string>, ...interpolations: Array<Interpolation>) =>
-      styledComponent(tag, css(strings, ...interpolations))
+  const styled = (tag: Target) => {
+    let newTag = tag
+    let name = null
+    if (typeof tag === 'string') {
+      const hasClass = tag.indexOf('.') !== -1
+      if (hasClass && classNameRegex.test(tag)) {
+        name = classNameRegex.exec(tag)[0].substr(1)
+        newTag = newTag.replace(classNameRegex, '')
+      }
+    }
+    return (strings: Array<string>, ...interpolations: Array<Interpolation>) =>
+      styledComponent(newTag, css(strings, ...interpolations), null, name)
+  }
 
   // Shorthands for all valid HTML Elements
   domElements.forEach(domElement => {

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -17,10 +17,12 @@ export default (nameGenerator: NameGenerator) => {
 
   class ComponentStyle {
     rules: RuleSet
+    name: ?string
     insertedRule: GlamorInsertedRule
 
-    constructor(rules: RuleSet) {
+    constructor(rules: RuleSet, name?: string) {
       this.rules = rules
+      this.name = name
       if (!styleSheet.injected) styleSheet.inject()
       this.insertedRule = styleSheet.insert('')
     }
@@ -32,11 +34,14 @@ export default (nameGenerator: NameGenerator) => {
      * Returns the hash to be injected on render()
      * */
     generateAndInjectStyles(executionContext: Object) {
-      const flatCSS = flatten(this.rules, executionContext).join('')
+      const notFlatCSS = flatten(this.rules, executionContext).join('')
+      const flatCSS = notFlatCSS
+        .replace(/~parent\('(.*?)'\)\s*?{([\s\S]+?)}/g, '')
         .replace(/^\s*\/\/.*$/gm, '') // replace JS comments
+
       const hash = hashStr(flatCSS)
       if (!inserted[hash]) {
-        const selector = nameGenerator(hash)
+        const selector = nameGenerator(hash, this.name)
         inserted[hash] = selector
         const root = parse(`.${selector} { ${flatCSS} }`)
         postcssNested(root)

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -12,15 +12,20 @@ import AbstractStyledComponent from './AbstractStyledComponent'
 import { CHANNEL } from './ThemeProvider'
 
 export default (ComponentStyle: Function) => {
-  // eslint-disable-next-line no-undef
-  const createStyledComponent = (target: Target, rules: RuleSet, parent?: ReactClass<*>) => {
+  const createStyledComponent = (
+    target: Target,
+    rules: RuleSet,
+    // eslint-disable-next-line no-undef
+    parent?: ReactClass<*>,
+    name?: string,
+  ) => {
     /* Handle styled(OtherStyledComponent) differently */
     const isStyledComponent = AbstractStyledComponent.isPrototypeOf(target)
     if (!isTag(target) && isStyledComponent) {
       return createStyledComponent(target.target, target.rules.concat(rules), target)
     }
 
-    const componentStyle = new ComponentStyle(rules)
+    const componentStyle = new ComponentStyle(rules, name)
     const ParentComponent = parent || AbstractStyledComponent
 
     class StyledComponent extends ParentComponent {

--- a/src/utils/generateAlphabeticName.js
+++ b/src/utils/generateAlphabeticName.js
@@ -2,7 +2,8 @@
 const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
 /* Some high number, usually 9-digit base-10. Map it to base-😎 */
-const generateAlphabeticName = (code: number): string => {
+const generateAlphabeticName = (code: number, name?: string): string => {
+  if (typeof name !== 'undefined' && name !== null) return name
   const lastDigit = chars[code % chars.length]
   return code > chars.length
     ? `${generateAlphabeticName(Math.floor(code / chars.length))}${lastDigit}`

--- a/src/utils/test/generateAlphabeticName.test.js
+++ b/src/utils/test/generateAlphabeticName.test.js
@@ -8,4 +8,7 @@ describe('generateAlphabeticName', () => {
     expect(generateAlphabeticName(1000000000)).toEqual('cGNYzm');
     expect(generateAlphabeticName(2000000000)).toEqual('fnBWYy');
   });
+  it('should return the exact class name', () => {
+    expect(generateAlphabeticName(2000000000, 'class_name')).toEqual('class_name');
+  });
 });


### PR DESCRIPTION
Add custom `classname` over the `generated name`.

I know that generated name is unique but sometimes i just need to specify my custom name of the class

for example,
```JS
import styled from 'styled-compontents';

const Section = styled('section.class-name')`
  color: red;
`;
```

it will generate
```CSS
.class-name {
  color: red;
}