### PR TITLE
Fix for strict flag in TypeScript

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -51,7 +51,7 @@ export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFacto
   <P, TTag extends keyof JSX.IntrinsicElements>(tag: TTag): ThemedStyledFunction<P, T, P & JSX.IntrinsicElements[TTag]>;
   <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<P, T, O>;
   <P extends { theme: T; }>(component: React.ComponentClass<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
-  <P>(component: React.ComponentClass<P>): ThemedStyledFunction<P, T>;
+  <P>(component: React.ComponentClass<P> | React.ComponentClass<T>): ThemedStyledFunction<P, T>;
   <P extends { [prop: string]: any; theme?: T; }>(component: React.StatelessComponent<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;


### PR DESCRIPTION

## Reproduction

Dependencies: 
```
 "dependencies": {
    "react": "^16.0.0",
    "react-dom": "^16.0.0",
    "styled-components": "^2.2.1"
  }
}

```
tsconfig.json with strict flag set to true. 
```
{
    "compilerOptions": {
        "outDir": "dist",
        "target": "es6",
        "module": "es2015",
        "declaration": true,
        "sourceMap": true,
        "noImplicitAny": true,
        "strictNullChecks": true,
        "noUnusedLocals": true,
        "removeComments": true,
        "jsx": "react",
        "moduleResolution": "node",
        "strict": true,
        "baseUrl": "."
    },
    "include": [
        "src/**/*"
    ],
    "exclude": [
        "node_modules"
    ]
}
```

Example:
```typescript
import * as React from 'react';
import styled from 'styled-components';

export interface MyCompProps  { 
    className: string;
}

export class MyComp extends React.Component<MyCompProps> {

   constructor(props: MyCompProps) { 
       super(props);
    }

    public render() {
        return (
            <div className={this.props.className}>
               Hello
            </div>
        );
    }
}

const MyCompStyled = styled(MyComp) `
    background: red;
`;

export default MyCompStyled;
```

## Error 

```sh
ERROR in [at-loader] ./src/components/core/heading.tsx:61:37
    TS2345: Argument of type 'typeof MyComp' is not assignable to parameter of type 'StatelessComponent<{}>'.
  Type 'typeof MyComp' provides no match for the signature '(props: { children?: ReactNode; }, context?: any): ReactElement<any> | null'.
```
Same error occurs if I provide the props type e.g: `styled<MyCompProps>(MyComp)`.. 

## Workaround 

The workaround is to cast the component type to an `any`:

```
const MyCompStyled = styled(MyComp as any) `
    background: red;
`;
```
The problem is that the shape of `MyComp` is different to `React.Component` so it does not pass the `strict` guard. This won't occur if you leave out the constructor (implicitly any) or set your constructor props to `any`. 


**Edit: fixed example**