### PR TITLE
update vscode syntax highlighting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ As soon as that PR is merged and a new version released, all you'll have to do i
 
 ### Visual Studio Code
 
-The [vscode-styled-components](https://github.com/styled-components/vscode-styled-components) extension provides syntax highlighting inside your Javascript files. You can install it as usual from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components).
+[**@gandm**](https://github.com/gandm)'s language-babel has been ported to VSCode under the name [Babel JavaScript](https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel) by [Michael McDermott](https://twitter.com/_mgmcdermott). It provides the same all-in-one solution for Babel syntax highlighting with styled-components included.
+
+If you would like to keep your current JavaScript syntax highlighting, you can use the [vscode-styled-components](https://github.com/styled-components/vscode-styled-components) extension to provide styled-components syntax highlighting inside your Javascript files. You can install it as usual from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components).
 
 ### VIM / NeoVim
 The [`vim-styled-components`](https://github.com/fleischie/vim-styled-components) plugin gives you syntax highlighting inside your Javascript files. Install it with your usual plugin manager like [Plug](https://github.com/junegunn/vim-plug), [Vundle](https://github.com/VundleVim/Vundle.vim), [Pathogen](https://github.com/tpope/vim-pathogen), etc.


### PR DESCRIPTION
I've ported language-babel from Atom to VSCode which supports styled-components syntax highlighting out of the box. I've updated the README to include this.

https://marketplace.visualstudio.com/items?itemName=mgmcdermott.vscode-language-babel