### PR TITLE
expose isStyledComponent utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Fixed bug where `innerRef` could be passed as undefined to components when using withTheme. This could cause issues when using prop spread within the component (e.g. `{...this.props}`), because React will still warn you about using a non-dom prop even though it's undefined. (see [#1414](https://github.com/styled-components/styled-components/pull/1414))
 
+- Expose `isStyledComponent` utility as a named export. This functionality is useful in some edge cases, such as knowing whether or not to use `innerRef` vs `ref` and detecting if a component class needs to be wrapped such that it can be used in a component selector. (see [#1418](https://github.com/styled-components/styled-components/pull/1418/))
+
 ## [v2.4.0] - 2017-12-22
 
 - remove some extra information from the generated hash that can differ between build environments ([see #1381](https://github.com/styled-components/styled-components/pull/1381))

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 /* Import singletons */
 import flatten from './utils/flatten'
 import stringifyRules from './utils/stringifyRules'
+import isStyledComponent from './utils/isStyledComponent'
 import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
 import ServerStyleSheet from './models/ServerStyleSheet'
@@ -55,6 +56,7 @@ export {
   css,
   keyframes,
   injectGlobal,
+  isStyledComponent,
   ThemeProvider,
   withTheme,
   ServerStyleSheet,

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -10,6 +10,7 @@ import _constructWithOptions from '../constructors/constructWithOptions'
 import css from '../constructors/css'
 import ThemeProvider from '../models/ThemeProvider'
 import withTheme from '../hoc/withTheme'
+import isStyledComponent from '../utils/isStyledComponent'
 
 import type { Target } from '../types'
 
@@ -43,5 +44,5 @@ aliases.split(/\s+/m).forEach(alias =>
   }),
 )
 
-export { css, ThemeProvider, withTheme }
+export { css, isStyledComponent, ThemeProvider, withTheme }
 export default styled

--- a/src/primitives/index.js
+++ b/src/primitives/index.js
@@ -10,6 +10,7 @@ import _constructWithOptions from '../constructors/constructWithOptions'
 import css from '../constructors/css'
 import ThemeProvider from '../models/ThemeProvider'
 import withTheme from '../hoc/withTheme'
+import isStyledComponent from '../utils/isStyledComponent'
 
 import type { Target } from '../types'
 
@@ -37,5 +38,5 @@ aliases.split(/\s+/m).forEach(alias =>
   }),
 )
 
-export { css, ThemeProvider, withTheme }
+export { css, isStyledComponent, ThemeProvider, withTheme }
 export default styled


### PR DESCRIPTION
Expose `isStyledComponent` utility as a named export. This functionality is useful in some edge cases, such as knowing whether or not to use `innerRef` vs `ref` and detecting if a component class needs to be wrapped such that it can be used in a component selector.