### PR TITLE
fix react-native main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/styled-components.cjs.js",
   "jsnext:main": "dist/styled-components.es.js",
   "module": "dist/styled-components.es.js",
-  "react-native": "dist/styled-components.cjs.native.js",
+  "react-native": "dist/styled-components.native.cjs.js",
   "browser": {
     "./dist/styled-components.es.js": "./dist/styled-components.browser.es.js",
     "./dist/styled-components.cjs.js": "./dist/styled-components.browser.cjs.js",


### PR DESCRIPTION
3.1.1 still contains a little problem for React-Native:

```
error: bundling failed: Error: While trying to resolve module `styled-components` from file `/Users/didou/js/react-native/git-point/App.js`, the package `/Users/didou/js/react-native/git-point/node_modules/styled-components/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/didou/js/react-native/git-point/node_modules/styled-components/dist/styled-components.cjs.native.js`. Indeed, none of these files exist:

  * `/Users/didou/js/react-native/git-point/node_modules/styled-components/dist/styled-components.cjs.native.js(.native||.ios.js|.native.js|.js|.ios.json|.native.json|.json)`
  * `/Users/didou/js/react-native/git-point/node_modules/styled-components/dist/styled-components.cjs.native.js/index(.native||.ios.js|.native.js|.js|.ios.json|.native.json|.json)`
```