### PR TITLE
Add `styled-shortcuts` to readme under Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ We could use your help to get syntax highlighting support to other editors! If y
 - [styled-components-theme](https://github.com/erikras/styled-components-theme): A library for refering to theme colors and modifying them inline. e.g. `color: ${primary.lighten(0.3)};`
 - [styled-map](https://github.com/scf4/styled-map) - Super simple lib to map props to styles with `styled-components`
 - [styled-system](https://github.com/jxnblk/styled-system) - Design system utilities for styled-components – used in grid-styled and Rebass ([demo](http://jxnblk.com/styled-system/))
+- [styled-shortcuts](https://github.com/donavon/styled-shortcuts): Use simple string notation to access props. No functions necessary! Example: `font-size: ${'theme.fontSize:px'};` ([demo](https://codesandbox.io/s/jRE0XxR9v))
 
 ### Boilerplates
 - [react-redux-styled-hot-universal](https://github.com/krasevych/react-redux-styled-hot-universal) (SSR, Universal Webpack, Redux, React-router, Webpack 2, Babel, Styled Components and more...)


### PR DESCRIPTION
>- [styled-shortcuts](https://github.com/donavon/styled-shortcuts): The easiest of the "props helpers". Use simple string notation to access props. No functions necessary! Example: `font-size: ${'theme.fontSize:px'};` ([CodeSandbox](https://codesandbox.io/s/jRE0XxR9v))