### PR TITLE
Test: withComponent(...).attrs is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## [Unreleased]
 
+- Added a test for `withComponent` followed by `attrs`, thanks to [@btmills](https://github.com/btmills). (see [#851](https://github.com/styled-components/styled-components/pull/851))
 - Upgrade stylis to v3.0.4. (see [#829](https://github.com/styled-components/styled-components/pull/829))
 
 ## [v2.0.0] - 2017-05-25

--- a/src/test/extending.test.js
+++ b/src/test/extending.test.js
@@ -163,10 +163,10 @@ describe('extending', () => {
     const Parent = styled.button`
       color: red;
     `
-    const Child = Parent.withComponent('a').attrs({
+    const Child = Parent.withComponent('a').extend.attrs({
       href: '/test'
     })``
 
-    expect(shallow(<Child />).html()).toEqual('<a class="sc-b c" href="/test"></a>')
+    expect(shallow(<Child />).html()).toEqual('<a href="/test" class="sc-c d"></a>')
   })
 })

--- a/src/test/extending.test.js
+++ b/src/test/extending.test.js
@@ -158,4 +158,15 @@ describe('extending', () => {
       .sc-c {} .d { color: red; color: green; }
     `)
   })
+
+  it('should allow changing component and adding attributes', () => {
+    const Parent = styled.button`
+      color: red;
+    `
+    const Child = Parent.withComponent('a').attrs({
+      href: '/test'
+    })``
+
+    expect(shallow(<Child />).html()).toEqual('<a class="sc-b c" href="/test"></a>')
+  })
 })


### PR DESCRIPTION
~:rotating_light: This pull request contains a failing test and should not be merged.~ *Edit: Test is no longer failing!*

Should it be possible to add `attrs` after overriding `withComponent`? I found a test for `withComponent` followed by `extend`, but none for `attrs`, so I added one:

```js
const Parent = styled.button`
  color: red;
`
const Child = Parent.withComponent('a').attrs({
  href: '/test'
})``
```

Currently this throws `TypeError: Parent.withComponent(...).attrs is not a function`.

I haven't looked into the implementation to see what might be causing this, but if it's an actual bug, I'd be willing to spend some time on a fix given a couple hints about where to start looking!