### PR TITLE
Typings for withComponent don't update props type (Closes #1201)

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -31,7 +31,7 @@ type Attrs<P, A extends Partial<P>, T> = {
 export interface StyledComponentClass<P, T, O = P> extends ComponentClass<ThemedOuterStyledProps<O, T>> {
   extend: ThemedStyledFunction<P, T, O>;
 
-  withComponent<K extends keyof JSX.IntrinsicElements>(tag: K): StyledComponentClass<JSX.IntrinsicElements[K], T, O>;
+  withComponent<K extends keyof JSX.IntrinsicElements>(tag: K): StyledComponentClass<JSX.IntrinsicElements[K], T, JSX.IntrinsicElements[K]>;
   withComponent(element: ComponentClass<P>): StyledComponentClass<P, T, O>;
 }
 

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -32,7 +32,7 @@ export interface StyledComponentClass<P, T, O = P> extends ComponentClass<Themed
   extend: ThemedStyledFunction<P, T, O>;
 
   withComponent<K extends keyof JSX.IntrinsicElements>(tag: K): StyledComponentClass<JSX.IntrinsicElements[K], T, JSX.IntrinsicElements[K]>;
-  withComponent(element: ComponentClass<P>): StyledComponentClass<P, T, O>;
+  withComponent<NewP>(element: ComponentClass<NewP>): StyledComponentClass<NewP, T, NewP>;
 }
 
 export interface ThemedStyledFunction<P, T, O = P> {

--- a/typings/tests/with-component-test.tsx
+++ b/typings/tests/with-component-test.tsx
@@ -13,6 +13,17 @@ function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min)) + min;
 }
 
+const H2 = H1.withComponent("h2");
+const abbr = H1.withComponent("abbr");
+
+const AnchorHeading = H1.withComponent("a");
+
+class LinkedHeading extends React.Component {
+  render() {
+    return <AnchorHeading href="https://example.com">Hello World</AnchorHeading>;
+  }
+}
+
 class Random extends React.Component<any, any> {
   render() {
     const i = getRandomInt(1, 6);
@@ -35,9 +46,5 @@ class Random extends React.Component<any, any> {
     }
   }
 }
-
-const H2 = H1.withComponent("h2");
-const a = H1.withComponent("a");
-const abbr = H1.withComponent("abbr");
 
 const RandomHeading = H1.withComponent(Random);

--- a/typings/tests/with-component-test.tsx
+++ b/typings/tests/with-component-test.tsx
@@ -24,23 +24,29 @@ class LinkedHeading extends React.Component {
   }
 }
 
-class Random extends React.Component<any, any> {
+type RandomProps = {
+  min: number;
+  max: number;
+  className?: string;
+};
+
+class Random extends React.Component<RandomProps> {
   render() {
-    const i = getRandomInt(1, 6);
+    const i = getRandomInt(this.props.min, this.props.max);
 
     switch (i) {
       case 1:
-        return <h1>Hello World</h1>;
+        return <h1 className={this.props.className}>Hello World</h1>;
       case 2:
-        return <h2>Hello World</h2>;
+        return <h2 className={this.props.className}>Hello World</h2>;
       case 3:
-        return <h3>Hello World</h3>;
+        return <h3 className={this.props.className}>Hello World</h3>;
       case 4:
-        return <h4>Hello World</h4>;
+        return <h4 className={this.props.className}>Hello World</h4>;
       case 5:
-        return <h5>Hello World</h5>;
+        return <h5 className={this.props.className}>Hello World</h5>;
       case 6:
-        return <h6>Hello World</h6>;
+        return <h6 className={this.props.className}>Hello World</h6>;
       default:
         return null;
     }
@@ -48,3 +54,9 @@ class Random extends React.Component<any, any> {
 }
 
 const RandomHeading = H1.withComponent(Random);
+
+const RandomHeadingContainer: React.SFC = () =>
+  <RandomHeading
+    min={1}
+    max={6}
+  />;


### PR DESCRIPTION
This is a fix for #1201 which is a bug report issue, despite being opened as a PR (for the record, I appreciate this approach.)

**Note:** This does _itself_ contain a regression, as best described by @Igorbek [here](https://github.com/styled-components/styled-components/pull/1201#issuecomment-333936999).