### PR TITLE
fix(native typescript): Remove Navigator

### DIFF
--- a/native/index.d.ts
+++ b/native/index.d.ts
@@ -35,7 +35,6 @@ export interface StyledInterface extends BaseStyledInterface {
   ListView: ReactNativeStyledFunction<ReactNative.ListViewProperties>;
   MapView: ReactNativeStyledFunction<ReactNative.MapViewProperties>;
   Modal: ReactNativeStyledFunction<ReactNative.ModalProperties>;
-  Navigator: ReactNativeStyledFunction<ReactNative.NavigatorProperties>;
   NavigatorIOS: ReactNativeStyledFunction<ReactNative.NavigatorIOSProperties>;
   Picker: ReactNativeStyledFunction<ReactNative.PickerProperties>;
   PickerIOS: ReactNativeStyledFunction<ReactNative.PickerIOSProperties>;


### PR DESCRIPTION
Navigator is no longer included in the react-native definition typings, so it throws an error at compile time.