### PR TITLE
updated package.json to allow patches of stylis when installing deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
     "prop-types": "^15.5.4",
-    "stylis": "^2.0.0",
+    "stylis": "~2.0.0",
     "supports-color": "^3.2.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5645,9 +5645,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-2.0.3.tgz#054b0ad1f636181664246c103adf506c84b502e7"
+stylis@~2.0.0:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-2.0.12.tgz#547253055d170f2a7ac2f6d09365d70635f2bec6"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
There have been multiple patch updates to stylis with fixes for multiple issues. Styled components currently installs 2.0.3. The latest stylis is 2.0.12. 

Examples of a few issues:
https://github.com/thysultan/stylis.js/issues/16
https://github.com/styled-components/styled-components/issues/775