### PR TITLE
Fixes for Flow v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Restore `setNativeProps` in StyledNativeComponent, thanks to [@MatthieuLemoine](https://github.com/MatthieuLemoine). (see [#764](https://github.com/styled-components/styled-components/pull/764))
 - Fix `ref` being passed to Stateless Functional Components in StyledNativeComponent. (see [#828](https://github.com/styled-components/styled-components/pull/828))
 - Add `displayName` to `componentId` when both are present (see [#821](https://github.com/styled-components/styled-components/pull/821))
+- Fix Flow type signatures for compatibility with Flow v0.47.0 (see [#840](https://github.com/styled-components/styled-components/pull/840))
 
 ## [v1.4.6] - 2017-05-02
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-jsx-a11y": "^2.0.2",
     "eslint-plugin-react": "^6.8.0",
     "express": "^4.14.1",
-    "flow-bin": "^0.43.1",
+    "flow-bin": "^0.47.0",
     "flow-copy-source": "^1.1.0",
     "flow-watch": "^1.1.1",
     "jest": "^19.0.2",

--- a/src/models/StyleSheetManager.js
+++ b/src/models/StyleSheetManager.js
@@ -10,8 +10,10 @@ class StyleSheetManager extends Component {
 
   render() {
     /* eslint-disable react/prop-types */
-    // $FlowFixMe
-    return React.Children.only(this.props.children)
+    // Flow v0.43.1 will report an error accessing the `children` property,
+    // but v0.47.0 will not. It is necessary to use a type cast instead of
+    // a "fixme" comment to satisfy both Flow versions.
+    return React.Children.only((this.props: any).children)
   }
 }
 

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -356,7 +356,7 @@ describe('theming', () => {
       },
     }
 
-    const Theme = ({ props }) => (
+    const Theme = props => (
       <ThemeProvider theme={{ color: 'green' }}>
         <Text {...props} />
       </ThemeProvider>

--- a/src/utils/create-broadcast.js
+++ b/src/utils/create-broadcast.js
@@ -7,7 +7,7 @@
 
 export type Broadcast = {
   publish: (value: mixed) => void,
-  subscribe: (listener: () => void) => () => void
+  subscribe: (listener: (currentValue: mixed) => void) => () => void
 }
 
 const createBroadcast = (initialValue: mixed): Broadcast => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,9 +2499,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.43.1:
-  version "0.43.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.43.1.tgz#0733958b448fb8ad4b1576add7e87c31794c81bc"
+flow-bin@^0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
 
 flow-copy-source@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Thank you for taking the trouble to ship type definitions with your library! There are changes in Flow v0.47.0 that cause Flow to report errors that were not reported in previous versions. I put together this PR so that your users will not see errors when they upgrade to the latest Flow. And I made sure that type-checking still passes with Flow v0.43.1 (the version that you have been using).

As of v0.47.0 Flow strictly checks function arity. That means you will get an error if you call a function with more arguments than are listed in the function signature.  For details see https://flow.org/blog/2017/05/07/Strict-Function-Call-Arity/

There are also some changes to checking React component prop types. The latest Flow will report some errors that previous versions missed.

The full changelog is here: https://github.com/facebook/flow/blob/master/Changelog.md#0470