### PR TITLE
Add Marquee tag to default attributes list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Refactor variable in generateAlphabeticName.js (see [#1040](https://github.com/styled-components/styled-components/pull/1040))
 - Enable the Node environment for SSR tests, switch some output verification to snapshot testing (see [#1023](https://github.com/styled-components/styled-components/pull/1023))
 - Add .extend and .withComponent deterministic ID generation (see [#1044](https://github.com/styled-components/styled-components/pull/1044))
+- Add `marquee` tag to domElements (see [#1167](https://github.com/styled-components/styled-components/pull/1167))
 
 ## [v2.1.1] - 2017-07-03
 

--- a/src/utils/domElements.js
+++ b/src/utils/domElements.js
@@ -66,6 +66,7 @@ export default [
   'main',
   'map',
   'mark',
+  'marquee',
   'menu',
   'menuitem',
   'meta',


### PR DESCRIPTION
Right now we can add `marquee` tag using `styled('marquee')`.

With this, we can use it by `styled.marquee`

/cc @philpl 