### PR TITLE
use a simpler hashing strategy when possible 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
--
+- remove some extra information from the generated hash that can differ between build environments ([see #1381](https://github.com/styled-components/styled-components/pull/1381))
 
 ## [v2.3.3] - 2017-12-20
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -23,17 +23,30 @@ import ServerStyleSheet from './ServerStyleSheet'
 const STATIC_EXECUTION_CONTEXT = {}
 
 export default (ComponentStyle: Function, constructWithOptions: Function) => {
-  /* We depend on components having unique IDs */
   const identifiers = {}
+
+  /* We depend on components having unique IDs */
   const generateId = (_displayName: string, parentComponentId: string) => {
     const displayName =
       typeof _displayName !== 'string' ? 'sc' : escape(_displayName)
 
-    const nr = (identifiers[displayName] || 0) + 1
-    identifiers[displayName] = nr
+    let componentId
 
-    const hash = ComponentStyle.generateName(displayName + nr)
-    const componentId = `${displayName}-${hash}`
+    /**
+     * only fall back to hashing the component injection order if
+     * a proper displayName isn't provided by the babel plugin
+     */
+    if (!_displayName) {
+      const nr = (identifiers[displayName] || 0) + 1
+      identifiers[displayName] = nr
+
+      componentId = `${displayName}-${ComponentStyle.generateName(
+        displayName + nr,
+      )}`
+    } else {
+      componentId = `${displayName}-${ComponentStyle.generateName(displayName)}`
+    }
+
     return parentComponentId !== undefined
       ? `${parentComponentId}-${componentId}`
       : componentId


### PR DESCRIPTION
the execution order of files can differ between build environments
and lead to mismatching hashes. if the babel plugin is being used, we
will usually have a displayName, which will be unique enough for hashing
purposes and we can fall back to the numerical way of doing things as
a fallback

I tested this out in the sandbox and it didn't appear to break anything.

Related: https://github.com/styled-components/babel-plugin-styled-components/issues/105 