### PR TITLE
[breaking][typescript] SVG type fix

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -60,7 +60,7 @@ type ThemedStyledComponentFactoriesSVG<T> = {
     [K in keyof SVGTags]: ThemedSvgStyledFunction<SVGTags[K], T>;
 };
 
-type ThemedStyledComponentFactories<T> = ThemedStyledComponentFactoriesHTML<T> & ThemedStyledComponentFactoriesHTML<T>;
+type ThemedStyledComponentFactories<T> = ThemedStyledComponentFactoriesHTML<T> & ThemedStyledComponentFactoriesSVG<T>;
 
 export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
   <P>(component: Component<P>): ThemedStyledFunction<P, T>;


### PR DESCRIPTION
Fixed:

`error TS2339: Property 'svg' does not exist on type 'ThemedBaseStyledInterface<Theme>`
`error TS2339: Property 'path' does not exist on type 'ThemedBaseStyledInterface<Theme>`

and so on...