### PR TITLE
Bug: Defining CSS Mixin below component throws Symbol error!

### DIFF
--- a/src/test/ssr.test.js
+++ b/src/test/ssr.test.js
@@ -4,13 +4,17 @@
 
 import React from 'react'
 import { renderToString } from 'react-dom/server'
+import { shallow  } from 'enzyme'
+
 import ServerStyleSheet from '../models/ServerStyleSheet'
 import { resetStyled } from './utils'
 import _injectGlobal from '../constructors/injectGlobal'
 import _keyframes from '../constructors/keyframes'
 import stringifyRules from '../utils/stringifyRules'
 import css from '../constructors/css'
+
 const injectGlobal = _injectGlobal(stringifyRules, css)
+
 
 let index = 0
 const keyframes = _keyframes(() => `keyframe_${index++}`, stringifyRules, css)
@@ -203,4 +207,39 @@ describe('ssr', () => {
     expect(elements[0].props.nonce).toBe('foo');
     expect(elements[1].props.nonce).toBe('foo');
   })
+
+  it('should apply styles to non-styled components using the component selector', () => {
+
+    const Text = (props) => (
+      <span className={props.className}>
+        {props.children}
+      </span>
+    );
+
+    const ButtonWithText = (props) => (
+      <button className={props.className}>
+        <Text>{props.children}</Text>
+      </button>
+    );
+
+
+    // This work work unless you placed it above Text
+    const ButtonStyle = css`
+      background: papayawhip;
+
+      ${Text} {
+        color: red;
+      }
+    `;
+
+    const StyledButton = styled(ButtonWithText)`
+        ${ButtonStyle}
+    `;
+
+    expect(() => {
+      shallow(
+        <StyledButton>Foobar</StyledButton>)
+      }
+    ).not.toThrow()
+  });
 })


### PR DESCRIPTION
#### Really strange bug but I've added a failing test.

Basically:

### This fails:

    const Text = (props) => (
      <span className={props.className}>
        {props.children}
      </span>
    );

    const ButtonWithText = (props) => (
      <button className={props.className}>
        <Text>{props.children}</Text>
      </button>
    );


    // This work work unless you placed it above Text
    const ButtonStyle = css`
      background: papayawhip;

      ${Text} {
        color: red;
      }
    `;

### This works:

    const ButtonStyle = css`
      background: papayawhip;

      ${Text} {
        color: red;
      }
    `;

    const Text = (props) => (
      <span className={props.className}>
        {props.children}
      </span>
    );

    const ButtonWithText = (props) => (
      <button className={props.className}>
        <Text>{props.children}</Text>
      </button>
    );


When it fails an error is thrown from flatten.js line 10 - I tracked it to this:
`if (isPlainObject(obj[key])) return objToCss(obj[key], key)`

Looks like it should be treating it similarly to being a plain object so I added a fix of also doing this if `typeof === 'Symbol' and whilst that cause the test to pass, it didn't create styles properly.

I don't have a big knowledge of the underlying code so I'm struggling to fix it properly by myself (happy to if pointed in the right direction) but this issue is a problem for my team using sc.
