### PR TITLE
Replace `$FlowInvalidInputTest` with `$FlowFixMe`.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,5 +17,4 @@
 
 [options]
 suppress_comment=.*\\$FlowFixMe
-suppress_comment=.*\\$FlowInvalidInputTest
 unsafe.enable_getters_and_setters=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. If a contri
 ## Unreleased
 
 - Upgrade stylis to 2.3 and use constructor to fix bugs with multiple libs using stylis simultaneously (see [#962](https://github.com/styled-components/styled-components/pull/962))
+- Replace `$FlowInvalidInputTest` with `$FlowFixMe`.  [#1004](https://github.com/styled-components/styled-components/pull/1004)
 
 ## [v2.1.0] - 2017-06-15
 

--- a/src/constructors/constructWithOptions.js
+++ b/src/constructors/constructWithOptions.js
@@ -6,7 +6,7 @@ export default (css: Function) => {
                                 tag: Target,
                                 options: Object = {}) => {
     if (typeof tag !== 'string' && typeof tag !== 'function') {
-      // $FlowInvalidInputTest
+      // $FlowFixMe
       throw new Error(`Cannot create styled-component for component: ${tag}`)
     }
 

--- a/src/no-parser/test/basic.test.js
+++ b/src/no-parser/test/basic.test.js
@@ -15,10 +15,10 @@ describe('basic', () => {
     const invalidComps = [undefined, null, 123, []]
     invalidComps.forEach(comp => {
       expect(() => {
-        // $FlowInvalidInputTest
+        // $FlowFixMe
         const Comp = styled(comp)
         shallow(<Comp />)
-        // $FlowInvalidInputTest
+        // $FlowFixMe
       }).toThrow(`Cannot create styled-component for component: ${comp}`)
     })
   })

--- a/src/no-parser/test/flatten.test.js
+++ b/src/no-parser/test/flatten.test.js
@@ -7,7 +7,7 @@ describe('preparsed flatten without executionContext', () => {
   })
 
   it('drops nulls', () => {
-    // $FlowInvalidInputTest
+    // $FlowFixMe
     expect(flatten([['foo', false, 'bar', undefined, 'baz', null]])).toEqual([['foo', 'bar', 'baz']])
   })
 
@@ -16,7 +16,7 @@ describe('preparsed flatten without executionContext', () => {
   })
 
   it('toStrings everything', () => {
-    // $FlowInvalidInputTest
+    // $FlowFixMe
     expect(flatten([[1, true]])).toEqual([['1', 'true']])
   })
 
@@ -66,7 +66,7 @@ describe('preparsed flatten with executionContext', () => {
   })
 
   it('drops nulls', () => {
-    // $FlowInvalidInputTest
+    // $FlowFixMe
     expect(flatten([['foo', false, 'bar', undefined, 'baz', null]], {})).toEqual(['foobarbaz'])
   })
 
@@ -75,7 +75,7 @@ describe('preparsed flatten with executionContext', () => {
   })
 
   it('toStrings everything', () => {
-    // $FlowInvalidInputTest
+    // $FlowFixMe
     expect(flatten([[1, true]], {})).toEqual(['1true'])
   })
 

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -22,10 +22,10 @@ describe('basic', () => {
     const invalidComps = [undefined, null, 123, []]
     invalidComps.forEach(comp => {
       expect(() => {
-        // $FlowInvalidInputTest
+        // $FlowFixMe
         const Comp = styled(comp)
         shallow(<Comp />)
-        // $FlowInvalidInputTest
+        // $FlowFixMe
       }).toThrow(`Cannot create styled-component for component: ${comp}`)
     })
   })

--- a/src/utils/test/flatten.test.js
+++ b/src/utils/test/flatten.test.js
@@ -6,14 +6,14 @@ describe('flatten', () => {
     expect(flatten(['foo', 'bar', 'baz'])).toEqual(['foo', 'bar', 'baz'])
   })
   it('drops nulls', () => {
-    // $FlowInvalidInputTest
+    // $FlowFixMe
     expect(flatten(['foo', false, 'bar', undefined, 'baz', null])).toEqual(['foo', 'bar', 'baz'])
   })
   it('doesnt drop any numbers', () => {
     expect(flatten(['foo', 0, 'bar', NaN, 'baz', -1])).toEqual(['foo', '0', 'bar', 'NaN', 'baz', '-1'])
   })
   it('toStrings everything', () => {
-    // $FlowInvalidInputTest
+    // $FlowFixMe
     expect(flatten([1, true])).toEqual(['1', 'true'])
   })
   it('hypenates objects', () => {


### PR DESCRIPTION
Just as the title says.  `$FlowInvalidInputTest` doesn't silence Flow errors in projects depending on `styled-components`, since it's in this package's `.flowconfig`.  And you already use `$FlowFixMe`.