### PR TITLE
Primitives: TextInput support

### DIFF
--- a/.jest.primitives.json
+++ b/.jest.primitives.json
@@ -3,8 +3,5 @@
   "globals": {
     "__DEV__": true
   },
-  "testRegex": "./src/primitives/test/.*.js$",
-  "moduleFileExtensions": ["ios.js", "js"],
-  "preset": "react-native",
-  "testEnvironment": "jsdom"
+  "testRegex": "./src/primitives/test/.*.js$"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Fixed nonce missing from global styles (see [#1088](https://github.com/styled-components/styled-components/pull/1088))
 - Improve component mount and unmount performance with changes to `createBroadcast`. Deprecates usage of `CHANNEL` as a function, will be update to `CHANNEL_NEXT`'s propType in a future version. (see [#1048](https://github.com/styled-components/styled-components/pull/1048))
 - Fixed comments in react-native (see [#1041](https://github.com/styled-components/styled-components/pull/1041))
+- Added TextInput support for primitives
 
 ## [v2.1.2] - 2017-08-04
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-native": "^0.39.2",
-    "react-primitives": "^0.4.2",
+    "react-primitives": "^0.4.3",
     "react-test-renderer": "^15.6.1",
     "rimraf": "^2.6.1",
     "rollup": "0.43.0",

--- a/src/primitives/index.js
+++ b/src/primitives/index.js
@@ -23,7 +23,7 @@ const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag)
 
 /* React native lazy-requires each of these modules for some reason, so let's
 *  assume it's for a good reason and not eagerly load them all */
-const aliases = 'Image Text Touchable View '
+const aliases = 'Image Text Touchable View TextInput'
 
 /* Define a getter for each alias which simply gets the reactNative component
  * and passes it to styled */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5266,9 +5266,9 @@ react-native@^0.39.2:
     xmldoc "^0.4.0"
     yargs "^6.4.0"
 
-react-primitives@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.4.2.tgz#cb001c1122734f177559f5bf590aadd5129b0914"
+react-primitives@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.4.3.tgz#4970afda5a32dccf5ea180380e3a0e16192e4b83"
   dependencies:
     animated "^0.1.5"
     asap "^2.0.5"


### PR DESCRIPTION
- TextInput support (PR waiting in react-primitives repo)
- Updated react-primitives 0.4.2. to 0.4.3
- made tests run (need help to make them pass)