### PR TITLE
Proposal: Top-level configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. If a contri
 
 *The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).*
 
+## Experimental
+
+- Configuration endpoint & ability to disable autoprefixing
+
 ## Unreleased
 
 - Fixed nonce missing from global styles (see [#1088](https://github.com/styled-components/styled-components/pull/1088))

--- a/config.js
+++ b/config.js
@@ -1,2 +1,24 @@
-/* eslint-disable */
-module.exports = require('./lib/config')
+/* Styled Components top level default configuration.
+ *
+ * Allows for some settings to be overridden before SC is
+ * loaded. I.e. you must import 'styled-components/config'
+ * BEFORE importing 'styled-components'
+ *
+ * For more information, see [DOCUMENTATION URL]
+ */
+
+var config = {
+  prefix_css: true,
+}
+
+var config_already_read = false
+exports.configure = function configure(overrides) {
+  if (config_already_read) throw new Error("Can only configure Styled Components before you've used it!")
+  var new_configuration = typeof overrides === 'function' ? overrides(config) : overrides
+  Object.keys(new_configuration).forEach(key => config[key] = new_configuration[key])
+}
+
+exports.getConfiguration = function getConfiguration() {
+  config_already_read = true
+  return config
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = require('./lib/config')

--- a/config.js
+++ b/config.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /* Styled Components top level default configuration.
  *
  * Allows for some settings to be overridden before SC is
@@ -7,15 +8,16 @@
  * For more information, see [DOCUMENTATION URL]
  */
 
-var config = {
+const config = {
   prefix_css: true,
 }
 
-var config_already_read = false
+let config_already_read = false
 exports.configure = function configure(overrides) {
   if (config_already_read) throw new Error("Can only configure Styled Components before you've used it!")
-  var new_configuration = typeof overrides === 'function' ? overrides(config) : overrides
-  Object.keys(new_configuration).forEach(key => config[key] = new_configuration[key])
+  Object.keys(overrides).forEach((key) => {
+    config[key] = overrides[key]
+  })
 }
 
 exports.getConfiguration = function getConfiguration() {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "build": "npm run build:lib && npm run build:dist",
     "prebuild:lib": "rimraf lib/*",
     "build:lib": "babel --out-dir lib --ignore \"*.test.js\" src",
+    "prebuild:es6": "rimraf dist/*",
+    "build:es6": "rollup -c --environment ESBUNDLE",
+    "build:es6:watch": "npm run build:es6 -- -w",
     "prebuild:dist": "rimraf dist/*",
     "build:dist": "rollup -c && rollup -c --environment ESBUNDLE && rollup -c --environment PRODUCTION",
     "build:watch": "npm run build:lib -- --watch",
@@ -122,6 +125,7 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^1.0.1",
     "rollup-plugin-visualizer": "^0.1.5",
+    "rollup-watch": "^4.3.1",
     "tslint": "^4.3.1",
     "typescript": "^2.4.1"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,19 +1,9 @@
-console.log('CONFIG FILE BEING LOADED')
+/* This loads the configuration (possibly after it has been changed)
+ * and exports the current values.
+ *
+ * It needs to be calling 'require' otherwise Rollup would inline it
+ * and the config method wouldn't work.
+ */
+const config = require('../config')
 
-const omg = {
-  hax: false,
-  touched: false,
-}
-
-export const config = () => {
-  console.log('EXEC CONFIG')
-  omg.touched = true
-  return omg
-}
-
-export default () => {
-  if (omg.touched) throw new Error("Can only configure Styled Components before you've used it!")
-  console.log('EXEC HAX')
-  omg.hax = true
-  console.log(omg)
-}
+export default config.getConfiguration()

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,19 @@
+console.log('CONFIG FILE BEING LOADED')
+
+const omg = {
+  hax: false,
+  touched: false,
+}
+
+export const config = () => {
+  console.log('EXEC CONFIG')
+  omg.touched = true
+  return omg
+}
+
+export default () => {
+  if (omg.touched) throw new Error("Can only configure Styled Components before you've used it!")
+  console.log('EXEC HAX')
+  omg.hax = true
+  console.log(omg)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 // @flow
+console.log('SC INDEX LOADING')
+const config = require('../config')
+console.log(config.config())
 
 /* Import singletons */
 import flatten from './utils/flatten'

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,4 @@
 // @flow
-console.log('SC INDEX LOADING')
-const config = require('../config')
-console.log(config.config())
 
 /* Import singletons */
 import flatten from './utils/flatten'

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -1,12 +1,13 @@
 // @flow
 import Stylis from 'stylis'
 import type { Interpolation } from '../types'
+import config from '../config'
 
 const stylis = new Stylis({
   global: false,
   cascade: true,
   keyframe: false,
-  prefix: true,
+  prefix: config.prefix_css,
   compress: false,
   semicolon: true,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,7 +1260,7 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-bundlesize@0.13.2:
+bundlesize@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/bundlesize/-/bundlesize-0.13.2.tgz#3a8aa61aa9f6d54f63321e2dfc7aa7716f91e73f"
   dependencies:
@@ -1365,6 +1365,21 @@ cheerio@^0.22.0:
 chokidar@^1.4.3, chokidar@^1.6.0, chokidar@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
+  dependencies:
+    anymatch "^1.3.0"
+    async-each "^1.0.0"
+    glob-parent "^2.0.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^2.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+  optionalDependencies:
+    fsevents "^1.0.0"
+
+chokidar@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
     anymatch "^1.3.0"
     async-each "^1.0.0"
@@ -5525,6 +5540,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-relative@0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+
 require-uncached@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -5657,6 +5676,21 @@ rollup-pluginutils@^1.2.0, rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1,
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
+
+rollup-watch@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-watch/-/rollup-watch-4.3.1.tgz#5aa1eaeab787addf368905d102b39d6fc5ce4a8b"
+  dependencies:
+    chokidar "^1.7.0"
+    require-relative "0.8.7"
+    rollup-pluginutils "^2.0.1"
 
 rollup@0.43.0:
   version "0.43.0"


### PR DESCRIPTION
First up, a bit of backstory. Styled-components has always been a zero-config library, pushing a "chosen" combination of features for simplicity and unification. If you're using SC, there's only one way to do things, which makes it quicker to get going with, makes all documentation relevant, etc.

I'm still committed to that design principle, but there are a few areas were global configuration would be really useful: turning off autoprefixing #719, and enabling "speedy" mode. In both cases, there are legit reasons why you'd want it (writing an electron app, writing an app with 10k rules), but they don't make sense to be the default (shitty browser support, shitty devtools experience). The point being neither of these config options change your _usage_ of the library, just its runtime behaviour. So it wouldn't fragment things the way, say, a configurable PostCSS pipeline would have.

As far as I can tell, there are really only 2 options for configuration in JS—factories and mutation. Factories are better from a software engineering point of view, but the way JS modules work make them suck. As soon as you want to change one config option you have to replace `import styled from 'styled-components'` with `import styled from '../../shared/custom-styled'` throughout your whole codebase. A nicer syntax, though it's much more limited and introduces other problems, would be using context:

```js
import { configure } from 'styled-components'
import App from './App'

export configure({
  speedy: true.
})(App)
```

It looks nice, but I don't think it's viable. Since `styled.div` runs _outside_ of the render tree, anything relying on context has to wait until render. So it limits the kinds of things we can make configurable, since they have to be evaluated in the context of a real React render cycle. But it also kinda raises the question of having config be defined at any point in the render tree, which confuses things a fair bit. I don't think it makes any sense for half the render tree to be using `insertRule` and the rest to not. It certainly would complicate the implementation to try to support that. Much better to be one or the other.

So, if mutation is the other option, there's obviously a bad way to do it:

```js
import styled from 'styled-components'
// ...
styled.SPEEDY = true
```

Again, the problem here is consistency. If in between those two lines you construct all your components, what happens when a config setting changes? What happens if it changes while your app is running?

The way I was trying to do this back before the release of v2 was effectively:

```js
import styled, { configure } from 'styled-components'

// Until styled is called, configure can be called.
configure({ prefix_css: false })

// Now the config is "locked"
styled.div` ... `

// This causes an explosion since SC is already configured.
configure({ speedy: true }) // 💥
```

That's tricky, but possible—we have to find every potentially config-sensitive function inside SC and "lock" the config when it's called. We can do that with a proxy object (not necessarily an ES6 proxy just something that intercepts function calls) but then we're kinda injecting this layer in between us and the users (most of whom don't need to configure anything) which feels wrong.

So, by a process of elimination, we get this:

### Glen's Least Terrible Way of Doing Config in JS That He Can Think Of

This is the usage:

```js
import { configure } from 'styled-components/config'

configure({
  prefix_css: false,
  speedy: true
})
```

This references the file `config.js` which is the only file with any mutability, and it exports two methods `configure` and `getConfiguration`. It's also an ES5 CJS file so it can be consumed as a top-level import above.

The key is that `src/config.js`, which is internal to SC, uses `require('../config.js')` to force Rollup not to inline the module. It calls `config.getConfiguration()` which locks the config. That gets imported by files that need it like `stringifyRules.js`, which is imported from `index.js`, so the final result is that **once you've imported 'styled-components' the config is locked**.

This is a bit dank, I know. Using internal module resolution to change something before some files are loaded doesn't seem on the right side of the clever/stupid divide. But the more I think about it, the more I think it's offers actually a pretty good DX:

* If you don't need to configure anything, literally nothing changes. The objects you import when you use styled components are all exactly as they were—not proxies, not factories, etc.
* When you want to change some config, do this:
  * Create a new file `configuration.js` (can use an existing file as long as it doesn't depend on SC)
  * `import { configure } from 'styled-components/config'` and call `configure` with whatever settings you want to change
  * Import your `configuration.js` _in index.js before importing App.js or anything else that depends on SC` ([example](https://github.com/geelen/sc-webpack2-test/blob/master/src/index.js#L3))

Because we're relying on import order, this is going to be pretty unexpected. But it does match the semantics of modules—they're executed in the order they're imported. And it does let us completely isolate the configuration step from the rest of the app.

I whipped up a test using CRA for both [webpack 1](https://github.com/geelen/sc-webpack1-test) and [2](https://github.com/geelen/sc-webpack2-test) to make sure things were still working even with our es bundle exports, and they are. You can try it out using this PR branch and `yarn link` if you like. Only `prefix_css` is so far implemented, speedy is gonna take a fair bit more work.

So, what do you think? I know it's not great, but I'm fairly confident the alternatives are worse 😉