### PR TITLE
fix: console error in attrs test

### DIFF
--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -105,7 +105,7 @@ describe('attrs', () => {
   })
 
   it('pass attrs to style block', () => {
-    /* Would be a React Router Link in URL */
+    /* Would be a React Router Link in real life */
     const Comp = styled.a.attrs({
       href: '#',
       'data-active-class-name': '--is-active'

--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -105,17 +105,17 @@ describe('attrs', () => {
   })
 
   it('pass attrs to style block', () => {
-    /* Would be a React Router Link in IRL */
+    /* Would be a React Router Link in URL */
     const Comp = styled.a.attrs({
       href: '#',
-      activeClassName: '--is-active'
+      'data-active-class-name': '--is-active'
     })`
       color:blue;
-      &.${props => props.activeClassName} {
+      &.${props => props['data-active-class-name']} {
         color:red;
       }
     `
-    expect(shallow(<Comp />).html()).toEqual('<a href="#" class="sc-a b"></a>')
+    expect(shallow(<Comp />).html()).toEqual('<a href="#" data-active-class-name="--is-active" class="sc-a b"></a>')
     expectCSSMatches('.sc-a {} .b { color:blue; } .b.--is-active { color:red; }')
   })
 


### PR DESCRIPTION
This PR should fix React 16 warning:

<img width="635" alt="screen shot 2018-01-04 at 19 40 55" src="https://user-images.githubusercontent.com/5403694/34584975-2f80af5e-f19e-11e7-8d12-d27fcac1e5f8.png">

Having a mission to "eradicate red from tests" I traced these guys:

<img width="633" alt="screen shot 2018-01-04 at 19 41 13" src="https://user-images.githubusercontent.com/5403694/34584990-3f2d54b6-f19e-11e7-9eb5-27c71c55a79d.png">

Unfortunately, they are coming from imports of `StyleSheet` and `View`. Related fixes already landed on react-native master branch and should be a part of upcoming version 0.52
- https://github.com/facebook/react-native/commit/50b11aa09b479e5ce8b06de98e02ba1dd6a8cca3#diff-00341ed486de763a230150ede8084f57R15
- https://github.com/facebook/react-native/commit/9afb71fde8199156ed683dca6aa59826f9fb9279#diff-a562e4a7ac9e900c6d2bc644453e9152R77