### PR TITLE
Set StyledComponent context directly on every class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Add `innerRef` support to `withTheme` HOC. (see [#710](https://github.com/styled-components/styled-components/pull/710))
 - Switch to babel-preset-env. (see [#717](https://github.com/styled-components/styled-components/pull/717))
 - Update StyledNativeComponent to match StyledComponent implementation.
+- Fix Theme context for StyledComponent for IE <10. (see [#807](https://github.com/styled-components/styled-components/pull/807))
 
 ## [Unreleased]
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { createElement } from 'react'
+import PropTypes from 'prop-types'
 
 import type { Theme } from './ThemeProvider'
 import createWarnTooManyClasses from '../utils/createWarnTooManyClasses'
@@ -191,6 +192,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     )
 
     class StyledComponent extends ParentComponent {
+      static contextTypes = {
+        [CHANNEL]: PropTypes.func,
+        [CONTEXT_KEY]: PropTypes.instanceOf(StyleSheet),
+      }
+
       static displayName = displayName
       static styledComponentId = componentId
       static attrs = attrs


### PR DESCRIPTION
Fix StyledComponent for older browsers IE<=10 by setting context directly on every StyledComponent class.

This isn't nice but should fix IE issues for now (?)

Shall we remove AbstractStyledComponent in the future, since it doesn't serve a purpose anymore, @geelen?