### PR TITLE
Add warning when template literal is passed incorrectly to injectGlobal.

### DIFF
--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -6,7 +6,7 @@ import type { Interpolation, Stringifier } from '../types'
 export default (stringifyRules: Stringifier, css: Function) => {
   const injectGlobal = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
     if (typeof strings === 'string') {
-        // eslint-disable-next-line no-console
+      // eslint-disable-next-line no-console
       console.warn(
           'injectGlobal: Pass template literal strings without parentheses, global styles are not be applied. ',
         )

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -5,6 +5,12 @@ import type { Interpolation, Stringifier } from '../types'
 
 export default (stringifyRules: Stringifier, css: Function) => {
   const injectGlobal = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
+    if (typeof strings === 'string') {
+        // eslint-disable-next-line no-console
+      console.warn(
+          'injectGlobal: Pass template literal strings without parentheses, global styles are not be applied. ',
+        )
+    }
     const rules = css(strings, ...interpolations)
     const hash = hashStr(JSON.stringify(rules))
 

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -5,7 +5,7 @@ import type { Interpolation, Stringifier } from '../types'
 
 export default (stringifyRules: Stringifier, css: Function) => {
   const injectGlobal = (strings: Array<string>, ...interpolations: Array<Interpolation>) => {
-    if (typeof strings === 'string') {
+    if (process.env.NODE_ENV !== 'production' && !(Array.isArray(strings))) {
       // eslint-disable-next-line no-console
       console.warn(
           'injectGlobal: Pass template literal strings without parentheses, global styles are not be applied. ',


### PR DESCRIPTION
```
injectGlobal(`
  body {
    font-family: sans-serif;
  }
`);
```
:x: This raises a warning to not use parentheses.
```
injectGlobal`
  body {
    font-family: sans-serif;
  }
`;
```
 :+1:  Correct Way