### PR TITLE
add envinfo command to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,10 +28,9 @@ Please keep it product-centric.
 -->
 
 <!-- BUG TEMPLATE -->
-## Version
-styled-components: 2.2.4
-babel-plugin-styled-components: 1.3.0
-<!-- Please remove babel-plugin-styled-components if it's not applicable -->
+## Environment
+<!-- Please run this command inside your project and paste its contents here (it automatically copies to your clipboard) -->
+`npx envinfo --system --binaries --npmPackages styled-components,babel-plugin-styled-components --markdown --clipboard`
 
 ## Reproduction
 


### PR DESCRIPTION
This is a partial solution to https://github.com/styled-components/styled-components/issues/1584

Here is a sample of the environment report that will envinfo will provide:

tabrindle-mbp:ap2-client tabrindle$ npx envinfo --markdown --clipboard --system --binaries --npmPackages styled-components,babel-plugin-styled-components

## System:
 - OS: macOS High Sierra 10.13
 - CPU: x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
 - Free Memory: 656.37 MB
 - Total Memory: 16.00 GB
 - Shell: /usr/local/bin/bash - 4.4.12
## Binaries:
 - Node: 8.9.4
 - Yarn: 1.3.2
 - npm: 5.6.0
 - Watchman: 4.9.0
 - Docker: 17.12.0-ce, build c97c6d6
 - Homebrew: 1.5.8
## npmPackages:
### styled-components:
 - wanted: ^3.1.6
 - installed: 3.1.6