### PR TITLE
Refactor to shave off a couple of bytes from bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
+- Replace murmurhash implementation and avoid destructuring tag function arguments (see [#1516](https://github.com/styled-components/styled-components/pull/1516))
+
 - Rewrite and refactor `StyleSheet` and `ServerStyleSheet` (no breaking change, see [#1501](https://github.com/styled-components/styled-components/pull/1501))
 
 - Add warning if there are several instances of `styled-components` initialized on the page (see [#1412](https://github.com/styled-components/styled-components/pull/1412))

--- a/src/constructors/constructWithOptions.js
+++ b/src/constructors/constructWithOptions.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Interpolation, Target } from '../types'
+import type { Target } from '../types'
 
 export default (css: Function) => {
   const constructWithOptions = (
@@ -16,10 +16,9 @@ export default (css: Function) => {
     }
 
     /* This is callable directly as a template function */
-    const templateFunction = (
-      strings: Array<string>,
-      ...interpolations: Array<Interpolation>
-    ) => componentConstructor(tag, options, css(strings, ...interpolations))
+    // $FlowFixMe: Not typed to avoid destructuring arguments
+    const templateFunction = (...args) =>
+      componentConstructor(tag, options, css(...args))
 
     /* If config methods are called, wrap up a new template function and merge options */
     templateFunction.withConfig = config =>

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -3,12 +3,14 @@ import hashStr from '../vendor/glamor/hash'
 import StyleSheet from '../models/StyleSheet'
 import type { Interpolation, Stringifier } from '../types'
 
+type InjectGlobalFn = (
+  strings: Array<string>,
+  ...interpolations: Array<Interpolation>
+) => void
+
 export default (stringifyRules: Stringifier, css: Function) => {
-  const injectGlobal = (
-    strings: Array<string>,
-    ...interpolations: Array<Interpolation>
-  ) => {
-    const rules = css(strings, ...interpolations)
+  const injectGlobal: InjectGlobalFn = (...args) => {
+    const rules = css(...args)
     const hash = hashStr(JSON.stringify(rules))
 
     const id = `sc-global-${hash}`

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -5,15 +5,17 @@ import StyleSheet from '../models/StyleSheet'
 
 const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 
+type KeyframesFn = (
+  strings: Array<string>,
+  ...interpolations: Array<Interpolation>
+) => string
+
 export default (
   nameGenerator: NameGenerator,
   stringifyRules: Stringifier,
   css: Function
-) => (
-  strings: Array<string>,
-  ...interpolations: Array<Interpolation>
-): string => {
-  const rules = css(strings, ...interpolations)
+): KeyframesFn => (...arr): string => {
+  const rules = css(...arr)
   const hash = hashStr(replaceWhitespace(JSON.stringify(rules)))
 
   const existingName = StyleSheet.master.getNameForHash(hash)

--- a/src/vendor/glamor/hash.js
+++ b/src/vendor/glamor/hash.js
@@ -1,64 +1,40 @@
-// murmurhash2 via https://gist.github.com/raycmorgan/588423
+// Source: https://github.com/garycourt/murmurhash-js/blob/master/murmurhash2_gc.js
+function murmurhash(str) {
+  var
+    l = str.length | 0,
+    h = l | 0,
+    i = 0,
+    k;
 
-export default function doHash(str, seed) {
-  var m = 0x5bd1e995;
-  var r = 24;
-  var h = seed ^ str.length;
-  var length = str.length;
-  var currentIndex = 0;
+  while (l >= 4) {
+    k =
+      ((str.charCodeAt(i) & 0xff)) |
+      ((str.charCodeAt(++i) & 0xff) << 8) |
+      ((str.charCodeAt(++i) & 0xff) << 16) |
+      ((str.charCodeAt(++i) & 0xff) << 24);
 
-  while (length >= 4) {
-    var k = UInt32(str, currentIndex);
+    k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+    k ^= k >>> 24;
+    k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
 
-    k = Umul32(k, m);
-    k ^= k >>> r;
-    k = Umul32(k, m);
+    h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)) ^ k;
 
-    h = Umul32(h, m);
-    h ^= k;
-
-    currentIndex += 4;
-    length -= 4;
+    l -= 4;
+    ++i;
   }
 
-  switch (length) {
-    case 3:
-      h ^= UInt16(str, currentIndex);
-      h ^= str.charCodeAt(currentIndex + 2) << 16;
-      h = Umul32(h, m);
-      break;
-
-    case 2:
-      h ^= UInt16(str, currentIndex);
-      h = Umul32(h, m);
-      break;
-
-    case 1:
-      h ^= str.charCodeAt(currentIndex);
-      h = Umul32(h, m);
-      break;
+  switch (l) {
+    case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
+    case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
+    case 1: h ^= (str.charCodeAt(i) & 0xff);
+            h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
   }
 
   h ^= h >>> 13;
-  h = Umul32(h, m);
+  h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
   h ^= h >>> 15;
 
   return h >>> 0;
 }
 
-function UInt32(str, pos) {
-  return str.charCodeAt(pos++) + (str.charCodeAt(pos++) << 8) + (str.charCodeAt(pos++) << 16) + (str.charCodeAt(pos) << 24);
-}
-
-function UInt16(str, pos) {
-  return str.charCodeAt(pos++) + (str.charCodeAt(pos++) << 8);
-}
-
-function Umul32(n, m) {
-  n = n | 0;
-  m = m | 0;
-  var nlo = n & 0xffff;
-  var nhi = n >>> 16;
-  var res = nlo * m + ((nhi * m & 0xffff) << 16) | 0;
-  return res;
-}
+export default murmurhash


### PR DESCRIPTION
- Avoid destructuring the tagged template function arguments, which should also help performance a tiny bit
- Replace murmurhash implementation (That's the best one for JS imho; The commit message has a link showing that they yield the same results btw)