### PR TITLE
Extract theme logic from StyledComponent lifecycle methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
-- N/A
+- Refactor out theme logic in StyledComponent's componentWillMount & componentWillReceiveProps (see [#1130](https://github.com/styled-components/styled-components/issues/1130))
+
 
 ## [v2.2.1] - 2017-10-04
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -7,6 +7,7 @@ import type { Theme } from './ThemeProvider'
 import isTag from '../utils/isTag'
 import isStyledComponent from '../utils/isStyledComponent'
 import getComponentName from '../utils/getComponentName'
+import determineTheme from '../utils/determineTheme'
 import type { RuleSet, Target } from '../types'
 
 import { CHANNEL, CHANNEL_NEXT, CONTEXT_CHANNEL_SHAPE } from './ThemeProvider'
@@ -67,15 +68,9 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
         const { subscribe } = styledContext
         this.unsubscribeId = subscribe(nextTheme => {
           // This will be called once immediately
-
-          // Props should take precedence over ThemeProvider, which should take precedence over
-          // defaultProps, but React automatically puts defaultProps on props.
-          const { defaultProps } = this.constructor
-          /* eslint-disable react/prop-types */
-          const isDefaultTheme = defaultProps && this.props.theme === defaultProps.theme
-          const theme = this.props.theme && !isDefaultTheme ? this.props.theme : nextTheme
-          /* eslint-enable */
+          const theme = determineTheme(this.props, nextTheme, this.constructor.defaultProps)
           const generatedStyles = this.generateAndInjectStyles(theme, this.props)
+
           this.setState({ theme, generatedStyles })
         })
       } else {
@@ -91,16 +86,10 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
 
     componentWillReceiveProps(nextProps: { theme?: Theme, [key: string]: any }) {
       this.setState((oldState) => {
-        // Props should take precedence over ThemeProvider, which should take precedence over
-        // defaultProps, but React automatically puts defaultProps on props.
-        const { defaultProps } = this.constructor
-        /* eslint-disable react/prop-types */
-        const isDefaultTheme = defaultProps && nextProps.theme === defaultProps.theme
-        const theme = nextProps.theme && !isDefaultTheme ? nextProps.theme : oldState.theme
-        /* eslint-enable */
-        const generatedStyles = this.generateAndInjectStyles(theme, nextProps)
+        const theme = determineTheme(nextProps, oldState.theme, this.constructor.defaultProps)
+        const generatedClassName = this.generateAndInjectStyles(theme, nextProps)
 
-        return { theme, generatedStyles }
+        return { theme, generatedClassName }
       })
     }
 

--- a/src/utils/determineTheme.js
+++ b/src/utils/determineTheme.js
@@ -1,6 +1,9 @@
 // @flow
+type Props = {
+  theme?: any,
+}
 
-export default (props: any, fallbackTheme: any, defaultProps: any) => {
+export default (props: Props, fallbackTheme: any, defaultProps: any) => {
   // Props should take precedence over ThemeProvider, which should take precedence over
   // defaultProps, but React automatically puts defaultProps on props.
 

--- a/src/utils/determineTheme.js
+++ b/src/utils/determineTheme.js
@@ -1,0 +1,13 @@
+// @flow
+
+export default (props: any, fallbackTheme: any, defaultProps: any) => {
+  // Props should take precedence over ThemeProvider, which should take precedence over
+  // defaultProps, but React automatically puts defaultProps on props.
+
+  /* eslint-disable react/prop-types */
+  const isDefaultTheme = defaultProps && props.theme === defaultProps.theme
+  const theme = props.theme && !isDefaultTheme ? props.theme : fallbackTheme
+  /* eslint-enable */
+
+  return theme
+}


### PR DESCRIPTION
This logic was being repeated in two places, and it looks like we want to place similar logic into the withTheme HOC (see [#1130](https://github.com/styled-components/styled-components/issues/1130).

I'd like some feedback on this before I further generalize it for withTheme.