### PR TITLE
Add @probablyup to the core team

### DIFF
--- a/CORE_TEAM.md
+++ b/CORE_TEAM.md
@@ -22,6 +22,7 @@ The current core team members, ordered by time of addition:
 * [@mxstbr](https://github.com/mxstbr)
 * [@philpl](https://github.com/philpl)
 * [@schwers](https://github.com/schwers)
+* [@probablyup](https://github.com/probablyup)
 
 ## Adding new Core Team Members
 


### PR DESCRIPTION
Due to his amazing contributions over the past months and clear understand of the styled-components vision we decided to invite Evan to the core team. To our joy, he's accepted the invitation, so please welcome the newest member of our core circle: [@probablyup](https://twitter.com/probablyup)! 🎉🎊