### PR TITLE
Don't treat props.children special

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Added per-component class names (see [#227](https://github.com/styled-components/styled-components/pull/227)).
 - Added the ability to override one component's styles from another.
 - Injecting an empty class for each instance of a component in development.
-- Added `attrs` constructor for passing extra attributes to the underlying element
+- Added `attrs` constructor for passing extra attributes/properties to the underlying element.
 - Added warnings for components generating a lot of classes, thanks to [@vdanchenkov](https://github.com/vdanchenkov). (see [#268](https://github.com/styled-components/styled-components/pull/268))
 - Standardised `styled(Comp)` to work the same in all cases, rather than a special extension case where `Comp` is another Styled Component. `Comp.extend` now covers that case. (see [#518](https://github.com/styled-components/styled-components/pull/518)).
 - Added `Comp.withComponent(Other)` to allow cloning of an existing SC with a new tag. (see [#814](https://github.com/styled-components/styled-components/pull/814).

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -123,7 +123,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     }
 
     render() {
-      const { children, innerRef } = this.props
+      const { innerRef } = this.props
       const { generatedClassName } = this.state
       const { styledComponentId, target } = this.constructor
 
@@ -164,7 +164,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
           return acc
         }, baseProps)
 
-      return createElement(target, propsForElement, children)
+      return createElement(target, propsForElement)
     }
   }
 

--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -118,4 +118,25 @@ describe('attrs', () => {
     expect(shallow(<Comp />).html()).toEqual('<a href="#" class="sc-a b"></a>')
     expectCSSMatches('.sc-a {} .b { color: blue; } .b.--is-active { color: red; }')
   })
+
+  it('should pass through children as a normal prop', () => {
+    const Comp = styled.div.attrs({
+      children: 'Probably a bad idea'
+    })``
+    expect(shallow(<Comp />).html()).toEqual('<div class="sc-a b">Probably a bad idea</div>')
+  })
+
+  it('should pass through complex children as well', () => {
+    const Comp = styled.div.attrs({
+      children: <span>Probably a bad idea</span>
+    })``
+    expect(shallow(<Comp />).html()).toEqual('<div class="sc-a b"><span>Probably a bad idea</span></div>')
+  })
+
+  it('should override children of course', () => {
+    const Comp = styled.div.attrs({
+      children: <span>Amazing</span>
+    })``
+    expect(shallow(<Comp>Something else</Comp>).html()).toEqual('<div class="sc-a b">Something else</div>')
+  })
 })


### PR DESCRIPTION
Previously we were handling children specifically, but if we don't, we get this interesting behaviour with attrs.

I definitely wouldn't document or recommend using `attrs({ children: '...' })` in this way but it seems odd that children doesn't work like the others, and who knows, maybe someone will come up with an interesting pattern using it?

I wouldn't have suggested doing this if it didn't simplify the implementation, so even though I'm unsure about it, I think we should merge this.