### PR TITLE
Prevent ref prop from being passed to SFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Update StyledNativeComponent to match StyledComponent implementation.
 - Fix Theme context for StyledComponent for IE <10. (see [#807](https://github.com/styled-components/styled-components/pull/807))
 - Restore `setNativeProps` in StyledNativeComponent, thanks to [@MatthieuLemoine](https://github.com/MatthieuLemoine). (see [#764](https://github.com/styled-components/styled-components/pull/764))
+- Fix `ref` being passed to Stateless Functional Components in StyledNativeComponent. (see [#828](https://github.com/styled-components/styled-components/pull/828))
 - Add `displayName` to `componentId` when both are present (see [#821](https://github.com/styled-components/styled-components/pull/821))
 
 ## [v1.4.6] - 2017-05-02

--- a/src/native/test/native.test.js
+++ b/src/native/test/native.test.js
@@ -164,10 +164,12 @@ describe('native', () => {
 
       const wrapper = mount(<Comp innerRef={ref} />)
       const view = wrapper.find('View').first()
+      const comp = wrapper.find(Comp).first()
 
       // $FlowFixMe
       expect(ref).toHaveBeenCalledWith(view.node)
       expect(view.prop('innerRef')).toBeFalsy()
+      expect(comp.node.root).toBeTruthy()
     })
 
     class InnerComponent extends React.Component {
@@ -182,10 +184,12 @@ describe('native', () => {
 
       const wrapper = mount(<OuterComponent innerRef={ref} />)
       const innerComponent = wrapper.find(InnerComponent).first()
+      const outerComponent = wrapper.find(OuterComponent).first()
 
       // $FlowFixMe
       expect(ref).toHaveBeenCalledWith(innerComponent.node)
       expect(innerComponent.prop('innerRef')).toBeFalsy()
+      expect(outerComponent.node.root).toBeTruthy()
     })
 
     it('should pass the innerRef to the wrapped styled component', () => {
@@ -196,9 +200,25 @@ describe('native', () => {
       const wrapper = mount(<OuterComponent innerRef={ref} />)
       const view = wrapper.find('View').first()
       const innerComponent = wrapper.find(InnerComponent).first()
+      const outerComponent = wrapper.find(OuterComponent).first()
 
       // $FlowFixMe
       expect(ref).toHaveBeenCalledWith(view.node)
+      expect(outerComponent.node.root).toBeTruthy()
+    })
+
+    it('should pass innerRef instead of ref to a wrapped stateless functional component', () => {
+      const InnerComponent = () => null
+      const OuterComponent = styled(InnerComponent)``
+      // NOTE: A ref should always be passed, so we don't need to (setNativeProps feature)
+
+      const wrapper = mount(<OuterComponent />)
+      const outerComponent = wrapper.find(OuterComponent).first()
+      const innerComponent = wrapper.find(InnerComponent).first()
+
+      expect(innerComponent.prop('ref')).toBeFalsy()
+      expect(innerComponent.prop('innerRef')).toBeTruthy()
+      expect(outerComponent.node.root).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
Due to the setNativeProps feature, a ref or innerRef will always be passed.
This causes a warning for stateless, functional components, since those
are not allowed to accept refs.

This changes the behaviour to pass innerRef instead and output a
warning if setNativeProps is used nonetheless.

Fix #766