### PR TITLE
Add additional proxy methods for NativeMethodsMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Added a test for `withComponent` followed by `attrs`, thanks to [@btmills](https://github.com/btmills). (see [#851](https://github.com/styled-components/styled-components/pull/851))
 - Upgrade stylis to v3.0.4. (see [#829](https://github.com/styled-components/styled-components/pull/829))
 - Fix Flow type signatures for compatibility with Flow v0.47.0 (see [#840](https://github.com/styled-components/styled-components/pull/840))
+- Add additional proxy methods for NativeMethodsMixin (see [#873](https://github.com/styled-components/styled-components/pull/873))
 
 ## [v2.0.0] - 2017-05-25
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -147,7 +147,6 @@ export default (constructWithOptions: Function) => {
     // $FlowFixMe
     BaseStyledNativeComponent.prototype[methodKey] = function nativeProxy(...args) {
       if (this.root !== undefined) {
-        // $FlowFixMe
         this.root[methodKey](...args)
       } else {
         const { displayName } = this.constructor


### PR DESCRIPTION
*Making SC Native future proof (TM)*

This will make Styled Components future-proof for
Yoga Nodes, which depends on a couple of additional
methods to exist. It's unclear whether this will actually
be enabled by default, but I'm sure it doesn't hurt to support
Yoga Nodes for those who need it.

The methods that were added: https://facebook.github.io/react-native/docs/nativemethodsmixin.html