### PR TITLE
Allow specifying the target element for appending style tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Fixed nonce missing from global styles (see [#1088](https://github.com/styled-components/styled-components/pull/1088))
 - Improve component mount and unmount performance with changes to `createBroadcast`. Deprecates usage of `CHANNEL` as a function, will be update to `CHANNEL_NEXT`'s propType in a future version. (see [#1048](https://github.com/styled-components/styled-components/pull/1048))
 - Fixed comments in react-native (see [#1041](https://github.com/styled-components/styled-components/pull/1041))
+- Add `target` prop to `StyleSheetManager` component to enable specifying where style tags should render (see [#1102](https://github.com/styled-components/styled-components/pull/1102))
 
 ## [v2.1.2] - 2017-08-04
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
 import ServerStyleSheet from './models/ServerStyleSheet'
 import StyleSheetManager from './models/StyleSheetManager'
+import StyleSheet from './models/StyleSheet'
 
 /* Import singleton constructors */
 import _StyledComponent from './models/StyledComponent'
@@ -42,4 +43,5 @@ export {
   withTheme,
   ServerStyleSheet,
   StyleSheetManager,
+  StyleSheet,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,6 @@ import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
 import ServerStyleSheet from './models/ServerStyleSheet'
 import StyleSheetManager from './models/StyleSheetManager'
-import StyleSheet from './models/StyleSheet'
-import { tagConstructorWithTarget } from './models/BrowserStyleSheet'
 
 /* Import singleton constructors */
 import _StyledComponent from './models/StyledComponent'
@@ -44,6 +42,4 @@ export {
   withTheme,
   ServerStyleSheet,
   StyleSheetManager,
-  StyleSheet,
-  tagConstructorWithTarget,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import css from './constructors/css'
 import ServerStyleSheet from './models/ServerStyleSheet'
 import StyleSheetManager from './models/StyleSheetManager'
 import StyleSheet from './models/StyleSheet'
+import { tagConstructorWithTarget } from './models/BrowserStyleSheet'
 
 /* Import singleton constructors */
 import _StyledComponent from './models/StyledComponent'
@@ -44,4 +45,5 @@ export {
   ServerStyleSheet,
   StyleSheetManager,
   StyleSheet,
+  tagConstructorWithTarget,
 }

--- a/src/models/BrowserStyleSheet.js
+++ b/src/models/BrowserStyleSheet.js
@@ -115,6 +115,20 @@ class BrowserTag implements Tag {
   }
 }
 
+/* Factory for making more tags */
+export function tagConstructorWithTarget(target?: HTMLElement): Function {
+  return function tagConstructor(isLocal: boolean): Tag {
+    const el = document.createElement('style')
+    el.type = 'text/css'
+    el.setAttribute(SC_ATTR, '')
+    el.setAttribute(LOCAL_ATTR, isLocal ? 'true' : 'false')
+    const targ = target || document.head
+    if (!targ) throw new Error('Missing document <head>')
+    targ.appendChild(el)
+    return new BrowserTag(el, isLocal)
+  }
+}
+
 /* Factory function to separate DOM operations from logical ones*/
 export default {
   create() {
@@ -138,17 +152,6 @@ export default {
       }
     }
 
-    /* Factory for making more tags */
-    const tagConstructor = (isLocal: boolean): Tag => {
-      const el = document.createElement('style')
-      el.type = 'text/css'
-      el.setAttribute(SC_ATTR, '')
-      el.setAttribute(LOCAL_ATTR, isLocal ? 'true' : 'false')
-      if (!document.head) throw new Error('Missing document <head>')
-      document.head.appendChild(el)
-      return new BrowserTag(el, isLocal)
-    }
-
-    return new StyleSheet(tagConstructor, tags, names)
+    return new StyleSheet(tagConstructorWithTarget(), tags, names)
   },
 }

--- a/src/models/StyleSheetManager.js
+++ b/src/models/StyleSheetManager.js
@@ -2,10 +2,27 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import StyleSheet, { CONTEXT_KEY } from './StyleSheet'
+import { tagConstructorWithTarget } from './BrowserStyleSheet'
 
 class StyleSheetManager extends Component {
+  sheetInstance: StyleSheet
+  props: {
+    sheet?: StyleSheet | null,
+    target?: HTMLElement | null
+  }
+
   getChildContext() {
-    return { [CONTEXT_KEY]: this.props.sheet }
+    return { [CONTEXT_KEY]: this.sheetInstance }
+  }
+
+  componentWillMount() {
+    if (this.props.sheet) {
+      this.sheetInstance = this.props.sheet
+    } else if (this.props.target) {
+      this.sheetInstance = new StyleSheet(tagConstructorWithTarget(this.props.target))
+    } else {
+      throw new Error('StyleSheetManager expects either a sheet or target prop')
+    }
   }
 
   render() {
@@ -22,7 +39,10 @@ StyleSheetManager.childContextTypes = {
 }
 
 StyleSheetManager.propTypes = {
-  sheet: PropTypes.instanceOf(StyleSheet).isRequired,
+  sheet: PropTypes.instanceOf(StyleSheet),
+  target: PropTypes.shape({
+    appendChild: PropTypes.func.isRequired,
+  }),
 }
 
 export default StyleSheetManager

--- a/src/models/test/StyleSheetManager.test.js
+++ b/src/models/test/StyleSheetManager.test.js
@@ -1,0 +1,76 @@
+// @flow
+/* eslint-disable react/no-multi-comp */
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { shallow, mount } from 'enzyme'
+import styled, { ServerStyleSheet, StyleSheetManager } from '../../index'
+
+describe('StyleSheetManager', () => {
+  it('should render its child', () => {
+    const target = document.head
+    const Title = styled.h1`color: palevioletred;`
+    const child = <Title />
+    const renderedComp = shallow(
+      <StyleSheetManager target={target}>
+        { child }
+      </StyleSheetManager>
+    )
+    expect(renderedComp.contains(child)).toEqual(true)
+  })
+
+  // it('should use given stylesheet instance', (done) => {
+  //   const sheet = new ServerStyleSheet()
+  //   const Title = styled.h1`color: palevioletred;`
+  //   renderToString(
+  //     <StyleSheetManager sheet={sheet}>
+  //       <Title />
+  //     </StyleSheetManager>
+  //   )
+  //   expect(sheet.getStyleTags().includes(`palevioletred`)).toEqual(true)
+  // })
+
+  it('should append style to given target', (done) => {
+    const target = document.body
+    const Title = styled.h1`color: palevioletred;`
+    class Child extends React.Component {
+      componentDidMount() {
+        // $FlowFixMe
+        const styles = target.querySelector('style').textContent
+        expect(styles.includes(`palevioletred`)).toEqual(true)
+        done();
+      }
+      render() { return <Title /> }
+    }
+    mount(
+      <StyleSheetManager target={target}>
+        <Child />
+      </StyleSheetManager>
+    )
+  })
+
+  it('should append style to given target in iframe', (done) => {
+    const iframe = document.createElement('iframe')
+    const app = document.createElement('div')
+    // $FlowFixMe
+    document.body.appendChild(iframe)
+    // $FlowFixMe
+    iframe.contentDocument.body.appendChild(app)
+    const target = iframe.contentDocument.head
+    const Title = styled.h1`color: palevioletred;`
+    class Child extends React.Component {
+      componentDidMount() {
+        // $FlowFixMe
+        const styles = target.querySelector('style').textContent
+        expect(styles.includes(`palevioletred`)).toEqual(true)
+        done();
+      }
+      render() { return <Title /> }
+    }
+    mount(
+      <StyleSheetManager target={target}>
+        <Child />
+      </StyleSheetManager>,
+      { attachTo: app }
+    )
+  })
+})

--- a/src/models/test/StyleSheetManager.test.js
+++ b/src/models/test/StyleSheetManager.test.js
@@ -6,6 +6,18 @@ import { shallow, mount } from 'enzyme'
 import styled, { ServerStyleSheet, StyleSheetManager } from '../../index'
 
 describe('StyleSheetManager', () => {
+
+  it('should use given stylesheet instance', () => {
+    const sheet = new ServerStyleSheet()
+    const Title = styled.h1`color: palevioletred;`
+    renderToString(
+      <StyleSheetManager sheet={sheet.instance}>
+        <Title />
+      </StyleSheetManager>
+    )
+    expect(sheet.getStyleTags().includes(`palevioletred`)).toEqual(true)
+  })
+
   it('should render its child', () => {
     const target = document.head
     const Title = styled.h1`color: palevioletred;`
@@ -18,18 +30,7 @@ describe('StyleSheetManager', () => {
     expect(renderedComp.contains(child)).toEqual(true)
   })
 
-  // it('should use given stylesheet instance', (done) => {
-  //   const sheet = new ServerStyleSheet()
-  //   const Title = styled.h1`color: palevioletred;`
-  //   renderToString(
-  //     <StyleSheetManager sheet={sheet}>
-  //       <Title />
-  //     </StyleSheetManager>
-  //   )
-  //   expect(sheet.getStyleTags().includes(`palevioletred`)).toEqual(true)
-  // })
-
-  it('should append style to given target', (done) => {
+  it('should append style to given target', () => {
     const target = document.body
     const Title = styled.h1`color: palevioletred;`
     class Child extends React.Component {
@@ -37,7 +38,6 @@ describe('StyleSheetManager', () => {
         // $FlowFixMe
         const styles = target.querySelector('style').textContent
         expect(styles.includes(`palevioletred`)).toEqual(true)
-        done();
       }
       render() { return <Title /> }
     }
@@ -48,7 +48,7 @@ describe('StyleSheetManager', () => {
     )
   })
 
-  it('should append style to given target in iframe', (done) => {
+  it('should append style to given target in iframe', () => {
     const iframe = document.createElement('iframe')
     const app = document.createElement('div')
     // $FlowFixMe
@@ -62,7 +62,6 @@ describe('StyleSheetManager', () => {
         // $FlowFixMe
         const styles = target.querySelector('style').textContent
         expect(styles.includes(`palevioletred`)).toEqual(true)
-        done();
       }
       render() { return <Title /> }
     }


### PR DESCRIPTION
Allows specifying any element to append stye tags to, rather than `document.head`. In combination with `StyleSheetManager` it allows you to specify where all children CSS should be appended.

This is especially useful for apps that use iframes or shadow dom. See https://github.com/styled-components/styled-components/issues/659

For example:
```js
import React from "react";
import ReactDOM from "react-dom";
import PropTypes from "prop-types";
import { StyleSheetManager, StyleSheet, tagConstructorWithTarget } from "styled-components";

export default class StyleManager extends React.Component {
  static propTypes = {
    children: PropTypes.element.isRequired
  };

  constructor(props) {
    super(props);
    const target = document.querySelector('#iframe').contentDocument.head;
    this.stylesheetInstance = new StyleSheet(tagConstructorWithTarget(target));
  }

  render() {
    return (
      <StyleSheetManager sheet={this.stylesheetInstance}>
        {this.props.children}
      </StyleSheetManager>
    );
  }
}
```

I've tried to keep the changes as minimal as possible, but I recognise exporting `StyleSheet` and `tagConstructorWithTarget` isn't ideal since it increases API surface area.

Let me know if there's anything I can do to get this merged.