### PR TITLE
Test for BrowserStyleSheet style rendering order

### DIFF
--- a/src/models/test/BrowserStyleSheet.test.js
+++ b/src/models/test/BrowserStyleSheet.test.js
@@ -1,0 +1,45 @@
+// @flow
+
+import React from 'react'
+import { mount } from 'enzyme'
+
+import styled from '../../index'
+import BrowserStyleSheet from '../BrowserStyleSheet'
+import StyleSheetManager from '../StyleSheetManager'
+import { expectCSSMatches, resetStyled } from '../../test/utils'
+
+describe('BrowserStyleSheet', () => {
+  it('should render styles in correct order when styled(StyledComponent) and StyleSheetManager is used', () => {
+    const Red = styled.div`
+      color: red;
+    `
+
+    const RedChangedToBlue = styled(Red)`
+      color: blue;
+    `
+
+    const sheet = BrowserStyleSheet.create()
+
+    const App = () =>
+      <StyleSheetManager sheet={sheet}>
+        <RedChangedToBlue>I should be blue</RedChangedToBlue>
+      </StyleSheetManager>
+
+    // $FlowFixMe
+    const attachPoint = document.body.appendChild(document.createElement('div'))
+    mount(<App />, { attachTo: attachPoint })
+
+    // window.getComputedStyles would be perfect, but it seems that JSDOM
+    // implementation of that function isn't complete, so need to work around
+    // it.
+    // $FlowFixMe
+    const source = document.documentElement.outerHTML
+
+    // regex in case test is run against minified CSS in the future
+    const indexOfRedStyle = source.search('color: red')
+    const indexOfBlueStyle = source.search('color: blue')
+    expect(indexOfRedStyle).toBeGreaterThanOrEqual(0)
+    expect(indexOfBlueStyle).toBeGreaterThanOrEqual(0)
+    expect(indexOfBlueStyle).toBeGreaterThan(indexOfRedStyle)
+  })
+})


### PR DESCRIPTION
As discussed here: https://github.com/styled-components/styled-components/pull/1102#issuecomment-333295857

The added test fails, which catches a bug that happens when #1102 is used, perhaps related to #1164 as well.

CC: @mxstbr, @philpl, @paul-veevers