### PR TITLE
Copy nested rules to multiple child

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -206,7 +206,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
 
       static extendWith(tag) {
         const { displayName: _, componentId: __, ...optionsToCopy } = options
-        const newOptions = { ...optionsToCopy, rules, ParentComponent: StyledComponent }
+        const newOptions = {
+          ...optionsToCopy,
+          rules: StyledComponent.componentStyle.rules,
+          ParentComponent: StyledComponent,
+        }
         return constructWithOptions(createStyledComponent, tag, newOptions)
       }
 

--- a/src/test/extending.test.js
+++ b/src/test/extending.test.js
@@ -145,4 +145,17 @@ describe('extending', () => {
 
     expect(shallow(<Child />).html()).toEqual('<span class="sc-b c"></span>')
   })
+
+  it('should copy nested rules to multiple child', () => {
+    const Parent = styled.div`color: red;`
+    const Child = Parent.extendWith('span')`font-size: 10px;`
+    const ChildChild = Child.extendWith('span')`background-color: pink;`
+    const ChildChildChild = ChildChild.extendWith('span')`background-color: yellow;`
+
+    shallow(<ChildChildChild />)
+
+    expectCSSMatches(`
+      .sc-d {} .e { color: red; font-size: 10px; background-color: pink; background-color: yellow; }
+    `)
+  })
 })


### PR DESCRIPTION
With this PR you can extend a component that is extending another component, in current version you only get the rules from the direct parent.

```js
const Parent = styled.div`color: red;`
const Child = Parent.extendWith('span')`font-size: 10px;`
const ChildChild = Child.extendWith('span')`background-color: pink;`
```

ChildChild will have both Parent and Child rules.