### PR TITLE
Upgrade stylis from 3.0.4 to 3.0.17 to fix a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Fixed `extend` not working with 3 or more inheritances, thanks to [@brunolemos](https://twitter.com/brunolemos). (see [#871](https://github.com/styled-components/styled-components/pull/871))
 - Added a test for `withComponent` followed by `attrs`, thanks to [@btmills](https://github.com/btmills). (see [#851](https://github.com/styled-components/styled-components/pull/851))
-- Upgrade stylis to v3.0.4. (see [#829](https://github.com/styled-components/styled-components/pull/829))
-- Fix Flow type signatures for compatibility with Flow v0.47.0 (see [#840](https://github.com/styled-components/styled-components/pull/840))
+- Upgraded stylis to v3.0. (see [#829](https://github.com/styled-components/styled-components/pull/829) and [#876](https://github.com/styled-components/styled-components/pull/876))
 
 ## [v2.0.0] - 2017-05-25
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
     "prop-types": "^15.5.4",
-    "stylis": "^3.0.4",
+    "stylis": "^3.0.17",
     "supports-color": "^3.2.3"
   },
   "devDependencies": {

--- a/src/test/css.test.js
+++ b/src/test/css.test.js
@@ -29,7 +29,7 @@ describe('css features', () => {
     expectCSSMatches(`
       .sc-a {}
       .b {
-        display:-webkit-box; display:-webkit-flex; display:-ms-flexbox; display:flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;
+        display: -webkit-box; display: -webkit-flex; display: -ms-flexbox; display: flex; -webkit-flex-direction: column; -ms-flex-direction: column; flex-direction: column; -webkit-align-items: center; -webkit-box-align: center; -ms-flex-align: center; align-items: center;
       }
     `)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5651,9 +5651,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.0.4.tgz#fd7a0f6c10c09903704cc362bc23449afda33458"
+stylis@^3.0.17:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.0.17.tgz#978643aed384f2138c54af9c02adeb61f1aa75f6"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fix ReferenceError: escade is not defined

See https://github.com/thysultan/stylis.js/issues/30