### PR TITLE
Typescript SSR Stream support

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "supports-color": "^3.2.3"
   },
   "devDependencies": {
+    "@types/node": "9.4.4",
     "@types/react": "^16",
+    "@types/react-dom": "^16",
     "@types/react-native": "^0.50.7",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.17.0",

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -93,6 +93,7 @@ export function withTheme<P extends { theme?: T; }, T>(component: Component<P>):
 
 export function keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
 export function injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;
+export function consolidateStreamedStyles(): void;
 
 export const ThemeProvider: ThemeProviderComponent<object>;
 
@@ -112,6 +113,7 @@ export class ServerStyleSheet {
 
   getStyleTags(): string;
   getStyleElement(): ReactElement<{}>[];
+  interleaveWithNodeStream(readableStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
   instance: StyleSheet;
 }
 

--- a/typings/tests/server-test.tsx
+++ b/typings/tests/server-test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import styled, { ServerStyleSheet, StyleSheetManager } from "../..";
+import * as ReactDOMServer from "react-dom/server";
+import styled, { consolidateStreamedStyles, ServerStyleSheet, StyleSheetManager } from "../..";
 
 const Title = styled.h1`
   font-size: 1.5em;
@@ -20,3 +21,13 @@ const element = (
 );
 
 const css2 = sheet2.getStyleElement();
+
+// Wrapping a node stream returned from renderToNodeStream with interleaveWithNodeStream
+
+const sheet3 = new ServerStyleSheet();
+const appStream = ReactDOMServer.renderToNodeStream(<Title>Hello world</Title>);
+const wrappedCssStream: NodeJS.ReadableStream = sheet3.interleaveWithNodeStream(appStream);
+
+// Ensure presence of consolidateStreamedStyles
+
+consolidateStreamedStyles();

--- a/typings/tests/tsconfig.json
+++ b/typings/tests/tsconfig.json
@@ -30,7 +30,8 @@
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
+    "skipLibCheck": true,
+    
     /* Module Resolution Options */
     "moduleResolution": "node",                /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,17 @@
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
 
+"@types/node@9.4.4":
+  version "9.4.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.4.tgz#4cad4305d1ec84eab2dc2bda97dfb6a5f652cccb"
+
+"@types/react-dom@^16":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.3.tgz#8accad7eabdab4cca3e1a56f5ccb57de2da0ff64"
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+
 "@types/react-native@^0.50.7":
   version "0.50.8"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.50.8.tgz#5a47c043a1cf626c054e3cb1dccd1b3045eb67d3"


### PR DESCRIPTION
This is a small change that adds TypeScript definitions for `ServerStyleSheet`'s `interleaveWithNodeStream` and the `consolidateStreamedStyles` methods.

One important thing to note is that there was a need to install the `@types/node` module to access the `NodeJS.ReadableStream` type, which is what `react-dom/server`'s `renderToNodeStream` returns. The TypeScript node definition conflicts with that of `react-native` because they both globally declare different require methods. For this reason, I had to set `skipLibCheck` to false in the tsconfig file.

For more information on the conflict:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16825