### PR TITLE
Fix Type for Broadcast.subscribe's Callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Update StyledNativeComponent to match StyledComponent implementation.
 - Fix Theme context for StyledComponent for IE <10. (see [#807](https://github.com/styled-components/styled-components/pull/807))
 - Restore `setNativeProps` in StyledNativeComponent, thanks to [@MatthieuLemoine](https://github.com/MatthieuLemoine). (see [#764](https://github.com/styled-components/styled-components/pull/764))
+- Fix flow type for Broadcast.subscribe, thanks to [@jameskraus](https://github.com/jameskraus). (see [#818](https://github.com/styled-components/styled-components/pull/818))
 
 ## [v1.4.6] - 2017-05-02
 

--- a/src/utils/create-broadcast.js
+++ b/src/utils/create-broadcast.js
@@ -7,7 +7,7 @@
 
 export type Broadcast = {
   publish: (value: mixed) => void,
-  subscribe: (listener: () => void) => () => void
+  subscribe: (listener: (value: mixed) => void) => () => void
 }
 
 const createBroadcast = (initialValue: mixed): Broadcast => {


### PR DESCRIPTION
Broadcast.subscribe takes a parameter, so it currently throws a flow type error because the type says it takes no parameters:
```
  node_modules/styled-components/src/utils/create-broadcast.js:20
   20:       listeners.forEach(listener => listener(currentValue))
                                                    ^^^^^^^^^^^^ unused function argument
     10:   subscribe: (listener: () => void) => () => void
                                 ^^^^^^^^^^ function type expects no arguments
```

This small change should fix this problem.