### PR TITLE
remove trailing commas for functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
   "rules": {
     "semi": 0,
     "quotes": 0,
+    "comma-dangle": 0,
     "curly": [2, "multi-line"],
     "arrow-parens": 0,
     "class-methods-use-this": 0,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "es5"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Add warning if you've accidently imported 'styled-components' on React Native instead of 'styled-components/native', thanks to [@tazsingh](https://github.com/tazsingh) (see [#1391](https://github.com/styled-components/styled-components/pull/1391))
 
+- Remove trailing commas on function arguments (not compatible with ES5 JS engines)
+
 ## [v2.4.0] - 2017-12-22
 
 - remove some extra information from the generated hash that can differ between build environments ([see #1381](https://github.com/styled-components/styled-components/pull/1381))

--- a/src/constructors/constructWithOptions.js
+++ b/src/constructors/constructWithOptions.js
@@ -5,7 +5,7 @@ export default (css: Function) => {
   const constructWithOptions = (
     componentConstructor: Function,
     tag: Target,
-    options: Object = {},
+    options: Object = {}
   ) => {
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -8,7 +8,7 @@ const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 export default (
   nameGenerator: NameGenerator,
   stringifyRules: Stringifier,
-  css: Function,
+  css: Function
 ) => (
   strings: Array<string>,
   ...interpolations: Array<Interpolation>
@@ -28,7 +28,7 @@ export default (
     true,
     generatedCSS,
     hash,
-    name,
+    name
   )
   return name
 }

--- a/src/hoc/withTheme.js
+++ b/src/hoc/withTheme.js
@@ -46,7 +46,7 @@ const wrapWithTheme = (Component: ReactClass<any>) => {
       ) {
         // eslint-disable-next-line no-console
         console.warn(
-          '[withTheme] You are not using a ThemeProvider nor passing a theme prop or a theme in defaultProps',
+          '[withTheme] You are not using a ThemeProvider nor passing a theme prop or a theme in defaultProps'
         )
       } else if (styledContext === undefined && themeProp !== undefined) {
         this.setState({ theme: themeProp })

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ if (
   console.warn(
     "It looks like you've imported 'styled-components' on React Native.\n" +
       "Perhaps you're looking to import 'styled-components/native'?\n" +
-      'Read more about this at https://www.styled-components.com/docs/basics#react-native',
+      'Read more about this at https://www.styled-components.com/docs/basics#react-native'
   )
 }
 
@@ -39,7 +39,7 @@ if (
 const ComponentStyle = _ComponentStyle(
   generateAlphabeticName,
   flatten,
-  stringifyRules,
+  stringifyRules
 )
 const constructWithOptions = _constructWithOptions(css)
 const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)

--- a/src/models/BrowserStyleSheet.js
+++ b/src/models/BrowserStyleSheet.js
@@ -67,7 +67,7 @@ class BrowserTag implements Tag {
 
     if (process.env.NODE_ENV !== 'production' && !comp) {
       throw new Error(
-        'Must add a new component before you can inject css into it',
+        'Must add a new component before you can inject css into it'
       )
     }
     if (comp.textNode.data === '') {
@@ -79,7 +79,7 @@ class BrowserTag implements Tag {
       const existingNames = this.el.getAttribute(SC_ATTR)
       this.el.setAttribute(
         SC_ATTR,
-        existingNames ? `${existingNames} ${name}` : name,
+        existingNames ? `${existingNames} ${name}` : name
       )
     }
 
@@ -145,11 +145,7 @@ export default {
       const el = nodes[i]
 
       tags.push(
-        new BrowserTag(
-          el,
-          el.getAttribute(LOCAL_ATTR) === 'true',
-          el.innerHTML,
-        ),
+        new BrowserTag(el, el.getAttribute(LOCAL_ATTR) === 'true', el.innerHTML)
       )
 
       const attr = el.getAttribute(SC_ATTR)

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -44,7 +44,7 @@ const isHRMEnabled =
 export default (
   nameGenerator: NameGenerator,
   flatten: Flattener,
-  stringifyRules: Stringifier,
+  stringifyRules: Stringifier
 ) => {
   class ComponentStyle {
     rules: RuleSet

--- a/src/models/InlineStyle.js
+++ b/src/models/InlineStyle.js
@@ -39,7 +39,7 @@ export default (styleSheet: StyleSheet) => {
           ) {
             /* eslint-disable no-console */
             console.warn(
-              `Node of type ${node.type} not supported as an inline style`,
+              `Node of type ${node.type} not supported as an inline style`
             )
           }
         })

--- a/src/models/ServerStyleSheet.js
+++ b/src/models/ServerStyleSheet.js
@@ -34,7 +34,7 @@ class ServerTag implements Tag {
   concatenateCSS() {
     return Object.keys(this.components).reduce(
       (styles, k) => styles + this.components[k].css,
-      '',
+      ''
     )
   }
 
@@ -43,7 +43,7 @@ class ServerTag implements Tag {
 
     if (process.env.NODE_ENV !== 'production' && !comp) {
       throw new Error(
-        'Must add a new component before you can inject css into it',
+        'Must add a new component before you can inject css into it'
       )
     }
     if (comp.css === '') comp.css = `/* sc-component-id: ${componentId} */\n`

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -44,7 +44,7 @@ export default class StyleSheet {
   constructor(
     tagConstructor: boolean => Tag,
     tags: Array<Tag> = [],
-    names: { [string]: boolean } = {},
+    names: { [string]: boolean } = {}
   ) {
     this.tagConstructor = tagConstructor
     this.tags = tags
@@ -97,7 +97,7 @@ export default class StyleSheet {
     isLocal: boolean,
     css: string,
     hash: ?any,
-    name: ?string,
+    name: ?string
   ) {
     if (this === instance) {
       clones.forEach(clone => {
@@ -168,7 +168,7 @@ export default class StyleSheet {
     const newSheet = new StyleSheet(
       oldSheet.tagConstructor,
       oldSheet.tags.map(tag => tag.clone()),
-      { ...oldSheet.names },
+      { ...oldSheet.names }
     )
 
     newSheet.hashes = { ...oldSheet.hashes }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -41,7 +41,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       identifiers[displayName] = nr
 
       componentId = `${displayName}-${ComponentStyle.generateName(
-        displayName + nr,
+        displayName + nr
       )}`
     } else {
       componentId = `${displayName}-${ComponentStyle.generateName(displayName)}`
@@ -98,13 +98,13 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       if (componentStyle.isStatic && attrs === undefined) {
         return componentStyle.generateAndInjectStyles(
           STATIC_EXECUTION_CONTEXT,
-          styleSheet,
+          styleSheet
         )
       } else {
         const executionContext = this.buildExecutionContext(theme, props)
         const className = componentStyle.generateAndInjectStyles(
           executionContext,
-          styleSheet,
+          styleSheet
         )
 
         if (
@@ -127,7 +127,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       if (componentStyle.isStatic) {
         const generatedClassName = this.generateAndInjectStyles(
           STATIC_EXECUTION_CONTEXT,
-          this.props,
+          this.props
         )
         this.setState({ generatedClassName })
         // If there is a theme in the context, subscribe to the event emitter. This
@@ -140,11 +140,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
           const theme = determineTheme(
             this.props,
             nextTheme,
-            this.constructor.defaultProps,
+            this.constructor.defaultProps
           )
           const generatedClassName = this.generateAndInjectStyles(
             theme,
-            this.props,
+            this.props
           )
 
           this.setState({ theme, generatedClassName })
@@ -154,7 +154,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         const theme = this.props.theme || {}
         const generatedClassName = this.generateAndInjectStyles(
           theme,
-          this.props,
+          this.props
         )
         this.setState({ theme, generatedClassName })
       }
@@ -175,11 +175,11 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         const theme = determineTheme(
           nextProps,
           oldState.theme,
-          this.constructor.defaultProps,
+          this.constructor.defaultProps
         )
         const generatedClassName = this.generateAndInjectStyles(
           theme,
-          nextProps,
+          nextProps
         )
 
         return { theme, generatedClassName }
@@ -234,7 +234,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
 
           return acc
         },
-        baseProps,
+        baseProps
       )
 
       return createElement(target, propsForElement)
@@ -244,7 +244,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
   const createStyledComponent = (
     target: Target,
     options: Object,
-    rules: RuleSet,
+    rules: RuleSet
   ) => {
     const {
       displayName = isTag(target)
@@ -264,7 +264,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     const componentStyle = new ComponentStyle(
       extendingRules === undefined ? rules : extendingRules.concat(rules),
       attrs,
-      styledComponentId,
+      styledComponentId
     )
 
     class StyledComponent extends ParentComponent {

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -70,11 +70,11 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
           const theme = determineTheme(
             this.props,
             nextTheme,
-            this.constructor.defaultProps,
+            this.constructor.defaultProps
           )
           const generatedStyles = this.generateAndInjectStyles(
             theme,
-            this.props,
+            this.props
           )
 
           this.setState({ theme, generatedStyles })
@@ -95,7 +95,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
         const theme = determineTheme(
           nextProps,
           oldState.theme,
-          this.constructor.defaultProps,
+          this.constructor.defaultProps
         )
         const generatedStyles = this.generateAndInjectStyles(theme, nextProps)
 
@@ -118,7 +118,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
         console.warn(
           'setNativeProps was called on a Styled Component wrapping a stateless functional component. ' +
             'In this case no ref will be stored, and instead an innerRef prop will be passed on.\n' +
-            `Check whether the stateless functional component is passing on innerRef as a ref in ${displayName}.`,
+            `Check whether the stateless functional component is passing on innerRef as a ref in ${displayName}.`
         )
       }
     }
@@ -164,7 +164,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
   const createStyledNativeComponent = (
     target: Target,
     options: Object,
-    rules: RuleSet,
+    rules: RuleSet
   ) => {
     const {
       displayName = isTag(target)
@@ -176,7 +176,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
     } = options
 
     const inlineStyle = new InlineStyle(
-      extendingRules === undefined ? rules : extendingRules.concat(rules),
+      extendingRules === undefined ? rules : extendingRules.concat(rules)
     )
 
     class StyledNativeComponent extends ParentComponent {
@@ -224,7 +224,7 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
         return constructWithOptions(
           createStyledNativeComponent,
           target,
-          newOptions,
+          newOptions
         )
       }
     }

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -28,7 +28,7 @@ if (process.env.NODE_ENV !== 'production') {
   warnChannelDeprecated = once(() => {
     // eslint-disable-next-line no-console
     console.error(
-      `Warning: Usage of \`context.${CHANNEL}\` as a function is deprecated. It will be replaced with the object on \`.context.${CHANNEL_NEXT}\` in a future version.`,
+      `Warning: Usage of \`context.${CHANNEL}\` as a function is deprecated. It will be replaced with the object on \`.context.${CHANNEL_NEXT}\` in a future version.`
     )
   })
 }
@@ -111,14 +111,14 @@ class ThemeProvider extends Component {
         !isPlainObject(mergedTheme)
       ) {
         throw new Error(
-          '[ThemeProvider] Please return an object from your theme function, i.e. theme={() => ({})}!',
+          '[ThemeProvider] Please return an object from your theme function, i.e. theme={() => ({})}!'
         )
       }
       return mergedTheme
     }
     if (!isPlainObject(theme)) {
       throw new Error(
-        '[ThemeProvider] Please make your theme prop a plain object',
+        '[ThemeProvider] Please make your theme prop a plain object'
       )
     }
     return { ...this.outerTheme, ...(theme: Object) }

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -17,7 +17,7 @@ const constructWithOptions = _constructWithOptions(css)
 const InlineStyle = _InlineStyle(reactNative.StyleSheet)
 const StyledNativeComponent = _StyledNativeComponent(
   constructWithOptions,
-  InlineStyle,
+  InlineStyle
 )
 const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag)
 
@@ -40,7 +40,7 @@ aliases.split(/\s+/m).forEach(alias =>
     get() {
       return styled(reactNative[alias])
     },
-  }),
+  })
 )
 
 export { css, ThemeProvider, withTheme }

--- a/src/no-parser/flatten.js
+++ b/src/no-parser/flatten.js
@@ -14,7 +14,7 @@ const isRuleSet = (interpolation: Interpolation): boolean =>
 
 const flatten = (
   chunks: Array<Interpolation>,
-  executionContext: ?Object,
+  executionContext: ?Object
 ): Array<Interpolation> => {
   /* Fall back to old flattener for non-rule-set chunks */
   if (!isRuleSet(chunks)) {
@@ -24,7 +24,7 @@ const flatten = (
   return chunks.reduce(
     (
       ruleSet: Array<Interpolation>,
-      chunk: ?Interpolation,
+      chunk: ?Interpolation
     ): Array<Interpolation> => {
       if (!Array.isArray(chunk)) {
         return ruleSet
@@ -35,7 +35,7 @@ const flatten = (
       const newChunk = chunk.reduce(
         (
           rules: Array<Interpolation>,
-          rule: ?Interpolation,
+          rule: ?Interpolation
         ): Array<Interpolation> => {
           /* Remove falsey values */
           if (
@@ -95,7 +95,7 @@ const flatten = (
 
           return [...rules, rule.toString()]
         },
-        [],
+        []
       )
 
       if (executionContext) {
@@ -109,7 +109,7 @@ const flatten = (
 
       return [...ruleSet, newChunk, ...appendChunks]
     },
-    [],
+    []
   )
 }
 

--- a/src/no-parser/index.js
+++ b/src/no-parser/index.js
@@ -28,7 +28,7 @@ import withTheme from '../hoc/withTheme'
 const ComponentStyle = _ComponentStyle(
   generateAlphabeticName,
   flatten,
-  stringifyRules,
+  stringifyRules
 )
 const constructWithOptions = _constructWithOptions(css)
 const StyledComponent = _StyledComponent(ComponentStyle, constructWithOptions)

--- a/src/no-parser/stringifyRules.js
+++ b/src/no-parser/stringifyRules.js
@@ -4,7 +4,7 @@ import type { Interpolation } from '../types'
 const stringifyRules = (
   rules: Array<Interpolation>,
   selector: ?string,
-  prefix: ?string,
+  prefix: ?string
 ): string =>
   rules.reduce(
     (str: string, partial: Interpolation, index: number): string =>
@@ -14,7 +14,7 @@ const stringifyRules = (
       (partial && Array.isArray(partial)
         ? partial.join('')
         : partial.toString()),
-    '',
+    ''
   )
 
 export default stringifyRules

--- a/src/primitives/index.js
+++ b/src/primitives/index.js
@@ -17,7 +17,7 @@ const constructWithOptions = _constructWithOptions(css)
 const InlineStyle = _InlineStyle(reactPrimitives.StyleSheet)
 const StyledNativeComponent = _StyledNativeComponent(
   constructWithOptions,
-  InlineStyle,
+  InlineStyle
 )
 const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag)
 
@@ -34,7 +34,7 @@ aliases.split(/\s+/m).forEach(alias =>
     get() {
       return styled(reactPrimitives[alias])
     },
-  }),
+  })
 )
 
 export { css, ThemeProvider, withTheme }

--- a/src/types.js
+++ b/src/types.js
@@ -15,13 +15,13 @@ export type NameGenerator = (hash: number) => string
 
 export type Flattener = (
   chunks: Array<Interpolation>,
-  executionContext: ?Object,
+  executionContext: ?Object
 ) => Array<Interpolation>
 
 export type Stringifier = (
   rules: Array<Interpolation>,
   selector: ?string,
-  prefix: ?string,
+  prefix: ?string
 ) => string
 
 export type StyleSheet = {

--- a/src/utils/createWarnTooManyClasses.js
+++ b/src/utils/createWarnTooManyClasses.js
@@ -21,7 +21,7 @@ export default (displayName: string) => {
             '      background,\n' +
             '    }),\n' +
             '  })`width: 100%;`\n\n' +
-            '  <Component />',
+            '  <Component />'
         )
         warningSeen = true
         generatedClasses = {}

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -26,7 +26,7 @@ export const objToCss = (obj: Object, prevKey?: string): string => {
 
 const flatten = (
   chunks: Array<Interpolation>,
-  executionContext: ?Object,
+  executionContext: ?Object
 ): Array<Interpolation> =>
   chunks.reduce((ruleSet: Array<Interpolation>, chunk: ?Interpolation) => {
     /* Remove falsey values */
@@ -53,7 +53,7 @@ const flatten = (
     if (typeof chunk === 'function') {
       return executionContext
         ? ruleSet.concat(
-            ...flatten([chunk(executionContext)], executionContext),
+            ...flatten([chunk(executionContext)], executionContext)
           )
         : ruleSet.concat(chunk)
     }
@@ -61,7 +61,7 @@ const flatten = (
     /* Handle objects */
     return ruleSet.concat(
       // $FlowFixMe have to add %checks somehow to isPlainObject
-      isPlainObject(chunk) ? objToCss(chunk) : chunk.toString(),
+      isPlainObject(chunk) ? objToCss(chunk) : chunk.toString()
     )
   }, [])
 

--- a/src/utils/interleave.js
+++ b/src/utils/interleave.js
@@ -3,10 +3,10 @@ import type { Interpolation } from '../types'
 
 export default (
   strings: Array<string>,
-  interpolations: Array<Interpolation>,
+  interpolations: Array<Interpolation>
 ): Array<Interpolation> =>
   interpolations.reduce(
     (array: Array<Interpolation>, interp: Interpolation, i: number) =>
       array.concat(interp, strings[i + 1]),
-    [strings[0]],
+    [strings[0]]
   )

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -14,7 +14,7 @@ const stylis = new Stylis({
 const stringifyRules = (
   rules: Array<Interpolation>,
   selector: ?string,
-  prefix: ?string,
+  prefix: ?string
 ): string => {
   const flatCSS = rules.join('').replace(/^\s*\/\/.*$/gm, '') // replace JS comments
 

--- a/src/utils/validAttr.js
+++ b/src/utils/validAttr.js
@@ -23,7 +23,7 @@ const ATTRIBUTE_NAME_START_CHAR =
   ':A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD'
 const ATTRIBUTE_NAME_CHAR = `${ATTRIBUTE_NAME_START_CHAR}\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040`
 const isCustomAttribute = RegExp.prototype.test.bind(
-  new RegExp(`^(data|aria)-[${ATTRIBUTE_NAME_CHAR}]*$`),
+  new RegExp(`^(data|aria)-[${ATTRIBUTE_NAME_CHAR}]*$`)
 )
 
 export default (name: string) =>


### PR DESCRIPTION
They're not supported in ES5, which is tested against in the node
versions included by the styled-components CI. Also disabled an
eslint rule that was conflicting with what prettier was doing.