### PR TITLE
Improve TypeScript typings for withTheme HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "rollup-plugin-uglify": "^1.0.1",
     "rollup-plugin-visualizer": "^0.1.5",
     "tslint": "^4.3.1",
-    "typescript": "^2.3.3"
+    "typescript": "^2.4.1"
   },
   "peerDependencies": {
     "react": ">= 0.14.0 < 17.0.0-0"

--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "supports-color": "^3.2.3"
   },
   "devDependencies": {
-    "@types/react": "^15.0.25",
-    "@types/react-dom": "^15.5.0",
-    "@types/react-native": "^0.44.4",
+    "@types/react": "^15.0.37",
+    "@types/react-dom": "^15.5.1",
+    "@types/react-native": "^0.46.0",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.1.1",

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -84,7 +84,7 @@ export interface ThemedCssFunction<T> {
 // Helper type operators
 type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, 'theme'> & { theme?: T; };
+type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, "theme"> & { theme?: T; };
 
 export interface ThemedStyledComponentsModule<T> {
   default: ThemedStyledInterface<T>;

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -63,6 +63,7 @@ type ThemedStyledComponentFactoriesSVG<T> = {
 type ThemedStyledComponentFactories<T> = ThemedStyledComponentFactoriesHTML<T> & ThemedStyledComponentFactoriesSVG<T>;
 
 export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
+  <P extends { theme?: T; }>(component: Component<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
   <P>(component: Component<P>): ThemedStyledFunction<P, T>;
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
@@ -80,13 +81,18 @@ export interface ThemedCssFunction<T> {
   <P>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P, T>>[]): FlattenInterpolation<ThemedStyledProps<P, T>>[];
 }
 
+// Helper type operators
+type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, 'theme'> & { theme?: T; };
+
 export interface ThemedStyledComponentsModule<T> {
   default: ThemedStyledInterface<T>;
 
   css: ThemedCssFunction<T>;
   keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
   injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;
-  withTheme<P extends { theme?: T; }, T>(component: Component<P>): ComponentClass<P>;
+  withTheme<P extends { theme?: T; }>(component: Component<P>): ComponentClass<WithOptionalTheme<P, T>>;
 
   ThemeProvider: ThemeProviderComponent<T>;
 }
@@ -94,7 +100,7 @@ export interface ThemedStyledComponentsModule<T> {
 declare const styled: StyledInterface;
 
 export const css: ThemedCssFunction<any>;
-export function withTheme<P extends { theme?: T; }, T>(component: Component<P>): ComponentClass<P>;
+export function withTheme<P extends { theme?: T; }, T>(component: Component<P>): ComponentClass<WithOptionalTheme<P, T>>;
 
 export function keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
 export function injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;

--- a/typings/tests/main-test.tsx
+++ b/typings/tests/main-test.tsx
@@ -40,7 +40,7 @@ interface MyTheme {
 interface ButtonProps {
   name: string;
   primary?: boolean;
-  theme?: MyTheme;
+  theme: MyTheme;
 }
 
 class MyButton extends React.Component<ButtonProps, {}> {

--- a/typings/tests/themed-tests/mytheme-styled-components.tsx
+++ b/typings/tests/themed-tests/mytheme-styled-components.tsx
@@ -17,7 +17,7 @@ const {
 } = styledComponents as ThemedStyledComponentsModule<MyTheme>;
 
 interface ThemeProps {
-  theme?: MyTheme;
+  theme: MyTheme;
 }
 
 export default styled;

--- a/typings/tests/themed-tests/with-theme-test.tsx
+++ b/typings/tests/themed-tests/with-theme-test.tsx
@@ -22,4 +22,5 @@ const text = "hey";
 
 const MyThemedComponent = withTheme(MyComponent);
 
-<MyThemedComponent text={text} />;
+<MyThemedComponent text={text} />; // ok
+<MyThemedComponent text={text} theme={theme} />; // ok

--- a/typings/tests/with-theme-test.tsx
+++ b/typings/tests/with-theme-test.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+import styled, { withTheme } from "../..";
+
+interface Props {
+    theme: {
+        color: string;
+    };
+    text: string;
+}
+
+const Component = (props: Props) => <div style={{color: props.theme.color}}>{props.text}</div>;
+
+const ComponentWithTheme = withTheme(Component);
+
+<ComponentWithTheme text={"hi"} />; // ok
+<ComponentWithTheme text={"hi"} theme={{ color: "red" }} />; // ok

--- a/yarn.lock
+++ b/yarn.lock
@@ -6056,9 +6056,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.3.tgz#9639f3c3b40148e8ca97fe08a51dd1891bb6be22"
+typescript@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,21 @@
 # yarn lockfile v1
 
 
-"@types/react-dom@^15.5.0":
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-15.5.0.tgz#7f4fb9613d4051141773242f7b6b5f1a46b34bd9"
+"@types/react-dom@^15.5.1":
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-15.5.1.tgz#f3c3e14c682785923c7d64583537df319442dec1"
   dependencies:
     "@types/react" "*"
 
-"@types/react-native@^0.44.4":
-  version "0.44.4"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.44.4.tgz#91ff838293f87f5b27827164fc1efe5e528b6f5a"
+"@types/react-native@^0.46.0":
+  version "0.46.0"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.46.0.tgz#ac2846578c44e59223eb8b3808a5694e1c77ef8f"
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^15.0.25":
-  version "15.0.25"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.25.tgz#d396949cccc9a90b61755def9781e5aced9b2261"
+"@types/react@*", "@types/react@^15.0.37":
+  version "15.0.37"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.37.tgz#e6391cdd4ffce7050b8a290b23611a61f2411da5"
 
 abab@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
This PR slightly improves typings for TypeScript of `withTheme` HOC.

The issue with previous definitions was in the fact that TypeScript did not allow removing required property from a generic type. However, that is exactly what `withTheme` does with a component's contract. It takes a component that **needs** `theme` prop (encoded as a required prop in the component) and makes another component that simply gets the theme from the context, so basically it removes it from the contract. Following the implementation logic, `theme` is not really removed, it's being made optional (because a consumer can override the theme by passing it directly as a prop).

To work this constraint around, previously we used `theme` defined as an optional, which is obviously not what we wanted. Now, you can see this from test changes, it can be declared as required.

The change is based on [great type operator helpers](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766) by @Pinpickle that opened up this possibility.

Here's details on changes:
- typescript upgraded to 2.4.1; the helpers do not work on previous versions, but they are not introducing regression
- made tests of `withTheme` more strict, particularly made `theme` a required prop
- added overload of `styled` function to also act like `withTheme`; because, in fact, an inner component can rely on `theme` prop defined in the context.
- changed `withTheme` definition (themed and non-themed variations)
- removed `T` generic parameter from non-themed variation of `withTheme`, which was never working and looks like a type

/ping @styled-components/typers 