### PR TITLE
fix a few bugs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 - Bugfix for the last style tag sometimes being emitted multiple times during streaming ([see #1479](https://github.com/styled-components/styled-components/pull/1479))
 
+- Bugfix for speedy mode rehydration and added handling for out-of-order style injection ([see #1482](https://github.com/styled-components/styled-components/pull/1482))
+
 ## [v3.1.5] - 2018-02-01
 
 - Apply a workaround to re-enable "speedy" mode for IE/Edge ([see #1468](https://github.com/styled-components/styled-components/pull/1468))

--- a/src/models/BrowserStyleSheet.js
+++ b/src/models/BrowserStyleSheet.js
@@ -419,7 +419,11 @@ export default {
       }
 
       tags.push(
-        new BrowserTag(el, el.getAttribute(LOCAL_ATTR) === 'true', el.innerHTML)
+        new BrowserTag(
+          el,
+          el.getAttribute(LOCAL_ATTR) === 'true',
+          el.textContent
+        )
       )
     }
 

--- a/src/models/ServerStyleSheet.js
+++ b/src/models/ServerStyleSheet.js
@@ -132,11 +132,10 @@ class ServerTag implements Tag {
 export default class ServerStyleSheet {
   closed: boolean
   instance: StyleSheet
-  isStreaming: boolean
 
   constructor() {
     this.instance = StyleSheet.clone(StyleSheet.instance)
-    this.isStreaming = false
+    this.instance.isStreaming = false
   }
 
   collectStyles(children: any) {
@@ -180,7 +179,7 @@ export default class ServerStyleSheet {
       // $FlowFixMe
       ourStream._read = () => {}
 
-      this.isStreaming = true
+      this.instance.isStreaming = true
 
       readableStream.on('data', chunk => {
         ourStream.push(

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -34,6 +34,7 @@ export default class StyleSheet {
   hashes: { [string]: string } = {}
   deferredInjections: { [string]: Array<string> } = {}
   componentTags: { [string]: Tag }
+  isStreaming: boolean
 
   // helper for `ComponentStyle` to know when it cache static styles.
   // staticly styled-component can not safely cache styles on the server
@@ -53,6 +54,7 @@ export default class StyleSheet {
     this.tags = tags
     this.names = names
     this.constructComponentTagMap()
+    this.isStreaming = false
   }
 
   constructComponentTagMap() {
@@ -138,7 +140,9 @@ export default class StyleSheet {
      * in a streaming context, once a tag is sealed it can never be added to again
      * or those styles will never make it to the client
      */
-    if (existingTag && !existingTag.isSealed()) {
+    if (
+      existingTag && this.isStreaming ? !existingTag.isSealed() : existingTag
+    ) {
       return existingTag
     }
 

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -133,7 +133,12 @@ export default class StyleSheet {
 
   getOrCreateTag(componentId: string, isLocal: boolean) {
     const existingTag = this.componentTags[componentId]
-    if (existingTag) {
+
+    /**
+     * in a streaming context, once a tag is sealed it can never be added to again
+     * or those styles will never make it to the client
+     */
+    if (existingTag && !existingTag.isSealed()) {
       return existingTag
     }
 


### PR DESCRIPTION
1. on rehydration when SPEEDY is on, certain CSS selector characters were getting HTML entity-ifed due to usage of `innerHTML`

2. fix a streaming edge case when additional styles are appended to an existing element whose tag was already emitted