### PR TITLE
Add mediaQuery helper method to manage media queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. If a contri
 ## [Unreleased]
 
 ### Added
+- Add `mediaQuery` helper method to manage media queries, thanks to [@JohnAlbin](https://github.com/JohnAlbin) (see [#791](https://github.com/styled-components/styled-components/issues/791))
 - Support for jsdom and other browsers that do not implement [ownerNode](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet/ownerNode), thanks to [@zvictor](https://github.com/zvictor)
 
 ### Changed

--- a/docs/api.md
+++ b/docs/api.md
@@ -160,6 +160,77 @@ A styled react component. This is returned when you call `styled.tagname` or `st
 
 ## Helpers
 
+### `mediaQuery`
+
+`web`, `native`.
+
+A helper method to manage media queries.
+
+The `mediaQuery` method is a tag function that takes the given media query features in a tagged template literal; it returns a new tag function. This new tag function can be used in styled components to take a CSS rulesets in a tagged template literal and returns the same CSS but wrapped in the pre-defined media query.
+
+#### Arguments
+
+1. `TaggedTemplateLiteral`: A tagged template literal containing the query features of a media query. e.g. `` `(min-width: 48em)` `` or `` `(min-width: 700px), handheld and (orientation: landscape)` ``
+
+#### Returns
+
+A new tag function.
+
+#### Example
+
+```JS
+// mediaQueries.js
+import { mediaQuery } from 'styled-components';
+
+// Define commonly used media queries and use them in all of your components.
+export const media = {
+  mobileOnly: mediaQuery`(max-width: ${767 / 16}em)`,
+  tablet:     mediaQuery`(min-width: ${768 / 16}em)`,
+  print:      mediaQuery`print`,
+};
+```
+
+```JS
+import styled from 'styled-components';
+import { media } from '../mediaQueries';
+
+const Button = styled.button`
+  width: 100%;
+
+  ${media.tablet`
+    width: auto;
+  `}
+
+  ${media.print`
+    color: black;
+  `}
+`;
+```
+
+This will generate CSS like the following:
+```CSS
+.examp {
+  width: 100%;
+}
+
+@media (min-width: 48em) {
+  .examp {
+    width: auto;
+  }
+}
+
+@media print {
+  .examp {
+    color: black;
+  }
+}
+```
+
+#### Tips
+
+- You're writing CSS, but with the power of JavaScript - utilise it! (see [Tips and Tricks](./tips-and-tricks.md) for more ideas)
+
+
 ### `keyframes`
 
 `web` only.

--- a/docs/api.md
+++ b/docs/api.md
@@ -118,7 +118,7 @@ If you're just returning a normal string you do not need to use this.
 
 #### Arguments
 
-1. `TaggedTemplateLiteral`: A tagged template literal with your keyframes inside.
+1. `TaggedTemplateLiteral`: A tagged template literal with your rulesets inside.
 
 #### Returns
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -109,74 +109,64 @@ Now we have javascript, we can do 🌟 _more powerful things_ 🌟
 
 ```js
 // style-utils.js
-import { css } from 'styled-components'
+import { mediaQuery } from 'styled-components'
 
+const sizes = {
+  tablet: 768,
+  desktop: 992,
+  giant: 1170,
+}
+
+// use em in breakpoints to work properly cross-browser and support users
+// changing their browsers font-size: https://zellwk.com/blog/media-query-units/
 export const media = {
-  handheld: (...args) => css`
-    @media (max-width: 420px) {
-      ${ css(...args) }
-    }
-  `
+  handheld:   mediaQuery`(max-width: ${(sizes.tablet - 1) / 16}em)`,
+  tablet:     mediaQuery`(min-width: ${sizes.tablet / 16}em)`,
+  tabletOnly: mediaQuery`(min-width: ${sizes.tablet / 16}em) and (max-width: ${(sizes.desktop - 1) / 16}em)`,
+  desktop:    mediaQuery`(min-width: ${sizes.desktop / 16}em)`,
+  giant:      mediaQuery`(min-width: ${sizes.giant / 16}em)`,
+  minWidth:   (pxValue) => mediaQuery`(min-width: ${pxValue / 16}em)`,
+  print:      mediaQuery`print`,
 }
 ```
 
+Because `media` is a static object you create, you can name it whatever you want (`respondTo`, `atMedia`, etc.) and, best of all, most IDEs will offer auto-complete suggestions when typing that object.
+
+Now that you've defined your media queries, you can use them like this:
+
 ```js
+import styled, { css } from 'styled-components';
 import { media } from '../style-utils';
 
-// Make the text smaller on handheld devices
 const Box = styled.div`
   font-size: 16px;
-  ${ media.handheld`
+
+  /* Make the text smaller on handheld devices */
+  ${media.handheld`
     font-size: 14px;
-  ` }
+  `}
+
+  /* Create a media query with a custom width not needed in other components. */
+  ${media.minWidth(500)`
+    border-width: 2px;
+  `}
+
+  /* tagged functions created with mediaQuery can be nested with other
+     interpolations using styled-component's tagged function, css(). */
+  ${({ wide }) => wide && css`
+    width: 100%;
+
+    ${media.tablet`
+      width: 80%;
+      margin: 0 auto;
+    `}
+  `}
 `;
 ```
 
-And voila! 💅
+And voila! 💅 Pretty easy, huh?
 
 *Not clear on why `css` is needed in the above example? Check the article on [Tagged Template Literals](./tagged-template-literals.md)*
-
-### Media Templates
-
-Due to the functional nature of javascript, you can easily define your own tagged template literal to wrap styles in media queries. For example:
-
-```js
-// these sizes are arbitrary and you can set them to whatever you wish
-import { css } from 'styled-components'
-
-const sizes = {
-  giant: 1170,
-  desktop: 992,
-  tablet: 768,
-  phone: 376
-}
-
-// iterate through the sizes and create a media template
-export const media = Object.keys(sizes).reduce((accumulator, label) => {
-  // use em in breakpoints to work properly cross-browser and support users
-  // changing their browsers font-size: https://zellwk.com/blog/media-query-units/
-  const emSize = sizes[label] / 16
-  accumulator[label] = (...args) => css`
-    @media (max-width: ${emSize}em) {
-      ${css(...args)}
-    }
-  `
-  return accumulator
-}, {})
-```
-
-Great! Now that you've defined your media templates, you can use them like this:
-
-```js
-const Container = styled.div`
-  color: #333;
-  ${media.desktop`padding: 0 20px;`}
-  ${media.tablet`padding: 0 10px;`}
-  ${media.phone`padding: 0 5px;`}
-`
-```
-
-Pretty easy, huh?
 
 ### Refs to DOM nodes
 

--- a/src/constructors/mediaQuery.js
+++ b/src/constructors/mediaQuery.js
@@ -1,0 +1,19 @@
+// @flow
+import css from './css'
+import type { Interpolation, RuleSet } from '../types'
+
+// Equivalent to:
+// const mediaQuery = (...query) => (...rules) => css`
+//   @media ${css(...query)} {
+//     ${css(...rules)}
+//   }
+// `
+
+const mediaQuery = (
+  queryStrings: Array<string>,
+  ...queryInterpolations: Array<Interpolation>
+): Function =>
+  (rulesStrings: Array<string>, ...rulesInterpolations: Array<Interpolation>): RuleSet =>
+    css`@media ${css(queryStrings, ...queryInterpolations)}{${css(rulesStrings, ...rulesInterpolations)}}`
+
+export default mediaQuery

--- a/src/constructors/test/mediaQuery.test.js
+++ b/src/constructors/test/mediaQuery.test.js
@@ -1,0 +1,73 @@
+// @flow
+import expect from 'expect'
+
+import mediaQuery from '../mediaQuery'
+import css from '../css'
+import styleSheet from '../../models/StyleSheet'
+import flatten from '../../utils/flatten'
+import { expectCSSMatches, resetStyled } from '../../test/utils'
+
+const addStylesheetRule = (rule) => {
+  styleSheet.insert(flatten(rule).join(''))
+}
+
+describe('mediaQuery', () => {
+  beforeEach(() => {
+    resetStyled()
+  })
+
+  it('should return a function', () => {
+    expect(mediaQuery`test`).toBeA('function')
+  })
+
+  describe('returned function', () => {
+    it('should return an array of strings', () => {
+      const testQuery = mediaQuery`testQuery`
+      const strings = ['string1', 'string2', 'string3']
+      const interpolations = ['interpolation1', 'interpolation2']
+      expect(testQuery(strings, ...interpolations)).toBeAn('array')
+    })
+
+    it('should handle a tagged template literal', () => {
+      const testQuery = mediaQuery`(min-width: ${768/16}em)`
+      const exampleFunction = () => true;
+      expect(testQuery`string1${'interpolation1'}string2${exampleFunction}string3`).toEqual([
+        '@media ',
+        '(min-width: ',
+        '48',
+        'em)',
+        '{',
+        'string1',
+        'interpolation1',
+        'string2',
+        exampleFunction,
+        'string3',
+        '}',
+      ])
+    })
+  })
+
+  it('should create a media query', () => {
+    const tablet = mediaQuery`(min-width: ${768/16}em)`
+    const rule = css`
+      .ex {
+        color: black;
+      }
+      ${tablet`
+        /* tablet rules */
+        .ex {
+          color: red;
+        }
+      `}
+    `
+
+    addStylesheetRule(rule)
+    expectCSSMatches(`
+      .ex { color: black; }
+      @media (min-width: 48em){
+        /* tablet rules */
+        .ex { color: red; }
+      }
+    `, { styleSheet })
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 /* Import singletons */
 import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
+import mediaQuery from './constructors/mediaQuery'
 import injectGlobal from './constructors/injectGlobal'
 
 /* Import singleton constructors */
@@ -23,4 +24,4 @@ const styled = _styled(_styledComponent(_ComponentStyle(generateAlphabeticName))
 
 /* Export everything */
 export default styled
-export { css, keyframes, injectGlobal, ThemeProvider, withTheme }
+export { css, mediaQuery, keyframes, injectGlobal, ThemeProvider, withTheme }

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -4,6 +4,7 @@
 import reactNative from 'react-native'
 
 import css from '../constructors/css'
+import mediaQuery from '../constructors/mediaQuery'
 
 import styledNativeComponent from '../models/StyledNativeComponent'
 import ThemeProvider from '../models/ThemeProvider'
@@ -34,5 +35,5 @@ aliases.split(/\s+/m).forEach(alias => Object.defineProperty(styled, alias, {
   },
 }))
 
-export { css, ThemeProvider, withTheme }
+export { css, mediaQuery, ThemeProvider, withTheme }
 export default styled


### PR DESCRIPTION
This fixes https://github.com/styled-components/styled-components/issues/791 There's a much longer explanation there.

While my original code was just this:

```JS
const mediaQuery = (...query) => (...rules) => css`
  @media ${css(...query)} {
    ${css(...rules)}
  }
`
```

I had to complicate it a bit to add Flow typing on the params and return types.