### PR TITLE
Upgrade to stylis 3.2 and use constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. If a contri
 
 *The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).*
 
+## Unreleased
+
+- Upgrade stylis to 2.3 and use constructor to fix bugs with multiple libs using stylis simultaneously (see [#962](https://github.com/styled-components/styled-components/pull/962))
+
 ## [v2.1.0] - 2017-06-15
 
 - Added missing v2.0 APIs to TypeScript typings, thanks to [@patrick91](https://github.com/patrick91), [@igorbek](https://github.com/igorbek) (see [#837](https://github.com/styled-components/styled-components/pull/837), [#882](https://github.com/styled-components/styled-components/pull/882))

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
     "prop-types": "^15.5.4",
-    "stylis": "^3.0.19",
+    "stylis": "^3.2.1",
     "supports-color": "^3.2.3"
   },
   "devDependencies": {

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -1,8 +1,8 @@
 // @flow
-import stylis from 'stylis'
+import Stylis from 'stylis'
 import type { Interpolation } from '../types'
 
-stylis.set({
+const stylis = new Stylis({
   global: false,
   cascade: true,
   keyframe: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,7 +2783,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.2:
+glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2804,7 +2804,7 @@ glob@^5.0.15, glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -4259,17 +4259,17 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
-
-minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  dependencies:
+    brace-expansion "^1.0.0"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -5861,9 +5861,9 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis@^3.0.19:
-  version "3.0.19"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.0.19.tgz#36013520bb19c209d374c629e97f190e8797a287"
+stylis@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.1.tgz#7a88988f8ccb5c238be3cc3cec173735cc594740"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This prevents bugs with shared options when different libraries all use
stylis.

~cc @thysultan Is the `keyframe ` option for namespacing broken? I'm seeing some regressions with mangled animation names.~

Edit:

```diff
-@-webkit-keyframes keyframe_880{ from{ opacity: 0; } } @keyframes keyframe_880{ from{ opacity: 0; } } .sc-a{ } .d{ -webkit-animation:keyframe_880 1s both; animation:keyframe_880 1s both; } @-webkit-keyframes keyframe_144{ from{ opacity: 1; } } @keyframes keyframe_144{ from{ opacity: 1; } } .sc-b{ } .c{ -webkit-animation:keyframe_144 1s both; animation:keyframe_144 1s both; }
+@-webkit-keyframes keyframe_880{ from{ opacity: 0; } } @keyframes keyframe_880{ from{ opacity: 0; } } .sc-a{ } .d{ -webkit-animation:keyframe_880-d 1s both; animation:keyframe_880-d 1s both; } @-webkit-keyframes keyframe_144{ from{ opacity: 1; } } @keyframes keyframe_144{ from{ opacity: 1; } } .sc-b{ } .c{ -webkit-animation:keyframe_144-c 1s both; animation:keyframe_144-c 1s both; }
```