### PR TITLE
Change navigator check to prevent crashing in node env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Fixed nested themes not being republished on outer theme changes, thanks to [@Andarist](https://github.com/Andarist) (see [#1382](https://github.com/styled-components/styled-components/pull/1382))
 
-- Add warning if you've accidently imported 'styled-components' on React Native instead of 'styled-components/native', thanks to [@tazsingh](https://github.com/tazsingh) (see [#1391](https://github.com/styled-components/styled-components/pull/1391))
+- Add warning if you've accidently imported 'styled-components' on React Native instead of 'styled-components/native', thanks to [@tazsingh](https://github.com/tazsingh) and [@gribnoysup](https://github.com/gribnoysup) (see [#1391](https://github.com/styled-components/styled-components/pull/1391) and [#1394](https://github.com/styled-components/styled-components/pull/1394))
 
 ## [v2.4.0] - 2017-12-22
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,7 @@ import withTheme from './hoc/withTheme'
 /* Warning if you've imported this file on React Native */
 if (
   process.env.NODE_ENV !== 'production' &&
-  typeof navigator === 'object' &&
-  navigator !== null &&
+  typeof navigator !== 'undefined' &&
   navigator.product === 'ReactNative'
 ) {
   console.warn(

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ import withTheme from './hoc/withTheme'
 /* Warning if you've imported this file on React Native */
 if (
   process.env.NODE_ENV !== 'production' &&
-  navigator &&
+  typeof navigator === 'object' &&
+  navigator !== null &&
   navigator.product === 'ReactNative'
 ) {
   console.warn(


### PR DESCRIPTION
Current check if `navigator` exists in `master` branch breaks styled-components in node env with `ReferenceError: navigator is not defined`

Probably this should be covered with tests somehow, but I'm not sure how. I tried to change imports in `ssr.test.js` from `import ServerStyleSheet from '../models/ServerStyleSheet'` to `import { ServerStyleSheet } from '../index'`, but after that all tests started to fail with `Invariant Violation: StyleSheetManager.getChildContext(): key "__styled-components-stylesheet__" is not defined in childContextTypes.` and I have no clue where this error is coming from 😿 