### PR TITLE
flatten: ignore falsy non-0 css values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
-- N/A
+- Don't emit empty rules like `color: ;` when using objects for CSS. Note that this still happens with template interpolations (see [#1149](https://github.com/styled-components/styled-components/pull/1149))
 
 ## [v2.2.0] - 2017-09-27
 

--- a/src/test/props.test.js
+++ b/src/test/props.test.js
@@ -19,10 +19,21 @@ describe('props', () => {
     expectCSSMatches('.sc-a {} .b { color: black; }')
   })
   it('should execute interpolations and inject props', () => {
-    const Comp = styled.div`
-      color: ${props => props.fg || 'black'};
-    `
-    shallow(<Comp fg="red"/>)
+    const Comp = styled.div`color: ${props => props.fg || 'black'};`
+    shallow(<Comp fg="red" />)
     expectCSSMatches('.sc-a {} .b { color: red; }')
+  })
+  it('should ignore non-0 falsy object interpolations', () => {
+    const Comp = styled.div`
+      ${() => ({
+        borderWidth: 0,
+        colorA: null,
+        colorB: false,
+        colorC: undefined,
+        colorD: '',
+      })};
+    `
+    shallow(<Comp fg="red" />)
+    expectCSSMatches('.sc-a {} .b { border-width: 0; ; ; }')
   })
 })

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -5,13 +5,23 @@ import isPlainObject from 'is-plain-object'
 import type { Interpolation } from '../types'
 
 export const objToCss = (obj: Object, prevKey?: string): string => {
-  const css = Object.keys(obj).map(key => {
-    if (isPlainObject(obj[key])) return objToCss(obj[key], key)
-    return `${hyphenate(key)}: ${obj[key]};`
-  }).join(' ')
-  return prevKey ? `${prevKey} {
+  const css = Object.keys(obj)
+    .filter(key => {
+      const chunk = obj[key]
+      return (
+        chunk !== undefined && chunk !== null && chunk !== false && chunk !== ''
+      )
+    })
+    .map(key => {
+      if (isPlainObject(obj[key])) return objToCss(obj[key], key)
+      return `${hyphenate(key)}: ${obj[key]};`
+    })
+    .join(' ')
+  return prevKey
+    ? `${prevKey} {
   ${css}
-}` : css
+}`
+    : css
 }
 
 const flatten = (chunks: Array<Interpolation>, executionContext: ?Object): Array<Interpolation> => (


### PR DESCRIPTION
This implements #1110.

Note that the output still includes spurious `;`, I have no idea where they come from, I even searched the code for all `;` :)