### PR TITLE
Support for non-keyed .attrs factory function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. If a contri
 - Enable the Node environment for SSR tests, switch some output verification to snapshot testing (see [#1023](https://github.com/styled-components/styled-components/pull/1023))
 - Add .extend and .withComponent deterministic ID generation (see [#1044](https://github.com/styled-components/styled-components/pull/1044))
 - Add `marquee` tag to domElements (see [#1167](https://github.com/styled-components/styled-components/pull/1167))
+- Add support for top level ``.attrs`` factory function (see [#1171](https://github.com/styled-components/styled-components/pull/1171))
 
 ## [v2.1.1] - 2017-07-03
 

--- a/src/constructors/constructWithOptions.js
+++ b/src/constructors/constructWithOptions.js
@@ -18,9 +18,13 @@ export default (css: Function) => {
     /* If config methods are called, wrap up a new template function and merge options */
     templateFunction.withConfig = config =>
       constructWithOptions(componentConstructor, tag, { ...options, ...config })
+
+    /* attrs could be either a plain object or a function (props => ({ attrs })) */
     templateFunction.attrs = attrs =>
       constructWithOptions(componentConstructor, tag, { ...options,
-        attrs: { ...(options.attrs || {}), ...attrs } })
+        attrs: typeof attrs === 'function'
+          ? (context) => ({ ...(options.attrs || {}), ...attrs(context) })
+          : { ...(options.attrs || {}), ...attrs } })
 
     return templateFunction
   }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -64,14 +64,22 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         return context
       }
 
-      this.attrs = Object.keys(attrs).reduce((acc, key) => {
+      this.attrs = this.resolveComponentAttrs(attrs, context)
+
+      return { ...context, ...this.attrs }
+    }
+
+    resolveComponentAttrs(attrs: any, context: any) {
+      if (typeof attrs === 'function') {
+        return attrs(context)
+      }
+
+      return Object.keys(attrs).reduce((acc, key) => {
         const attr = attrs[key]
         // eslint-disable-next-line no-param-reassign
         acc[key] = typeof attr === 'function' ? attr(context) : attr
         return acc
       }, {})
-
-      return { ...context, ...this.attrs }
     }
 
     generateAndInjectStyles(theme: any, props: any) {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -40,7 +40,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
   class BaseStyledComponent extends Component {
     static target: Target
     static styledComponentId: string
-    static attrs: Object
+    static resolveAttrs: Function
     static componentStyle: Object
     static warnTooManyClasses: Function
 
@@ -58,28 +58,21 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     }
 
     buildExecutionContext(theme: any, props: any) {
-      const { attrs } = this.constructor
+      const { resolveAttrs } = this.constructor
       const context = { ...props, theme }
-      if (attrs === undefined) {
+      if (resolveAttrs === undefined) {
         return context
       }
 
-      this.attrs = this.resolveComponentAttrs(attrs, context)
-
-      return { ...context, ...this.attrs }
-    }
-
-    resolveComponentAttrs(attrs: any, context: any) {
-      if (typeof attrs === 'function') {
-        return attrs(context)
-      }
-
-      return Object.keys(attrs).reduce((acc, key) => {
+      const attrs = resolveAttrs(context)
+      this.attrs = Object.keys(attrs).reduce((acc, key) => {
         const attr = attrs[key]
         // eslint-disable-next-line no-param-reassign
         acc[key] = typeof attr === 'function' ? attr(context) : attr
         return acc
       }, {})
+
+      return { ...context, ...this.attrs }
     }
 
     generateAndInjectStyles(theme: any, props: any) {
@@ -201,7 +194,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       componentId = generateId(options.displayName, options.parentComponentId),
       ParentComponent = BaseStyledComponent,
       rules: extendingRules,
-      attrs,
+      resolveAttrs,
     } = options
 
     const styledComponentId = (options.displayName && options.componentId) ?
@@ -226,7 +219,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
 
       static displayName = displayName
       static styledComponentId = styledComponentId
-      static attrs = attrs
+      static resolveAttrs = resolveAttrs
       static componentStyle = componentStyle
       static warnTooManyClasses = warnTooManyClasses
       static target = target

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -15,7 +15,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
   class BaseStyledNativeComponent extends Component {
     static target: Target
     static styledComponentId: string
-    static attrs: Object
+    static resolveAttrs: Function
     static inlineStyle: Object
     root: ?Object
 
@@ -33,14 +33,14 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
       }
     }
 
-
     buildExecutionContext(theme: any, props: any) {
-      const { attrs } = this.constructor
+      const { resolveAttrs } = this.constructor
       const context = { ...props, theme }
-      if (attrs === undefined) {
+      if (resolveAttrs === undefined) {
         return context
       }
 
+      const attrs = resolveAttrs(context)
       this.attrs = Object.keys(attrs).reduce((acc, key) => {
         const attr = attrs[key]
         // eslint-disable-next-line no-param-reassign
@@ -173,7 +173,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
       displayName = isTag(target) ? `styled.${target}` : `Styled(${getComponentName(target)})`,
       ParentComponent = BaseStyledNativeComponent,
       rules: extendingRules,
-      attrs,
+      resolveAttrs,
     } = options
 
     const inlineStyle = new InlineStyle(
@@ -183,7 +183,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
     class StyledNativeComponent extends ParentComponent {
       static displayName = displayName
       static target = target
-      static attrs = attrs
+      static resolveAttrs = resolveAttrs
       static inlineStyle = inlineStyle
 
       static contextTypes = {

--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -139,4 +139,25 @@ describe('attrs', () => {
     })``
     expect(shallow(<Comp>Something else</Comp>).html()).toEqual('<div class="sc-a b">Something else</div>')
   })
+
+  it('should accept function with props as argument', () => {
+    const Comp = styled.input.attrs(props => ({
+      className: props.example,
+      type: 'password',
+    }))``
+    expect(shallow(<Comp example="test"/>).html())
+      .toEqual('<input type="password" class="sc-a test b"/>')
+  })
+
+  it('should accept function with attrs props when extending', () => {
+    const Comp = styled.input.attrs(props => ({
+      className: props.example,
+      type: 'password',
+    }))``
+    const Test = Comp.extend`
+      color: blue
+    `;
+    expect(shallow(<Test example="test"/>).html())
+      .toEqual('<input type="password" class="sc-b test c"/>')
+  });
 })

--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -16,6 +16,12 @@ describe('attrs', () => {
     expect(shallow(<Comp />).html()).toEqual('<div class="sc-a b"></div>')
   })
 
+  it('work fine with null object', () => {
+    const attrs = null;
+    const Comp = styled.div.attrs(attrs)``
+    expect(shallow(<Comp />).html()).toEqual('<div class="sc-a b"></div>')
+  })
+
   it('pass a simple attr', () => {
     const Comp = styled.button.attrs({
       type: 'button'
@@ -160,4 +166,20 @@ describe('attrs', () => {
     expect(shallow(<Test example="test"/>).html())
       .toEqual('<input type="password" class="sc-b test c"/>')
   });
+
+  it('should accept attrs nesting', () => {
+    const WithNestedAttrs = styled.input.attrs({
+      type: 'password'
+    }).attrs({
+      className: 'nested'
+    }).attrs(props => (
+      { id: props.val })
+    ).attrs({
+      disabled: 'disabled',
+      name: props => props.test
+    })``;
+
+    expect(shallow(<WithNestedAttrs val="nested" test="test"/>).html())
+      .toEqual('<input type="password" class="sc-a nested b" id="nested" disabled="" name="test"/>')
+  })
 })


### PR DESCRIPTION
This PR enhances the ``.attrs`` function support for a top level factory function which receives the component props as an argument.

Example:
```javascript
const Input = styled.input.attrs(props => ({
  placeholder: props.placeholder
}))`
  color: red;
`
```

This change is very handy when integrating a styled-component within [``redux-form``](https://redux-form.com) [``Field``](https://redux-form.com/7.0.4/docs/api/field.md/) element where this code:
```javascript
const Input = styled.input.attrs({
  onChange: props => props.input.onChange,
  onBlur: props => props.input.onBlur,
  onFocus: props => props.input.onFocus,
  ...
})`
  color: red;
`
```

can be easily changed to:
```javascript
const Input = styled.input.attrs(props => ({
   ...props.input // ensure all redux-form props and handlers are passed to the wrapped input component
})`
  color: red;
`
```