### PR TITLE
Fixed nested themes not being republished on outer theme changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
--
+- Fixed nested themes not being republished on outer theme changes, thanks to [@Andarist](https://github.com/Andarist) (see [#1382](https://github.com/styled-components/styled-components/pull/1382))
 
 ## [v2.3.3] - 2017-12-20
 

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -59,8 +59,13 @@ class ThemeProvider extends Component {
     if (outerContext !== undefined) {
       this.unsubscribeToOuterId = outerContext.subscribe(theme => {
         this.outerTheme = theme
+
+        if (this.broadcast !== undefined) {
+          this.publish(this.props.theme)
+        }
       })
     }
+
     this.broadcast = createBroadcast(this.getTheme())
   }
 
@@ -86,7 +91,7 @@ class ThemeProvider extends Component {
 
   componentWillReceiveProps(nextProps: ThemeProviderProps) {
     if (this.props.theme !== nextProps.theme) {
-      this.broadcast.publish(this.getTheme(nextProps.theme))
+      this.publish(nextProps.theme)
     }
   }
 
@@ -117,6 +122,10 @@ class ThemeProvider extends Component {
       )
     }
     return { ...this.outerTheme, ...(theme: Object) }
+  }
+
+  publish(theme: Theme | ((outerTheme: Theme) => void)) {
+    this.broadcast.publish(this.getTheme(theme))
   }
 
   render() {


### PR DESCRIPTION
**What**:

This fixes a bug when having nested `ThemeProvider`s and updating outer theme the change is not reaching the `StyledComponent`
```jsx
<ThemeProvider theme={{}}>
	<ThemeProvider theme={{}}>
		<StyledComponent>
	</ThemeProvider>
</ThemeProvider>
```

**Why**:

This is a bug fix.

**How**:
Using publish in the nested `ThemeProvider`s subscriptions.

**Checklist**:
- [x] Tests - gonna add tests soon
- [x] Code complete

Repro provided by @mitchellhamilton - https://codesandbox.io/s/w7y56yznj7