### PR TITLE
Fix some typos and improve styling in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to `styled-components`
 
-As the creators and maintainers of this project, we want to ensure that `styled-components` lives and continues to grow and evolved. The evolution of the library should never be blocked by any single person's time. One of the simplest ways of doing this is by encouraging a larger set of shallow contributors. Through this, we hope to mitigate the problems of a project that needs updates but there's no-one who has the power to do so.
+As the creators and maintainers of this project, we want to ensure that `styled-components` lives and continues to grow and evolve. The evolution of the library should never be blocked by any single person's time. One of the simplest ways of doing this is by encouraging a larger set of shallow contributors. Through this, we hope to mitigate the problems of a project that needs updates but there's no-one who has the power to do so.
 
 ## Ownership
 
@@ -104,7 +104,7 @@ You can use an interactive editor, powered by [`react-live`](https://react-live.
 
 In the sandbox source, `styled-components` is an alias to `styled-components/src` folder, so you can edit the source directly and dev-server will handle rebuilding the source and livereloading your sandbox after the build is done.
 
-When you commit our pre-commit hook will run, which executes `lint-staged`. It will run the linter automatically and warn you, if the code you've written doesn't comply with our code style.
+When you commit our pre-commit hook will run, which executes `lint-staged`. It will run the linter automatically and warn you if the code you've written doesn't comply with our code style guidelines.
 
 ## Release process
 

--- a/CORE_TEAM.md
+++ b/CORE_TEAM.md
@@ -10,7 +10,7 @@ The `styled-components` Core Team has the following responsibilities:
 * Being available to review longstanding/forgotten pull requests.
 * Occasionally check `styled-components` issues, offer input, and categorize with GitHub issue labels.
 * Looking out for up-and-coming members of the `styled-components` community who might want to serve as Core Team members.
-* Pushing new releases of the package to npm
+* Pushing new releases of the package to `npm`.
 
 Note that the `styled-components` Core Team – and all `styled-components` contributors – are open source _volunteers_; membership on the Core Team is expressly _not_ an obligation. The Core Team is distinguished as leaders in the community and while they are a good group to turn to when someone needs an answer to a question, they are still volunteering their time, and may not be available to help immediately.
 


### PR DESCRIPTION
As we are discussing your [guideline improvements](https://github.com/styled-components/styled-components/pull/1364) in the [Moya organisation](https://github.com/Moya/contributors/issues/19), I read through the changes and saw a typo and styling issues, so I fixed them. 😇

There were two main questions I still had after reading both `CONTRIBUTING.md` and `CORE_TEAM.md`; which I want to let you know of - and we'll probably be discussing these over at Moya too:

- Why do you specifically state that the beginning of the process of becoming a core team member should happen privately? I think it would help if there would be an explanation as to why you'd not want this to happen publicly.
- I think it would be a good idea to think about how a core team member can step down - and document it. I think that is another barrier that, if documented, can help people be more open and comfortable about it.

Let me know your thoughts!