### PR TITLE
simplify stream emitter code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
+- Bugfix for the last style tag sometimes being emitted multiple times during streaming ([see #1479](https://github.com/styled-components/styled-components/pull/1479))
+
 ## [v3.1.5] - 2018-02-01
 
 - Apply a workaround to re-enable "speedy" mode for IE/Edge ([see #1468](https://github.com/styled-components/styled-components/pull/1468))

--- a/src/models/ServerStyleSheet.js
+++ b/src/models/ServerStyleSheet.js
@@ -133,7 +133,6 @@ export default class ServerStyleSheet {
   closed: boolean
   instance: StyleSheet
   isStreaming: boolean
-  lastIndex: number
 
   constructor() {
     this.instance = StyleSheet.clone(StyleSheet.instance)
@@ -182,17 +181,17 @@ export default class ServerStyleSheet {
       ourStream._read = () => {}
 
       this.isStreaming = true
-      this.lastIndex = 0
 
       readableStream.on('data', chunk => {
         ourStream.push(
-          this.instance.tags
-            .slice(this.lastIndex)
-            .map(tag => tag.toHTML())
-            .join('') + chunk
-        )
+          this.instance.tags.reduce((html, tag) => {
+            if (!tag.isSealed()) {
+              html += tag.toHTML() // eslint-disable-line no-param-reassign
+            }
 
-        this.lastIndex = this.instance.tags.length - 1
+            return html
+          }, '') + chunk
+        )
       })
 
       readableStream.on('end', () => {


### PR DESCRIPTION
fixes a bug where the last tag might end up getting emitted multiple times due to an off-by-1 issue