### PR TITLE
Disable marker comment in NODE_ENV = produciton

### DIFF
--- a/src/models/StyleTags.js
+++ b/src/models/StyleTags.js
@@ -46,7 +46,10 @@ The clone method cannot be used on the client!
 }
 
 /* this marker separates component styles and is important for rehydration */
-const makeTextMarker = id => `\n/* sc-component-id: ${id} */\n`
+const makeTextMarker = id =>
+  process.env.NODE_ENV !== 'production'
+    ? `\n/* sc-component-id: ${id} */\n`
+    : ''
 
 /* retrieve a sheet for a given style tag */
 const sheetForTag = (tag: HTMLStyleElement): CSSStyleSheet => {


### PR DESCRIPTION
Recently in production ( especially [AMP Site](https://www.ampproject.org/) ), response sizes from servers are wanted as short as possible.
[AMP restrict css sizes to 50,000 bytes.](https://www.ampproject.org/docs/guides/responsive_amp)

So I'd like to delete `makeTextMarker` comment in production.
I'm not sure what kind of effects exist in rehydration, so could you please confirm about it.