### PR TITLE
change prepublish script to prepare. fixes #963

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,154 +1,152 @@
 {
-  "name": "styled-components",
-  "version": "2.1.0",
-  "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
-  "main": "lib/index.js",
-  "typings": "typings/styled-components.d.ts",
-  "jsnext:main": "dist/styled-components.es.js",
-  "module": "dist/styled-components.es.js",
-  "scripts": {
-    "build": "npm run build:lib && npm run build:dist",
-    "prebuild:lib": "rimraf lib/*",
-    "build:lib": "babel --out-dir lib src",
-    "prebuild:dist": "rimraf dist/*",
-    "build:dist": "rollup -c && rollup -c --environment ESBUNDLE && rollup -c --environment PRODUCTION",
-    "build:watch": "npm run build:lib -- --watch",
-    "test": "npm run test:web && npm run test:native && npm run test:size",
-    "test:web": "jest",
-    "test:web:watch": "npm run test:web -- --watch",
-    "test:native": "jest -c .jest.native.json",
-    "test:native:watch": "npm run test:native -- --watch",
-    "test:primitives": "jest -c .jest.primitives.json",
-    "test:primitives:watch": "npm run test:primitives -- --watch",
-    "test:size": "bundlesize",
-    "flow": "flow check",
-    "flow:watch": "flow-watch",
-    "lint": "eslint src",
-    "tslint": "tslint typings/*.ts native/*.ts",
-    "typescript": "tsc --project ./typings/tests",
-    "prepublish": "npm run build",
-    "lint-staged": "lint-staged",
-    "dev": "babel-node example/devServer.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/styled-components/styled-components.git"
-  },
-  "files": [
-    "no-parser.js",
-    "CONTRIBUTING.md",
-    "CODE_OF_CONDUCT.md",
-    "dist",
-    "docs",
-    "flow-typed",
-    "lib",
-    "native",
-    "primitives",
-    "src",
-    "typings"
-  ],
-  "keywords": [
-    "react",
-    "css",
-    "css-in-js",
-    "styled-components"
-  ],
-  "author": "Glen Maddern",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/styled-components/styled-components/issues"
-  },
-  "homepage": "https://styled-components.com",
-  "dependencies": {
-    "buffer": "^5.0.3",
-    "css-to-react-native": "^2.0.3",
-    "fbjs": "^0.8.9",
-    "hoist-non-react-statics": "^1.2.0",
-    "is-function": "^1.0.1",
-    "is-plain-object": "^2.0.1",
-    "prop-types": "^15.5.4",
-    "stylis": "^3.2.1",
-    "supports-color": "^3.2.3"
-  },
-  "devDependencies": {
-    "@types/react": "^15.0.25",
-    "@types/react-dom": "^15.5.0",
-    "@types/react-native": "^0.44.4",
-    "babel-cli": "^6.22.2",
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^7.1.1",
-    "babel-loader": "^6.2.10",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-external-helpers": "^6.22.0",
-    "babel-plugin-flow-react-proptypes": "^2.1.3",
-    "babel-plugin-transform-class-properties": "^6.22.0",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.22.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.1",
-    "babel-preset-env": "^1.4.0",
-    "babel-preset-react": "^6.22.0",
-    "bundlesize": "^0.5.5",
-    "chokidar": "^1.6.0",
-    "danger": "^0.16.0",
-    "enzyme": "^2.8.2",
-    "eslint": "^3.15.0",
-    "eslint-config-airbnb": "^13.0.0",
-    "eslint-plugin-flowtype": "^2.30.0",
-    "eslint-plugin-flowtype-errors": "^2.0.1",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^2.0.2",
-    "eslint-plugin-react": "^6.8.0",
-    "express": "^4.14.1",
-    "flow-bin": "^0.47.0",
-    "flow-copy-source": "^1.1.0",
-    "flow-watch": "^1.1.1",
-    "jest": "^19.0.2",
-    "jsdom": "^9.10.0",
-    "lint-staged": "^3.3.0",
-    "node-watch": "^0.4.1",
-    "pre-commit": "^1.2.2",
-    "react": "^15.5.4",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.5.4",
-    "react-native": "^0.39.2",
-    "react-primitives": "^0.4.2",
-    "rimraf": "^2.6.1",
-    "rollup": "^0.37.0",
-    "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-commonjs": "^6.0.0",
-    "rollup-plugin-flow": "^1.1.1",
-    "rollup-plugin-inject": "^2.0.0",
-    "rollup-plugin-json": "^2.1.0",
-    "rollup-plugin-node-resolve": "^2.0.0",
-    "rollup-plugin-replace": "^1.1.1",
-    "rollup-plugin-uglify": "^1.0.1",
-    "rollup-plugin-visualizer": "^0.1.5",
-    "tslint": "^4.3.1",
-    "typescript": "^2.3.3"
-  },
-  "peerDependencies": {
-    "react": ">= 0.14.0 < 17.0.0-0"
-  },
-  "jest": {
-    "roots": [
-      "<rootDir>/src/"
+    "name": "styled-components",
+    "version": "2.1.0",
+    "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
+    "main": "lib/index.js",
+    "typings": "typings/styled-components.d.ts",
+    "jsnext:main": "dist/styled-components.es.js",
+    "module": "dist/styled-components.es.js",
+    "scripts": {
+        "build": "npm run build:lib && npm run build:dist",
+        "prebuild:lib": "rimraf lib/*",
+        "build:lib": "babel --out-dir lib src",
+        "prebuild:dist": "rimraf dist/*",
+        "build:dist": "rollup -c && rollup -c --environment ESBUNDLE && rollup -c --environment PRODUCTION",
+        "build:watch": "npm run build:lib -- --watch",
+        "test": "npm run test:web && npm run test:native && npm run test:size",
+        "test:web": "jest",
+        "test:web:watch": "npm run test:web -- --watch",
+        "test:native": "jest -c .jest.native.json",
+        "test:native:watch": "npm run test:native -- --watch",
+        "test:primitives": "jest -c .jest.primitives.json",
+        "test:primitives:watch": "npm run test:primitives -- --watch",
+        "test:size": "bundlesize",
+        "flow": "flow check",
+        "flow:watch": "flow-watch",
+        "lint": "eslint src",
+        "tslint": "tslint typings/*.ts native/*.ts",
+        "typescript": "tsc --project ./typings/tests",
+        "prepare": "npm run build",
+        "lint-staged": "lint-staged",
+        "dev": "babel-node example/devServer.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/styled-components/styled-components.git"
+    },
+    "files": [
+        "no-parser.js",
+        "CONTRIBUTING.md",
+        "CODE_OF_CONDUCT.md",
+        "dist",
+        "docs",
+        "flow-typed",
+        "lib",
+        "native",
+        "primitives",
+        "src",
+        "typings"
     ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/src/native",
-      "<rootDir>/src/primitives"
-    ]
-  },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ]
-  },
-  "pre-commit": "lint-staged",
-  "bundlesize": [
-    {
-      "path": "./dist/styled-components.min.js",
-      "threshold": "14kB"
-    }
-  ]
+    "keywords": [
+        "react",
+        "css",
+        "css-in-js",
+        "styled-components"
+    ],
+    "author": "Glen Maddern",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/styled-components/styled-components/issues"
+    },
+    "homepage": "https://styled-components.com",
+    "dependencies": {
+        "buffer": "^5.0.3",
+        "css-to-react-native": "^2.0.3",
+        "fbjs": "^0.8.9",
+        "hoist-non-react-statics": "^1.2.0",
+        "is-function": "^1.0.1",
+        "is-plain-object": "^2.0.1",
+        "prop-types": "^15.5.4",
+        "stylis": "^3.2.1",
+        "supports-color": "^3.2.3"
+    },
+    "devDependencies": {
+        "@types/react": "^15.0.25",
+        "@types/react-dom": "^15.5.0",
+        "@types/react-native": "^0.44.4",
+        "babel-cli": "^6.22.2",
+        "babel-core": "^6.17.0",
+        "babel-eslint": "^7.1.1",
+        "babel-loader": "^6.2.10",
+        "babel-plugin-add-module-exports": "^0.2.1",
+        "babel-plugin-external-helpers": "^6.22.0",
+        "babel-plugin-flow-react-proptypes": "^2.1.3",
+        "babel-plugin-transform-class-properties": "^6.22.0",
+        "babel-plugin-transform-flow-strip-types": "^6.22.0",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0",
+        "babel-plugin-transform-react-remove-prop-types": "^0.4.1",
+        "babel-preset-env": "^1.4.0",
+        "babel-preset-react": "^6.22.0",
+        "bundlesize": "^0.5.5",
+        "chokidar": "^1.6.0",
+        "danger": "^0.16.0",
+        "enzyme": "^2.8.2",
+        "eslint": "^3.15.0",
+        "eslint-config-airbnb": "^13.0.0",
+        "eslint-plugin-flowtype": "^2.30.0",
+        "eslint-plugin-flowtype-errors": "^2.0.1",
+        "eslint-plugin-import": "^2.2.0",
+        "eslint-plugin-jsx-a11y": "^2.0.2",
+        "eslint-plugin-react": "^6.8.0",
+        "express": "^4.14.1",
+        "flow-bin": "^0.47.0",
+        "flow-copy-source": "^1.1.0",
+        "flow-watch": "^1.1.1",
+        "jest": "^19.0.2",
+        "jsdom": "^9.10.0",
+        "lint-staged": "^3.3.0",
+        "node-watch": "^0.4.1",
+        "pre-commit": "^1.2.2",
+        "react": "^15.5.4",
+        "react-addons-test-utils": "^15.4.1",
+        "react-dom": "^15.5.4",
+        "react-native": "^0.39.2",
+        "react-primitives": "^0.4.2",
+        "rimraf": "^2.6.1",
+        "rollup": "^0.37.0",
+        "rollup-plugin-babel": "^2.7.1",
+        "rollup-plugin-commonjs": "^6.0.0",
+        "rollup-plugin-flow": "^1.1.1",
+        "rollup-plugin-inject": "^2.0.0",
+        "rollup-plugin-json": "^2.1.0",
+        "rollup-plugin-node-resolve": "^2.0.0",
+        "rollup-plugin-replace": "^1.1.1",
+        "rollup-plugin-uglify": "^1.0.1",
+        "rollup-plugin-visualizer": "^0.1.5",
+        "tslint": "^4.3.1",
+        "typescript": "^2.3.3"
+    },
+    "peerDependencies": {
+        "react": ">= 0.14.0 < 17.0.0-0"
+    },
+    "jest": {
+        "roots": [
+            "<rootDir>/src/"
+        ],
+        "testPathIgnorePatterns": [
+            "<rootDir>/src/native",
+            "<rootDir>/src/primitives"
+        ]
+    },
+    "lint-staged": {
+        "*.js": [
+            "eslint --fix",
+            "git add"
+        ]
+    },
+    "pre-commit": "lint-staged",
+    "bundlesize": [{
+        "path": "./dist/styled-components.min.js",
+        "threshold": "14kB"
+    }]
 }


### PR DESCRIPTION
This fixes #963 and runs the build process of `dist` and `lib` when either publishing or installing the package.