### PR TITLE
Allow ComponentType to be passed to styled

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -53,7 +53,7 @@ type ThemedStyledComponentFactories<T> = {
 export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
   <P, TTag extends keyof JSX.IntrinsicElements>(tag: TTag): ThemedStyledFunction<P, T, P & JSX.IntrinsicElements[TTag]>;
   <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<P, T, O>;
-  <P>(component: React.ComponentType<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
+  <P extends { [prop: string]: any; theme?: T }>(component: React.ComponentType<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
 

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -53,9 +53,7 @@ type ThemedStyledComponentFactories<T> = {
 export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFactories<T> {
   <P, TTag extends keyof JSX.IntrinsicElements>(tag: TTag): ThemedStyledFunction<P, T, P & JSX.IntrinsicElements[TTag]>;
   <P, O>(component: StyledComponentClass<P, T, O>): ThemedStyledFunction<P, T, O>;
-  <P extends { theme: T; }>(component: React.ComponentClass<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
-  <P>(component: React.ComponentClass<P>): ThemedStyledFunction<P, T>;
-  <P extends { [prop: string]: any; theme?: T; }>(component: React.StatelessComponent<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
+  <P>(component: React.ComponentType<P>): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>;
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
 

--- a/typings/tests/component-type-test.tsx
+++ b/typings/tests/component-type-test.tsx
@@ -6,4 +6,9 @@ declare const C: React.ComponentClass | React.StatelessComponent;
 
 styled(A); // succeeds
 styled(B); // succeeds
-styled(C); // fails
+styled(C); // used to fail; see issue trail linked below
+
+// https://github.com/mui-org/material-ui/pull/8781#issuecomment-349460247
+// https://github.com/mui-org/material-ui/issues/9838
+// https://github.com/styled-components/styled-components/pull/1420
+// https://github.com/styled-components/styled-components/pull/1427

--- a/typings/tests/component-type-test.tsx
+++ b/typings/tests/component-type-test.tsx
@@ -11,4 +11,5 @@ styled(C); // used to fail; see issue trail linked below
 // https://github.com/mui-org/material-ui/pull/8781#issuecomment-349460247
 // https://github.com/mui-org/material-ui/issues/9838
 // https://github.com/styled-components/styled-components/pull/1420
+// https://github.com/Microsoft/TypeScript/issues/21175
 // https://github.com/styled-components/styled-components/pull/1427

--- a/typings/tests/component-type-test.tsx
+++ b/typings/tests/component-type-test.tsx
@@ -1,0 +1,9 @@
+import styled from "../..";
+
+declare const A: React.ComponentClass;
+declare const B: React.StatelessComponent;
+declare const C: React.ComponentClass | React.StatelessComponent;
+
+styled(A); // succeeds
+styled(B); // succeeds
+styled(C); // fails

--- a/typings/tests/component-type-test.tsx
+++ b/typings/tests/component-type-test.tsx
@@ -2,7 +2,7 @@ import styled from "../..";
 
 declare const A: React.ComponentClass;
 declare const B: React.StatelessComponent;
-declare const C: React.ComponentClass | React.StatelessComponent;
+declare const C: React.ComponentType;
 
 styled(A); // succeeds
 styled(B); // succeeds


### PR DESCRIPTION
This simplifies the typing of `styled` and allows passing it a `React.ComponentType<P>`. Adds a very simple test case that checks the same thing as #1420 but without the need to depend on all of `material-ui`.

Resolves #1420.
Resolves https://github.com/mui-org/material-ui/issues/9838.