### PR TITLE
Regression: Typings for withComponent don't support extended attributes

### DIFF
--- a/typings/tests/with-component-test.tsx
+++ b/typings/tests/with-component-test.tsx
@@ -37,7 +37,13 @@ class Random extends React.Component<any, any> {
 }
 
 const H2 = H1.withComponent("h2");
-const a = H1.withComponent("a");
+const AnchorElement = H1.withComponent("a");
 const abbr = H1.withComponent("abbr");
 
 const RandomHeading = H1.withComponent(Random);
+
+class LinkedHeading extends React.Component<any, any> {
+  render() {
+    return <AnchorElement href="https://example.com">Hello World</AnchorElement>;
+  }
+}


### PR DESCRIPTION
This is a bug report reported via a failing test, as per the issue template.

Since styled-components 2.2.0 I'm no longer able to use attributes which are only present in the child component after using `withComponent`. Specifically, when extending a `span` to an `a`, I'm not able to use the `href` attribute on the `a` element since Typescript gives me a typings error:

```
typings/tests/with-component-test.tsx(47,27): error TS2339: Property 'href' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ThemedOuterStyledProps<DetailedHTMLProps...'.
```

This worked fine in 2.1.2, so it must be a regression introduced somewhere between then and 2.2.0.