### PR TITLE
Inner ref fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Add warning if you've accidently imported 'styled-components' on React Native instead of 'styled-components/native', thanks to [@tazsingh](https://github.com/tazsingh) and [@gribnoysup](https://github.com/gribnoysup) (see [#1391](https://github.com/styled-components/styled-components/pull/1391) and [#1394](https://github.com/styled-components/styled-components/pull/1394))
 
+- Fixed bug where `innerRef` could be passed as undefined to components when using withTheme. This could cause issues when using prop spread within the component (e.g. `{...this.props}`), because React will still warn you about using a non-dom prop even though it's undefined. (see [#1414](https://github.com/styled-components/styled-components/pull/1414))
+
 ## [v2.4.0] - 2017-12-22
 
 - remove some extra information from the generated hash that can differ between build environments ([see #1381](https://github.com/styled-components/styled-components/pull/1381))

--- a/src/hoc/withTheme.js
+++ b/src/hoc/withTheme.js
@@ -86,7 +86,7 @@ const wrapWithTheme = (Component: ReactClass<any>) => {
         <Component
           theme={theme}
           {...this.props}
-          innerRef={shouldSetInnerRef ? innerRef : undefined}
+          {...(shouldSetInnerRef ? { innerRef } : {})}
           ref={shouldSetInnerRef ? undefined : innerRef}
         />
       )

--- a/src/hoc/withTheme.js
+++ b/src/hoc/withTheme.js
@@ -14,12 +14,13 @@ import determineTheme from '../utils/determineTheme'
 
 const wrapWithTheme = (Component: ReactClass<any>) => {
   const componentName = Component.displayName || Component.name || 'Component'
+  const isStatelessFunctionalComponent =
+    typeof Component === 'function' &&
+    !(Component.prototype && 'isReactComponent' in Component.prototype)
 
+  // NOTE: We can't pass a ref to a stateless functional component
   const shouldSetInnerRef =
-    _isStyledComponent(Component) ||
-    // NOTE: We can't pass a ref to a stateless functional component
-    (typeof Component === 'function' &&
-      !(Component.prototype && 'isReactComponent' in Component.prototype))
+    _isStyledComponent(Component) || isStatelessFunctionalComponent
 
   class WithTheme extends React.Component {
     static displayName = `WithTheme(${componentName})`
@@ -78,18 +79,17 @@ const wrapWithTheme = (Component: ReactClass<any>) => {
     }
 
     render() {
-      // eslint-disable-next-line react/prop-types
-      const { innerRef } = this.props
-      const { theme } = this.state
+      const props = {
+        theme: this.state.theme,
+        ...this.props,
+      }
 
-      return (
-        <Component
-          theme={theme}
-          {...this.props}
-          {...(shouldSetInnerRef ? { innerRef } : {})}
-          ref={shouldSetInnerRef ? undefined : innerRef}
-        />
-      )
+      if (!shouldSetInnerRef) {
+        props.ref = props.innerRef
+        delete props.innerRef
+      }
+
+      return <Component {...props} />
     }
   }
 

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -404,7 +404,29 @@ describe('theming', () => {
 
     // $FlowFixMe
     expect(ref).toHaveBeenCalledWith(inner.node)
-    expect(inner.prop('innerRef')).not.toHaveProperty('innerRef')
+    expect(inner.prop('innerRef')).toBe(ref)
+  })
+
+  it('should only pass the theme prop', () => {
+    class Comp extends React.Component {
+      render() {
+        return <div />
+      }
+    }
+
+    const CompWithTheme = withTheme(Comp)
+
+    const wrapper = mount(
+      <ThemeProvider theme={{}}>
+        <CompWithTheme />
+      </ThemeProvider>
+    )
+
+    const inner = wrapper.find(Comp).first()
+
+    // $FlowFixMe
+    expect(Object.keys(inner.props()).length).toEqual(1)
+    expect(inner.props()).toEqual({ theme: {} })
   })
 
   it('should accept innerRef and pass it on for stateless function components', () => {

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -384,29 +384,6 @@ describe('theming', () => {
     expect(MyComponentWithTheme.myStaticProperty).toBe(true)
   })
 
-  it('should accept innerRef and pass it on as ref', () => {
-    class Comp extends React.Component {
-      render() {
-        return <div />
-      }
-    }
-
-    const CompWithTheme = withTheme(Comp)
-    const ref = jest.fn()
-
-    const wrapper = mount(
-      <ThemeProvider theme={{}}>
-        <CompWithTheme innerRef={ref} />
-      </ThemeProvider>
-    )
-
-    const inner = wrapper.find(Comp).first()
-
-    // $FlowFixMe
-    expect(ref).toHaveBeenCalledWith(inner.node)
-    expect(inner.prop('innerRef')).toBe(ref)
-  })
-
   it('should only pass the theme prop', () => {
     class Comp extends React.Component {
       render() {
@@ -427,6 +404,30 @@ describe('theming', () => {
     // $FlowFixMe
     expect(Object.keys(inner.props()).length).toEqual(1)
     expect(inner.props()).toEqual({ theme: {} })
+  })
+
+  it('should accept innerRef and pass it on as ref', () => {
+    class Comp extends React.Component {
+      render() {
+        console.log("COMP PROPS", this.props);
+        return <div />
+      }
+    }
+
+    const CompWithTheme = withTheme(Comp, "BLABLA")
+    const ref = jest.fn()
+
+    const wrapper = mount(
+      <ThemeProvider theme={{}}>
+        <CompWithTheme innerRef={ref} />
+      </ThemeProvider>
+    )
+
+    const inner = wrapper.find(Comp).first();
+
+    // $FlowFixMe
+    expect(ref).toHaveBeenCalledWith(inner.node)
+    expect(inner.props()).not.toHaveProperty('innerRef')
   })
 
   it('should accept innerRef and pass it on for stateless function components', () => {

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -401,7 +401,6 @@ describe('theming', () => {
 
     const inner = wrapper.find(Comp).first()
 
-    // $FlowFixMe
     expect(Object.keys(inner.props()).length).toEqual(1)
     expect(inner.props()).toEqual({ theme: {} })
   })

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -414,7 +414,7 @@ describe('theming', () => {
       }
     }
 
-    const CompWithTheme = withTheme(Comp, "BLABLA")
+    const CompWithTheme = withTheme(Comp)
     const ref = jest.fn()
 
     const wrapper = mount(

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -409,7 +409,6 @@ describe('theming', () => {
   it('should accept innerRef and pass it on as ref', () => {
     class Comp extends React.Component {
       render() {
-        console.log("COMP PROPS", this.props);
         return <div />
       }
     }

--- a/src/test/theme.test.js
+++ b/src/test/theme.test.js
@@ -404,7 +404,7 @@ describe('theming', () => {
 
     // $FlowFixMe
     expect(ref).toHaveBeenCalledWith(inner.node)
-    expect(inner.prop('innerRef')).toBe(undefined)
+    expect(inner.prop('innerRef')).not.toHaveProperty('innerRef')
   })
 
   it('should accept innerRef and pass it on for stateless function components', () => {


### PR DESCRIPTION
Fixes the warning that sometimes occurs when using `withTheme`. Currently, when `shouldSetInnerRef` is `false`, it adds `innerRef` as `undefined` when it should not add it at all. 

<img width="394" alt="screen shot 2018-01-08 at 2 27 10 pm" src="https://user-images.githubusercontent.com/4398635/34688420-15272f40-f480-11e7-8181-5b66a4662776.png">

If I try to use `{...this.props}` inside the component, it produces this error:

```
Warning: React does not recognize the `innerRef` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `innerref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```