### PR TITLE
Remove unnecessary listing `flow-typed` in [libs]

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,7 +10,6 @@
 [include]
 
 [libs]
-flow-typed
 
 [options]
 suppress_comment=.*\\$FlowFixMe


### PR DESCRIPTION
It's already included by default

https://flow.org/en/docs/config/libs/