### PR TITLE
Add support for correct execution of postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublish": "npm run build",
     "lint-staged": "lint-staged",
     "dev": "cross-env BABEL_ENV=cjs babel-node example/startServer.js",
-    "postinstall": "opencollective postinstall"
+    "postinstall": "opencollective postinstall || exit 0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As we can see in opencollection documentation https://github.com/opencollective/opencollective-postinstall#install, for correct work in production "exit 0" should be added to postinstall script.

Without this case sometimes styled-components produces an error:
npm ERR! code ELIFECYCLE
npm ERR! errno 126
npm ERR! styled-components@3.2.0 postinstall: `opencollective postinstall`
npm ERR! Exit status 126
npm ERR! 
npm ERR! Failed at the styled-components@3.2.0 postinstall script.