### PR TITLE
fix: coalesce tags with similar locality prior to injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Improve component mount and unmount performance with changes to `createBroadcast`. Deprecates usage of `CHANNEL` as a function, will be update to `CHANNEL_NEXT`'s propType in a future version. (see [#1048](https://github.com/styled-components/styled-components/pull/1048))
 - Fixed comments in react-native (see [#1041](https://github.com/styled-components/styled-components/pull/1041))
+- Reduce the number of injected style tags when using many types of injection (component style, `injectGlobal`, etc) interleaved in a single component tree (see [#1117](https://github.com/styled-components/styled-components/pull/1117))
 
 ## [v2.1.2] - 2017-08-04
 

--- a/src/test/__snapshots__/ssr.test.js.snap
+++ b/src/test/__snapshots__/ssr.test.js.snap
@@ -17,12 +17,12 @@ exports[`ssr should allow global styles to be injected during rendering 1`] = `"
 exports[`ssr should allow global styles to be injected during rendering 2`] = `
 "<style type=\\"text/css\\" data-styled-components=\\"\\" data-styled-components-is-local=\\"false\\">/* sc-component-id: sc-global-737874422 */
 html::before{content: 'Before both renders';}
+/* sc-component-id: sc-global-2914197427 */
+html::before{content: 'During first render';}
 </style><style type=\\"text/css\\" data-styled-components=\\"a\\" data-styled-components-is-local=\\"true\\">/* sc-component-id: PageOne */
 .PageOne {}
 
 .a{color: red;}
-</style><style type=\\"text/css\\" data-styled-components=\\"\\" data-styled-components-is-local=\\"false\\">/* sc-component-id: sc-global-2914197427 */
-html::before{content: 'During first render';}
 </style>"
 `;
 
@@ -31,16 +31,16 @@ exports[`ssr should allow global styles to be injected during rendering 3`] = `"
 exports[`ssr should allow global styles to be injected during rendering 4`] = `
 "<style type=\\"text/css\\" data-styled-components=\\"\\" data-styled-components-is-local=\\"false\\">/* sc-component-id: sc-global-737874422 */
 html::before{content: 'Before both renders';}
-</style><style type=\\"text/css\\" data-styled-components=\\"b\\" data-styled-components-is-local=\\"true\\">/* sc-component-id: PageTwo */
-.PageTwo {}
-
-.b{color: blue;}
-</style><style type=\\"text/css\\" data-styled-components=\\"\\" data-styled-components-is-local=\\"false\\">/* sc-component-id: sc-global-2914197427 */
+/* sc-component-id: sc-global-2914197427 */
 html::before{content: 'During first render';}
 /* sc-component-id: sc-global-1207956261 */
 html::before{content: 'Between renders';}
 /* sc-component-id: sc-global-3990873394 */
 html::before{content: 'During second render';}
+</style><style type=\\"text/css\\" data-styled-components=\\"b\\" data-styled-components-is-local=\\"true\\">/* sc-component-id: PageTwo */
+.PageTwo {}
+
+.b{color: blue;}
 </style>"
 `;
 

--- a/src/test/rehydration.test.js
+++ b/src/test/rehydration.test.js
@@ -179,16 +179,15 @@ describe('rehydration', () => {
       expectCSSMatches('body { background: papayawhip; } .TWO {} .b { color: red; }')
     })
 
-    it('should inject new global styles at the end', () => {
+    it('should inject new global styles after the existing ones', () => {
       injectGlobal`
         body { color: tomato; }
       `
-      expectCSSMatches('body { background: papayawhip; } .TWO {} .b { color: red; } body { color: tomato; }')
+      expectCSSMatches('body { background: papayawhip; } body { color: tomato; } .TWO {} .b { color: red; }')
 
       expect(getStyleTags()).toEqual([
-        { isLocal: 'false', css: '/* sc-component-id: sc-global-557410406 */ body { background: papayawhip; }', },
+        { isLocal: 'false', css: '/* sc-component-id: sc-global-557410406 */ body { background: papayawhip; } /* sc-component-id: sc-global-2299393384 */ body{color: tomato;}', },
         { isLocal: 'true', css: '/* sc-component-id: TWO */ .TWO {} .b { color: red; }', },
-        { isLocal: 'false', css: '/* sc-component-id: sc-global-2299393384 */ body{color: tomato;}', },
       ])
     })
 
@@ -199,12 +198,10 @@ describe('rehydration', () => {
       const A = styled.div.withConfig({ componentId: 'ONE' })`color: blue;`
       shallow(<A />)
 
-      expectCSSMatches('body { background: papayawhip; } .TWO {} .b { color: red; } body { color: tomato; } .ONE { } .a { color: blue; }')
+      expectCSSMatches('body { background: papayawhip; } body { color: tomato; } .TWO {} .b { color: red; } .ONE { } .a { color: blue; }')
       expect(getStyleTags()).toEqual([
-        { isLocal: 'false', css: '/* sc-component-id: sc-global-557410406 */ body { background: papayawhip; }', },
-        { isLocal: 'true', css: '/* sc-component-id: TWO */ .TWO {} .b { color: red; }', },
-        { isLocal: 'false', css: '/* sc-component-id: sc-global-2299393384 */ body{color: tomato;}', },
-        { isLocal: 'true', css: '/* sc-component-id: ONE */ .ONE {} .a{color: blue;}', },
+        { isLocal: 'false', css: '/* sc-component-id: sc-global-557410406 */ body { background: papayawhip; } /* sc-component-id: sc-global-2299393384 */ body{color: tomato;}', },
+        { isLocal: 'true', css: '/* sc-component-id: TWO */ .TWO {} .b { color: red; } /* sc-component-id: ONE */ .ONE {} .a{color: blue;}', },
       ])
     })
   })

--- a/src/test/ssr.test.js
+++ b/src/test/ssr.test.js
@@ -203,4 +203,55 @@ describe('ssr', () => {
     expect(elements[0].props.nonce).toBe('foo');
     expect(elements[1].props.nonce).toBe('foo');
   })
+
+  it('should group nonlocal and local styles into single stylesheets', () => {
+    injectGlobal`
+      body { background: papayawhip; }
+    `
+    const Heading = styled.h1`
+      color: red;
+    `
+
+    injectGlobal`
+      body { color: gainsboro; }
+    `
+
+    const Box = styled.div`
+      background: blue;
+      height: 10px;
+      width: 10px;
+    `
+
+    const sheet = new ServerStyleSheet()
+
+    renderToString(sheet.collectStyles(<Heading>Hello SSR! <Box /></Heading>))
+    const elements = sheet.getStyleElement()
+
+    expect(elements).toHaveLength(2)
+    expect(elements[0].props['data-styled-components-is-local']).toBe('false')
+    expect(elements[1].props['data-styled-components-is-local']).toBe('true')
+  })
+
+  it('should always inject non-local stylesheets first', () => {
+    const Heading = styled.h1`
+      color: red;
+    `
+
+    injectGlobal`
+      body { background: papayawhip; }
+    `
+
+    injectGlobal`
+      body { color: gainsboro; }
+    `
+
+    const sheet = new ServerStyleSheet()
+
+    renderToString(sheet.collectStyles(<Heading>Hello SSR!</Heading>))
+    const elements = sheet.getStyleElement()
+
+    expect(elements).toHaveLength(2)
+    expect(elements[0].props['data-styled-components-is-local']).toBe('false')
+    expect(elements[1].props['data-styled-components-is-local']).toBe('true')
+  })
 })


### PR DESCRIPTION
Prior to an injection run being completed, it's safe to concatenate non-local styles together into a single style element and likewise with local component styles. This helps reduce the overall number
of injected style tags in a highly diverse component tree.

Fixes #1108 