### PR TITLE
feat(typescript): type domTag (HTML only) component factories

### DIFF
--- a/typings/built-in-component-factories.d.ts
+++ b/typings/built-in-component-factories.d.ts
@@ -1,0 +1,126 @@
+import {
+  WithOptionalTheme,
+  ThemedStyledFunction,
+} from './styled-components'
+
+type HTMLStyledComponentFactory<Theme, Props, Element> = ThemedStyledFunction<
+  Props,
+  Theme,
+  WithOptionalTheme<Props, Theme>
+>;
+
+export interface HTMLComponentFactory<Theme, Props extends { theme?: Theme; }> {
+  a: HTMLStyledComponentFactory<Theme, Props, HTMLAnchorElement>
+  abbr: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  address: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  area: HTMLStyledComponentFactory<Theme, Props, HTMLAreaElement>
+  article: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  aside: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  audio: HTMLStyledComponentFactory<Theme, Props, HTMLAudioElement>
+  b: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  base: HTMLStyledComponentFactory<Theme, Props, HTMLBaseElement>
+  bdi: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  bdo: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  big: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  blockquote: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  body: HTMLStyledComponentFactory<Theme, Props, HTMLBodyElement>
+  br: HTMLStyledComponentFactory<Theme, Props, HTMLBRElement>
+  button: HTMLStyledComponentFactory<Theme, Props, HTMLButtonElement>
+  canvas: HTMLStyledComponentFactory<Theme, Props, HTMLCanvasElement>
+  caption: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  cite: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  code: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  col: HTMLStyledComponentFactory<Theme, Props, HTMLTableColElement>
+  colgroup: HTMLStyledComponentFactory<Theme, Props, HTMLTableColElement>
+  data: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  datalist: HTMLStyledComponentFactory<Theme, Props, HTMLDataListElement>
+  dd: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  del: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  details: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  dfn: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  dialog: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  div: HTMLStyledComponentFactory<Theme, Props, HTMLDivElement>
+  dl: HTMLStyledComponentFactory<Theme, Props, HTMLDListElement>
+  dt: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  em: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  embed: HTMLStyledComponentFactory<Theme, Props, HTMLEmbedElement>
+  fieldset: HTMLStyledComponentFactory<Theme, Props, HTMLFieldSetElement>
+  figcaption: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  figure: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  footer: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  form: HTMLStyledComponentFactory<Theme, Props, HTMLFormElement>
+  h1: HTMLStyledComponentFactory<Theme, Props, HTMLHeadingElement>
+  h2: HTMLStyledComponentFactory<Theme, Props, HTMLHeadingElement>
+  h3: HTMLStyledComponentFactory<Theme, Props, HTMLHeadingElement>
+  h4: HTMLStyledComponentFactory<Theme, Props, HTMLHeadingElement>
+  h5: HTMLStyledComponentFactory<Theme, Props, HTMLHeadingElement>
+  h6: HTMLStyledComponentFactory<Theme, Props, HTMLHeadingElement>
+  head: HTMLStyledComponentFactory<Theme, Props, HTMLHeadElement>
+  header: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  hgroup: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  hr: HTMLStyledComponentFactory<Theme, Props, HTMLHRElement>
+  html: HTMLStyledComponentFactory<Theme, Props, HTMLHtmlElement>
+  i: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  iframe: HTMLStyledComponentFactory<Theme, Props, HTMLIFrameElement>
+  img: HTMLStyledComponentFactory<Theme, Props, HTMLImageElement>
+  input: HTMLStyledComponentFactory<Theme, Props, HTMLInputElement>
+  ins: HTMLStyledComponentFactory<Theme, Props, HTMLModElement>
+  kbd: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  keygen: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  label: HTMLStyledComponentFactory<Theme, Props, HTMLLabelElement>
+  legend: HTMLStyledComponentFactory<Theme, Props, HTMLLegendElement>
+  li: HTMLStyledComponentFactory<Theme, Props, HTMLLIElement>
+  link: HTMLStyledComponentFactory<Theme, Props, HTMLLinkElement>
+  main: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  map: HTMLStyledComponentFactory<Theme, Props, HTMLMapElement>
+  mark: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  menu: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  menuitem: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  meta: HTMLStyledComponentFactory<Theme, Props, HTMLMetaElement>
+  meter: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  nav: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  noscript: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  object: HTMLStyledComponentFactory<Theme, Props, HTMLObjectElement>
+  ol: HTMLStyledComponentFactory<Theme, Props, HTMLOListElement>
+  optgroup: HTMLStyledComponentFactory<Theme, Props, HTMLOptGroupElement>
+  option: HTMLStyledComponentFactory<Theme, Props, HTMLOptionElement>
+  output: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  p: HTMLStyledComponentFactory<Theme, Props, HTMLParagraphElement>
+  param: HTMLStyledComponentFactory<Theme, Props, HTMLParamElement>
+  picture: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  pre: HTMLStyledComponentFactory<Theme, Props, HTMLPreElement>
+  progress: HTMLStyledComponentFactory<Theme, Props, HTMLProgressElement>
+  q: HTMLStyledComponentFactory<Theme, Props, HTMLQuoteElement>
+  rp: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  rt: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  ruby: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  s: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  samp: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  script: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  section: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  select: HTMLStyledComponentFactory<Theme, Props, HTMLSelectElement>
+  small: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  source: HTMLStyledComponentFactory<Theme, Props, HTMLSourceElement>
+  span: HTMLStyledComponentFactory<Theme, Props, HTMLSpanElement>
+  strong: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  style: HTMLStyledComponentFactory<Theme, Props, HTMLStyleElement>
+  sub: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  summary: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  sup: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  table: HTMLStyledComponentFactory<Theme, Props, HTMLTableElement>
+  tbody: HTMLStyledComponentFactory<Theme, Props, HTMLTableSectionElement>
+  td: HTMLStyledComponentFactory<Theme, Props, HTMLTableDataCellElement>
+  textarea: HTMLStyledComponentFactory<Theme, Props, HTMLTextAreaElement>
+  tfoot: HTMLStyledComponentFactory<Theme, Props, HTMLTableSectionElement>
+  th: HTMLStyledComponentFactory<Theme, Props, HTMLTableHeaderCellElement>
+  thead: HTMLStyledComponentFactory<Theme, Props, HTMLTableSectionElement>
+  time: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  title: HTMLStyledComponentFactory<Theme, Props, HTMLTitleElement>
+  tr: HTMLStyledComponentFactory<Theme, Props, HTMLTableRowElement>
+  track: HTMLStyledComponentFactory<Theme, Props, HTMLTrackElement>
+  u: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  ul: HTMLStyledComponentFactory<Theme, Props, HTMLUListElement>
+  "var": HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+  video: HTMLStyledComponentFactory<Theme, Props, HTMLVideoElement>
+  wbr: HTMLStyledComponentFactory<Theme, Props, HTMLElement>
+}

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -65,6 +65,15 @@ type ThemedStyledComponentFactories<T> = ThemedStyledComponentFactoriesHTML<T> &
 export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
   <P extends { theme?: T; }>(component: Component<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
   <P>(component: Component<P>): ThemedStyledFunction<P, T>;
+
+  // Html styled component factories
+  <Props extends { theme?: T; }>(
+    domTag: keyof HTMLTags
+  ): ThemedStyledFunction<Props, T, WithOptionalTheme<Props, T>>;
+  <Props>(
+    domTag: keyof HTMLTags
+  ): ThemedStyledFunction<Props, T>;
+
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
 
@@ -84,7 +93,7 @@ export interface ThemedCssFunction<T> {
 // Helper type operators
 type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
-type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, "theme"> & { theme?: T; };
+export type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, "theme"> & { theme?: T; };
 
 export interface ThemedStyledComponentsModule<T> {
   default: ThemedStyledInterface<T>;

--- a/typings/tests/main-test.tsx
+++ b/typings/tests/main-test.tsx
@@ -3,12 +3,17 @@ import * as React from "react";
 import styled from "../..";
 import { css, keyframes, ThemeProvider, injectGlobal, withTheme, ServerStyleSheet } from "../..";
 
+interface TitleProps {
+  visible: boolean;
+}
+
 // Create a <Title> react component that renders an <h1> which is
 // centered, palevioletred and sized at 1.5em
-const Title = styled.h1`
+const Title = styled<TitleProps>("h1")`
   font-size: 1.5em;
   text-align: center;
   color: palevioletred;
+  display: ${props => props.visible ? "block" : "none" };
 `;
 
 // Create a <Wrapper> react component that renders a <section> with
@@ -102,7 +107,7 @@ class Example extends React.Component<{}, {}> {
   render() {
     return <ThemeProvider theme={theme}>
       <Wrapper>
-        <Title>Hello World, this is my first styled component!</Title>
+        <Title visible>Hello World, this is my first styled component!</Title>
 
         <Input placeholder="@mxstbr" type="text" />
         <TomatoButton name="demo" />


### PR DESCRIPTION
**What**:

Adding typing for styled function to accept dom (html only) node tags (with optional props).

**Why**:

This allows you to type props inside the tagged template string, and also use wittAttrs with dom tags.

**How**:

Extended the ThemedBaseStyledInterface interface with a new interace which has typing for all the HTML dom factories.

inspired by the glamorous typings https://github.com/paypal/glamorous/blob/master/typings/built-in-component-factories.d.ts

if this is okay, I'll proceed with adding the svg typings.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [ ] Ready to be merged

