### PR TITLE
Add .extend and .withComponent deterministic ID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Add react-native `ImageBackground` alias (see [#1028](https://github.com/styled-components/styled-components/pull/1028))
 
+- Add .extend and .withComponent deterministic ID generation (see [#1044](https://github.com/styled-components/styled-components/pull/1044))
+
 ## [v2.1.0] - 2017-06-15
 
 - Added missing v2.0 APIs to TypeScript typings, thanks to [@patrick91](https://github.com/patrick91), [@igorbek](https://github.com/igorbek) (see [#837](https://github.com/styled-components/styled-components/pull/837), [#882](https://github.com/styled-components/styled-components/pull/882))

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -225,7 +225,6 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
 
       static get extend() {
         const {
-          componentId: previousComponentId,
           rules: rulesFromOptions,
           ...optionsToCopy
         } = options
@@ -235,20 +234,22 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
             ? rules
             : rulesFromOptions.concat(rules)
 
-        const newComponentId =
-          previousComponentId &&
-          `${previousComponentId}-${ComponentStyle.generateName(
-            newRules.join(''),
-          )}`
-
         const newOptions = {
           ...optionsToCopy,
-          componentId: newComponentId,
           rules: newRules,
           ParentComponent: StyledComponent,
         }
 
-        return constructWithOptions(createStyledComponent, target, newOptions)
+        const createWithHash = (tag, opts, css) => {
+          const newOpts = opts.componentId ? {
+            ...opts,
+            componentId: `${opts.componentId}-${ComponentStyle.generateName(css.join(''))}`,
+          } : opts
+
+          return createStyledComponent(tag, newOpts, css)
+        }
+
+        return constructWithOptions(createWithHash, target, newOptions)
       }
     }
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -33,7 +33,9 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
 
     const hash = ComponentStyle.generateName(displayName + nr)
     const componentId = `${displayName}-${hash}`
-    return parentComponentId ? `${parentComponentId}-${componentId}` : componentId
+    return parentComponentId !== undefined
+      ? `${parentComponentId}-${componentId}`
+      : componentId
   }
 
   class BaseStyledComponent extends AbstractStyledComponent {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -208,25 +208,42 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       static target = target
 
       static withComponent(tag) {
-        const { displayName: _, componentId: __, ...optionsToCopy } = options
-        const newOptions = { ...optionsToCopy, ParentComponent: StyledComponent }
+        const { componentId: previousComponentId, ...optionsToCopy } = options
+
+        const newComponentId =
+          previousComponentId &&
+          `${previousComponentId}-${isTag(tag) ? tag : getComponentName(tag)}`
+
+        const newOptions = {
+          ...optionsToCopy,
+          componentId: newComponentId,
+          ParentComponent: StyledComponent,
+        }
+
         return createStyledComponent(tag, newOptions, rules)
       }
 
       static get extend() {
         const {
-          displayName: _,
-          componentId: __,
+          componentId: previousComponentId,
           rules: rulesFromOptions,
           ...optionsToCopy
         } = options
 
-        const newRules = rulesFromOptions === undefined
-          ? rules
-          : rulesFromOptions.concat(rules)
+        const newRules =
+          rulesFromOptions === undefined
+            ? rules
+            : rulesFromOptions.concat(rules)
+
+        const newComponentId =
+          previousComponentId &&
+          `${previousComponentId}-${ComponentStyle.generateName(
+            newRules.join(''),
+          )}`
 
         const newOptions = {
           ...optionsToCopy,
+          componentId: newComponentId,
           rules: newRules,
           ParentComponent: StyledComponent,
         }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -241,10 +241,15 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         }
 
         const createWithHash = (tag, opts, css) => {
-          const newOpts = opts.componentId ? {
-            ...opts,
-            componentId: `${opts.componentId}-${ComponentStyle.generateName(css.join(''))}`,
-          } : opts
+          let newOpts = opts
+          if (opts.componentId) {
+            const cssStr = css.map(rule => typeof rule === 'function' ? 'FUNC' : rule).join('')
+            const hash = ComponentStyle.generateName(cssStr)
+            newOpts = {
+              ...opts,
+              componentId: `${opts.componentId}-${hash}`,
+            }
+          }
 
           return createStyledComponent(tag, newOpts, css)
         }

--- a/src/test/expanded-api.test.js
+++ b/src/test/expanded-api.test.js
@@ -73,8 +73,8 @@ describe('expanded api', () => {
       `
       expect(Comp.styledComponentId).toBe('Comp-LOLOMG')
       expect(shallow(<Comp />).prop('className')).toMatch(/Comp-LOLOMG/)
-      expect(Comp2.styledComponentId).toBe('Comp-LOLOMG-a')
-      expect(shallow(<Comp2 bg="red" />).prop('className')).toMatch(/Comp-LOLOMG-a/)
+      expect(Comp2.styledComponentId).toBe('LOLOMG-Comp-a')
+      expect(shallow(<Comp2 bg="red" />).prop('className')).toMatch(/LOLOMG-Comp-a/)
     })
 
     it('should work with `.withComponent`', () => {

--- a/src/test/expanded-api.test.js
+++ b/src/test/expanded-api.test.js
@@ -62,6 +62,19 @@ describe('expanded api', () => {
       expect(Comp2.styledComponentId).toBe('Comp2-OMGLOL')
       expect(shallow(<Comp2 />).prop('className')).toMatch(/Comp2-OMGLOL/)
     })
+
+    it('should work with `.extend` and `.withComponent`', () => {
+      const Dummy = () => null
+      const Comp = styled.div.withConfig({ displayName: 'Comp', componentId: 'LOLOMG' })``.extend``
+      const Comp2 = styled.div.withConfig({ displayName: 'Comp2', componentId: 'OMGLOL' })``.withComponent('h1')
+      const Comp3 = styled.div.withConfig({ displayName: 'Comp3', componentId: 'OMFG' })``.withComponent(Dummy)
+      expect(Comp.styledComponentId).toBe('Comp-LOLOMG-a')
+      expect(shallow(<Comp />).prop('className')).toMatch(/Comp-LOLOMG-a/)
+      expect(Comp2.styledComponentId).toBe('Comp2-OMGLOL-h1')
+      expect(shallow(<Comp2 />).prop('className')).toMatch(/Comp2-OMGLOL-h1/)
+      expect(Comp3.styledComponentId).toBe('Comp3-OMFG-Dummy')
+      expect(shallow(<Comp3 />).prop('className')).toMatch(/Comp3-OMFG-Dummy/)
+    })
   })
 
   describe('chaining', () => {

--- a/src/test/expanded-api.test.js
+++ b/src/test/expanded-api.test.js
@@ -63,17 +63,28 @@ describe('expanded api', () => {
       expect(shallow(<Comp2 />).prop('className')).toMatch(/Comp2-OMGLOL/)
     })
 
-    it('should work with `.extend` and `.withComponent`', () => {
+    it.only('should work with `.extend`', () => {
+      const Comp = styled.div.withConfig({ displayName: 'Comp', componentId: 'LOLOMG' })`
+        color: blue;
+      `
+      const Comp2 = Comp.extend`
+        color: red;
+        background: ${props => props.bg};
+      `
+      expect(Comp.styledComponentId).toBe('Comp-LOLOMG')
+      expect(shallow(<Comp />).prop('className')).toMatch(/Comp-LOLOMG/)
+      expect(Comp2.styledComponentId).toBe('Comp-LOLOMG-a')
+      expect(shallow(<Comp2 bg="red" />).prop('className')).toMatch(/Comp-LOLOMG-a/)
+    })
+
+    it('should work with `.withComponent`', () => {
       const Dummy = () => null
-      const Comp = styled.div.withConfig({ displayName: 'Comp', componentId: 'LOLOMG' })``.extend``
-      const Comp2 = styled.div.withConfig({ displayName: 'Comp2', componentId: 'OMGLOL' })``.withComponent('h1')
-      const Comp3 = styled.div.withConfig({ displayName: 'Comp3', componentId: 'OMFG' })``.withComponent(Dummy)
-      expect(Comp.styledComponentId).toBe('Comp-LOLOMG-a')
-      expect(shallow(<Comp />).prop('className')).toMatch(/Comp-LOLOMG-a/)
-      expect(Comp2.styledComponentId).toBe('Comp2-OMGLOL-h1')
-      expect(shallow(<Comp2 />).prop('className')).toMatch(/Comp2-OMGLOL-h1/)
-      expect(Comp3.styledComponentId).toBe('Comp3-OMFG-Dummy')
-      expect(shallow(<Comp3 />).prop('className')).toMatch(/Comp3-OMFG-Dummy/)
+      const Comp = styled.div.withConfig({ displayName: 'Comp', componentId: 'OMGLOL' })``.withComponent('h1')
+      const Comp2 = styled.div.withConfig({ displayName: 'Comp2', componentId: 'OMFG' })``.withComponent(Dummy)
+      expect(Comp.styledComponentId).toBe('Comp-OMGLOL-h1')
+      expect(shallow(<Comp />).prop('className')).toMatch(/Comp-OMGLOL-h1/)
+      expect(Comp2.styledComponentId).toBe('Comp2-OMFG-Dummy')
+      expect(shallow(<Comp2 />).prop('className')).toMatch(/Comp2-OMFG-Dummy/)
     })
   })
 

--- a/src/test/expanded-api.test.js
+++ b/src/test/expanded-api.test.js
@@ -63,12 +63,12 @@ describe('expanded api', () => {
       expect(shallow(<Comp2 />).prop('className')).toMatch(/Comp2-OMGLOL/)
     })
 
-    it.only('should work with `.extend`', () => {
+    it('should work with `.extend`', () => {
       const Comp = styled.div.withConfig({ displayName: 'Comp', componentId: 'LOLOMG' })`
         color: blue;
       `
       const Comp2 = Comp.extend`
-        color: red;
+        color: ${'red'};
         background: ${props => props.bg};
       `
       expect(Comp.styledComponentId).toBe('Comp-LOLOMG')


### PR DESCRIPTION
Will fix #1031

I added a test with the new behaviour. This should fix server-side rendering issues with `.extend` and `.withComponent`.