### PR TITLE
Fix CHANGELOG from last 2 merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Fixed `extend` not working with 3 or more inheritances, thanks to [@brunolemos](https://twitter.com/brunolemos). (see [#871](https://github.com/styled-components/styled-components/pull/871))
 - Added a test for `withComponent` followed by `attrs`, thanks to [@btmills](https://github.com/btmills). (see [#851](https://github.com/styled-components/styled-components/pull/851))
+- Fix Flow type signatures for compatibility with Flow v0.47.0 (see [#840](https://github.com/styled-components/styled-components/pull/840))
 - Upgraded stylis to v3.0. (see [#829](https://github.com/styled-components/styled-components/pull/829) and [#876](https://github.com/styled-components/styled-components/pull/876))
 
 ## [v2.0.0] - 2017-05-25


### PR DESCRIPTION
Apparently some merging went wrong and removed [this change](https://github.com/styled-components/styled-components/pull/874/files) in my [pr](https://github.com/styled-components/styled-components/commit/6854486c6c791bed3cc62a7e98235f1f167a267b)