### PR TITLE
Parent selectors hash resolution

### DIFF
--- a/src/test/props.test.js
+++ b/src/test/props.test.js
@@ -39,20 +39,16 @@ describe('props', () => {
       }
       `
     })
-    it('Should give the same root class to the prop children and the propless one', ()=> {
+    it('Should give the same class to the prop children and the propless one', ()=> {
       const wrapper = mount(<div><Comp /><Comp red /></div>)
       const comps = wrapper.find(Comp)
-      const proplessClass = comps.at(0).find('div').first().prop('className').split(' ')
+      const proplessClass = comps.at(0).find('div').first().prop('className')
       const withPropClass = comps.at(1).find('div').first().prop('className').split(' ')
-      const atLeastOneClass = proplessClass.some((appliedClass) => (
-        appliedClass.indexOf(withPropClass) !== -1
-      ))
-      expect(atLeastOneClass).toEqual(true)
+      expect(withPropClass.indexOf(proplessClass) !== -1).toEqual(true)
     })
-    it.only('Should attach the sibling rule to the common root class', () => {
+    it('Should attach the sibling rule to the common root class', () => {
       const wrapper = mount(<div><Comp /><Comp red /></div>)
-      console.log(styleSheet.rules().map(rule => rule.cssText).join('\n'))
-      expectCSSMatches('.root + .root { color: black; } .a { color: white; } .b { color: red}')
+      expectCSSMatches(' .a { color: white; } .a + .a { color: black; } .b { color: red}')
     })
   })
 })

--- a/src/test/props.test.js
+++ b/src/test/props.test.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react'
-import { shallow } from 'enzyme'
-
+import { mount, shallow } from 'enzyme'
+import jsdom from 'mocha-jsdom'
+import expect from 'expect'
+import styleSheet from '../models/StyleSheet'
 import { resetStyled, expectCSSMatches } from './utils'
 
 let styled
@@ -24,5 +26,33 @@ describe('props', () => {
     `
     shallow(<Comp fg="red"/>)
     expectCSSMatches('.a { color: red; }')
+  })
+  describe('sibling props', () => {
+    jsdom()
+    let Comp
+    beforeEach(() => {
+      styled = resetStyled()
+      Comp = styled.div`
+      color: ${props => props.red ? 'red' : 'white'}
+      & + & {
+        color: 'black'
+      }
+      `
+    })
+    it('Should give the same root class to the prop children and the propless one', ()=> {
+      const wrapper = mount(<div><Comp /><Comp red /></div>)
+      const comps = wrapper.find(Comp)
+      const proplessClass = comps.at(0).find('div').first().prop('className').split(' ')
+      const withPropClass = comps.at(1).find('div').first().prop('className').split(' ')
+      const atLeastOneClass = proplessClass.some((appliedClass) => (
+        appliedClass.indexOf(withPropClass) !== -1
+      ))
+      expect(atLeastOneClass).toEqual(true)
+    })
+    it.only('Should attach the sibling rule to the common root class', () => {
+      const wrapper = mount(<div><Comp /><Comp red /></div>)
+      console.log(styleSheet.rules().map(rule => rule.cssText).join('\n'))
+      expectCSSMatches('.root + .root { color: black; } .a { color: white; } .b { color: red}')
+    })
   })
 })


### PR DESCRIPTION
This fix aims to solve the problem described [here](https://github.com/styled-components/styled-components/issues/774) upon which sibling selectors is unexpectedly applied when using props on a component.

This is not complete being submited for the time just for input and guidance.