### PR TITLE
Fix for 1068

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -63,8 +63,10 @@ type ThemedStyledComponentFactoriesSVG<T> = {
 type ThemedStyledComponentFactories<T> = ThemedStyledComponentFactoriesHTML<T> & ThemedStyledComponentFactoriesSVG<T>;
 
 export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
-  <P extends { theme?: T; }>(component: Component<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
-  <P>(component: Component<P>): ThemedStyledFunction<P, T>;
+  <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<P, T, O>;
+  <P extends { theme: T; }>(component: React.ComponentClass<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
+  <P>(component: React.ComponentClass<P>): ThemedStyledFunction<P, T>;
+  <P extends { [prop: string]: any; theme?: T; }>(component: React.StatelessComponent<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
 

--- a/typings/tests/issue1068.tsx
+++ b/typings/tests/issue1068.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import styled from "../..";
+
+interface Props {
+    text?: string;
+}
+
+const StatelessComponent = (props: Props) =>
+    <div>{props.text}</div>;
+const StyledStatelessComponent = styled(StatelessComponent)``;
+const StyledStatelessComponent2 = styled(StyledStatelessComponent)``;
+
+<StatelessComponent />;
+<StatelessComponent text="test" />;
+<StyledStatelessComponent text="test" />;
+<StyledStatelessComponent2 text="test" />;
+
+class PureComponent extends React.PureComponent<Props, {}> {
+    public render() {
+        return <div>{this.props.text}</div>;
+    }
+}
+
+const StyledPureComponent = styled(PureComponent)``;
+const StyledPureComponent2 = styled(StyledPureComponent)``;
+
+<PureComponent />;
+<PureComponent text="test" />;
+<StyledPureComponent text="test" />;
+<StyledPureComponent2 text="test" />;
+
+class ClassicComponent extends React.Component<Props, {}> {
+    public render() {
+        return <div>{this.props.text}</div>;
+    }
+}
+
+const StyledClassicComponent = styled(ClassicComponent)``;
+const StyledClassicComponent2 = styled(StyledClassicComponent)``;
+
+<StyledClassicComponent />;
+<StyledClassicComponent text="test" />;
+<StyledPureComponent text="test" />;
+<StyledClassicComponent2 text="test" />;

--- a/typings/tests/issue1068.tsx
+++ b/typings/tests/issue1068.tsx
@@ -1,44 +1,226 @@
 import * as React from "react";
 import styled from "../..";
 
-interface Props {
+interface OptionalProps {
     text?: string;
 }
+interface ThemedOptionalProps extends OptionalProps {
+    theme: any;
+}
+interface RequiredProps {
+    text: string;
+}
+interface ThemedRequiredProps extends RequiredProps {
+    theme: any;
+}
 
-const StatelessComponent = (props: Props) =>
-    <div>{props.text}</div>;
-const StyledStatelessComponent = styled(StatelessComponent)``;
-const StyledStatelessComponent2 = styled(StyledStatelessComponent)``;
+declare const theme: any;
 
-<StatelessComponent />;
-<StatelessComponent text="test" />;
-<StyledStatelessComponent text="test" />;
-<StyledStatelessComponent2 text="test" />;
+// Tests of stateless functional components
+function statelessFunctionalComponents() {
 
-class PureComponent extends React.PureComponent<Props, {}> {
-    public render() {
-        return <div>{this.props.text}</div>;
+    function optionalProps() {
+        const Component = (props: OptionalProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component />;
+        <Component text="test" />;
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function optionalPropsWithRequiredTheme() {
+        const Component = (props: ThemedOptionalProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredProps() {
+        const Component = (props: RequiredProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component />; // text required
+        <Component text="test" />;
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredPropsWithRequiredTheme() {
+        const Component = (props: ThemedRequiredProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text required
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+}
+
+// Tests of pure components
+function pureComponents() {
+
+    function optionalProps() {
+        class Component extends React.PureComponent<OptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component />;
+        <Component text="test" />;
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function optionalPropsWithRequiredTheme() {
+        class Component extends React.PureComponent<ThemedOptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredProps() {
+        class Component extends React.PureComponent<RequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component />; // text required
+        <Component text="test" />;
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredPropsWithRequiredTheme() {
+        class Component extends React.PureComponent<ThemedRequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text required
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
     }
 }
 
-const StyledPureComponent = styled(PureComponent)``;
-const StyledPureComponent2 = styled(StyledPureComponent)``;
+// Tests of classic components
+function classicComponents() {
 
-<PureComponent />;
-<PureComponent text="test" />;
-<StyledPureComponent text="test" />;
-<StyledPureComponent2 text="test" />;
+    function optionalProps() {
+        class Component extends React.Component<OptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
 
-class ClassicComponent extends React.Component<Props, {}> {
-    public render() {
-        return <div>{this.props.text}</div>;
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component />;
+        <Component text="test" />;
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function optionalPropsWithRequiredTheme() {
+        class Component extends React.Component<ThemedOptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredProps() {
+        class Component extends React.Component<RequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component />; // text required
+        <Component text="test" />;
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredPropsWithRequiredTheme() {
+        class Component extends React.Component<ThemedRequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text required
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
     }
 }
-
-const StyledClassicComponent = styled(ClassicComponent)``;
-const StyledClassicComponent2 = styled(StyledClassicComponent)``;
-
-<StyledClassicComponent />;
-<StyledClassicComponent text="test" />;
-<StyledPureComponent text="test" />;
-<StyledClassicComponent2 text="test" />;

--- a/typings/tests/themed-tests/issue1068.tsx
+++ b/typings/tests/themed-tests/issue1068.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import styled from "./mytheme-styled-components";
+
+interface Props {
+    text?: string;
+}
+
+const StatelessComponent = (props: Props) =>
+    <div>{props.text}</div>;
+const StyledStatelessComponent = styled(StatelessComponent)``;
+const StyledStatelessComponent2 = styled(StyledStatelessComponent)``;
+
+<StatelessComponent />;
+<StatelessComponent text="test" />;
+<StyledStatelessComponent text="test" />;
+<StyledStatelessComponent2 text="test" />;
+
+class PureComponent extends React.PureComponent<Props, {}> {
+    public render() {
+        return <div>{this.props.text}</div>;
+    }
+}
+
+const StyledPureComponent = styled(PureComponent)``;
+const StyledPureComponent2 = styled(StyledPureComponent)``;
+
+<PureComponent />;
+<PureComponent text="test" />;
+<StyledPureComponent text="test" />;
+<StyledPureComponent2 text="test" />;
+
+class ClassicComponent extends React.Component<Props, {}> {
+    public render() {
+        return <div>{this.props.text}</div>;
+    }
+}
+
+const StyledClassicComponent = styled(ClassicComponent)``;
+const StyledClassicComponent2 = styled(StyledClassicComponent)``;
+
+<StyledClassicComponent />;
+<StyledClassicComponent text="test" />;
+<StyledPureComponent text="test" />;
+<StyledClassicComponent2 text="test" />;

--- a/typings/tests/themed-tests/issue1068.tsx
+++ b/typings/tests/themed-tests/issue1068.tsx
@@ -1,44 +1,226 @@
 import * as React from "react";
-import styled from "./mytheme-styled-components";
+import styled, { MyTheme } from "./mytheme-styled-components";
 
-interface Props {
+interface OptionalProps {
     text?: string;
 }
+interface ThemedOptionalProps extends OptionalProps {
+    theme: MyTheme;
+}
+interface RequiredProps {
+    text: string;
+}
+interface ThemedRequiredProps extends RequiredProps {
+    theme: MyTheme;
+}
 
-const StatelessComponent = (props: Props) =>
-    <div>{props.text}</div>;
-const StyledStatelessComponent = styled(StatelessComponent)``;
-const StyledStatelessComponent2 = styled(StyledStatelessComponent)``;
+declare const theme: MyTheme;
 
-<StatelessComponent />;
-<StatelessComponent text="test" />;
-<StyledStatelessComponent text="test" />;
-<StyledStatelessComponent2 text="test" />;
+// Tests of stateless functional components
+function statelessFunctionalComponents() {
 
-class PureComponent extends React.PureComponent<Props, {}> {
-    public render() {
-        return <div>{this.props.text}</div>;
+    function optionalProps() {
+        const Component = (props: OptionalProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component />;
+        <Component text="test" />;
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function optionalPropsWithRequiredTheme() {
+        const Component = (props: ThemedOptionalProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredProps() {
+        const Component = (props: RequiredProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component />; // text required
+        <Component text="test" />;
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredPropsWithRequiredTheme() {
+        const Component = (props: ThemedRequiredProps) => <div>{props.text}</div>;
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text required
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+}
+
+// Tests of pure components
+function pureComponents() {
+
+    function optionalProps() {
+        class Component extends React.PureComponent<OptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component />;
+        <Component text="test" />;
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function optionalPropsWithRequiredTheme() {
+        class Component extends React.PureComponent<ThemedOptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredProps() {
+        class Component extends React.PureComponent<RequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component />; // text required
+        <Component text="test" />;
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredPropsWithRequiredTheme() {
+        class Component extends React.PureComponent<ThemedRequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text required
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
     }
 }
 
-const StyledPureComponent = styled(PureComponent)``;
-const StyledPureComponent2 = styled(StyledPureComponent)``;
+// Tests of classic components
+function classicComponents() {
 
-<PureComponent />;
-<PureComponent text="test" />;
-<StyledPureComponent text="test" />;
-<StyledPureComponent2 text="test" />;
+    function optionalProps() {
+        class Component extends React.Component<OptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
 
-class ClassicComponent extends React.Component<Props, {}> {
-    public render() {
-        return <div>{this.props.text}</div>;
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component />;
+        <Component text="test" />;
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function optionalPropsWithRequiredTheme() {
+        class Component extends React.Component<ThemedOptionalProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredProps() {
+        class Component extends React.Component<RequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component />; // text required
+        <Component text="test" />;
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />;
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text allowed
+        <StyledStyledComponent text="test" />;
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
+    }
+
+    function requiredPropsWithRequiredTheme() {
+        class Component extends React.Component<ThemedRequiredProps> {
+            render() { return <div>{this.props.text}</div>; }
+        }
+
+        const StyledComponent = styled(Component)``;
+        const StyledStyledComponent = styled(StyledComponent)``;
+
+        // <Component theme={theme} />; // theme is required
+        <Component text="test" theme={theme} />; // theme is required
+        // <StyledComponent />; // text required
+        <StyledComponent text="test" />; // theme is optional
+        <StyledComponent text="test" theme={theme} />; // theme is allowed
+        // <StyledStyledComponent />; // text required
+        <StyledStyledComponent text="test" />; // theme is optional
+        <StyledStyledComponent text="test" theme={theme} />; // theme is allowed
     }
 }
-
-const StyledClassicComponent = styled(ClassicComponent)``;
-const StyledClassicComponent2 = styled(StyledClassicComponent)``;
-
-<StyledClassicComponent />;
-<StyledClassicComponent text="test" />;
-<StyledPureComponent text="test" />;
-<StyledClassicComponent2 text="test" />;


### PR DESCRIPTION
This PR fixes #1068 and maybe others related

The main cause was in the fact that React's stateless functional components are contravariant on their prop types. And when the previous constraint `P extends { theme?: T; }` was not met by new aggressive exceed property checks, TypeScript fell back to the constraint itself which only had optional fields, and because of contravariance they were structurally assignable.

This PR improves typing of `styled` making class components special case and working around exceed property check for stateless functional components.