### PR TITLE
stopped transpiling and publishing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "npm run build:lib && npm run build:dist",
     "prebuild:lib": "rimraf lib/*",
-    "build:lib": "babel --out-dir lib src",
+    "build:lib": "babel --out-dir lib --ignore \"*.test.js\" src",
     "prebuild:dist": "rimraf dist/*",
     "build:dist": "rollup -c && rollup -c --environment ESBUNDLE && rollup -c --environment PRODUCTION",
     "build:watch": "npm run build:lib -- --watch",


### PR DESCRIPTION
I've changed to build scripts to stop transpiling and publishing the test files

- these files aren't actually used for tests (you're using `jest`)
- these files make the package take longer to install
- these files are inconsistent by distributing the tests for a single target (e.g. there no tests published for `es` or `umd`)
- these files force me to ignore `node_modules/styled-components` unless I `flow-typed install jest`