### PR TITLE
Add failing test for nested media queries

### DIFF
--- a/src/test/css.test.js
+++ b/src/test/css.test.js
@@ -34,6 +34,28 @@ describe('css features', () => {
     `)
   })
 
+  it('should generate styles for nested media queries', () => {
+    const Comp = styled.div`
+      @media (min-width: 10px) {
+        @media (min-height: 20px) {
+          color: red;
+        }
+      }
+    `
+    shallow(<Comp />)
+    expectCSSMatches(`
+      .sc-a {}
+      
+      @media (min-width: 10px) {
+        @media (min-height: 20px) {
+          .b {
+            color: red;
+          }
+        }
+      }
+    `)
+  })
+
   it('should pass through custom properties', () => {
     const Comp = styled.div`
       --custom-prop: some-val;


### PR DESCRIPTION
Nested media queries generate incorrect CSS.

Such component:
```js
const Comp = styled.div`
  @media (min-width: 10px) {
    @media (min-height: 20px) {
        color: red;
     }
  }
`
```

Will generate this CSS:
```
.sc-a {}
      
@media (min-width: 10px) {
  @media (min-height: 20px) {
    .b {
      color: red;
    }
  }
      
```

Notice the missing closing curly brace character (`}`)

I would love to fix this myself, but unfortunately, I don't know the code enough.

styled-components version: 3.1.6