### PR TITLE
Fix duplicate keyframes being added to the global stylesheet

### DIFF
--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -6,14 +6,23 @@ import type { Interpolation, NameGenerator } from '../types'
 
 const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 
+let inserted = {}
+
+export const clearKeyframeCache = () => {
+  inserted = {}
+}
+
 export default (nameGenerator: NameGenerator) =>
   (strings: Array<string>, ...interpolations: Array<Interpolation>): string => {
     const rules = css(strings, ...interpolations)
     const hash = hashStr(replaceWhitespace(JSON.stringify(rules)))
-    const name = nameGenerator(hash)
-    const keyframes = new GlobalStyle(rules, `@keyframes ${name}`)
-    const keyframesWebkit = new GlobalStyle(rules, `@-webkit-keyframes ${name}`)
-    keyframes.generateAndInject()
-    keyframesWebkit.generateAndInject()
-    return name
+    if (!inserted[hash]) {
+      const name = nameGenerator(hash)
+      inserted[hash] = name
+      const keyframes = new GlobalStyle(rules, `@keyframes ${name}`)
+      const keyframesWebkit = new GlobalStyle(rules, `@-webkit-keyframes ${name}`)
+      keyframes.generateAndInject()
+      keyframesWebkit.generateAndInject()
+    }
+    return inserted[hash]
   }

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -1,7 +1,7 @@
 // @flow
 import expect from 'expect'
 
-import _keyframes from '../keyframes'
+import _keyframes, { clearKeyframeCache } from '../keyframes'
 import styleSheet from '../../models/StyleSheet'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
 
@@ -14,6 +14,7 @@ const keyframes = _keyframes(() => `keyframe_${index++}`)
 describe('keyframes', () => {
   beforeEach(() => {
     resetStyled()
+    clearKeyframeCache()
     index = 0
   })
 


### PR DESCRIPTION
I'm not sure if you're still accepting PRs for version 1 but this fixes a bug whereby identical keyframes are added multiple times to the global stylesheet rather than only once.