### PR TITLE
Add link to the TypeScript styled plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The [`webstorm-styled-components`](https://github.com/styled-components/webstorm
 
 We could use your help to get syntax highlighting support to other editors! If you want to start working on syntax highlighting for your editor, open an issue to let us know.
 
+## Code completions and error reporting
+
+Along with sytnax highlighting, you can install the [TypeScript styled plugin](https://github.com/Microsoft/typescript-styled-plugin) to get error reporting and code completeion for styled components in your editor. The plugin supports styled components in both JavaScript and TypeScript files, and works in Visual Studio Code, Sublime, and Atom.
+
 ## Built with `styled-components`
 
 ### Libraries


### PR DESCRIPTION
The TypeScript styled plugin adds styled component string error reporting and IntelliSense to VS Code, Sublime, and Atom