### PR TITLE
Fix peer dependency of react to include v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "typescript": "^2.3.3"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0"
+    "react": ">= 0.14.0 < 17.0.0-0"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
Fix #921 

Note: The actual issue with this is a yarn bug, but we can circumvent it completely by including react v16 into our peer dependencies, which is a safe modification and actually the default on React Native.