### PR TITLE
Fix rollup build failing

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,6 +42,7 @@ const plugins = [
     },
   },
   flow(),
+  json(),
   nodeResolve(),
   commonjs({
     ignoreGlobal: true,
@@ -67,7 +68,6 @@ const plugins = [
       'transform-class-properties',
     ].filter(Boolean),
   }),
-  json(),
 ]
 
 if (prod) plugins.push(uglify(), visualizer({ filename: './bundle-stats.html' }))


### PR DESCRIPTION
Rollup was failing because some plugin was trying to import `package.json` as a javascript module, which obviously threw a syntax error.

Fixed by moving `json()` above the other plugins.