### PR TITLE
Upgrade stylis & stylis-rule-sheet to fix nested at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
-- n/a
+- Fix nested media at-rules by upgrading to stylis@^3.5.0 and stylis-rule-sheet@^0.0.10 (see [#1595](https://github.com/styled-components/styled-components/pull/1595))
 
 ## [v3.2.1] - 2018-03-07
 

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "is-plain-object": "^2.0.1",
     "opencollective": "^1.0.3",
     "prop-types": "^15.5.4",
-    "stylis": "^3.4.10",
-    "stylis-rule-sheet": "^0.0.8",
+    "stylis": "^3.5.0",
+    "stylis-rule-sheet": "^0.0.10",
     "supports-color": "^3.2.3"
   },
   "devDependencies": {

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -176,5 +176,18 @@ describe('basic', () => {
 
       expectCSSMatches('.sc-a {} .d { color:red; } .sc-b {} .c { color:blue; }')
     })
+
+    it('handle media at-rules inside style rules', () => {
+      const Comp = styled.div`
+        > * {
+          @media (min-width: 500px) {
+            color: pink;
+          }
+        }
+      `
+
+      shallow(<Comp />)
+      expectCSSMatches('.sc-a{ } @media (min-width:500px){ .b > *{ color:pink; } } ')
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7310,13 +7310,13 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-stylis-rule-sheet@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.8.tgz#b0d0a126c945b1f3047447a3aae0647013e8d166"
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
 
-stylis@^3.4.10:
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.10.tgz#a135cab4b9ff208e327fbb5a6fde3fa991c638ee"
+stylis@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Resolves #1576 

This will simply upgrade to stylis@^3.5.0 and stylis-rule-sheet@^0.0.10

See: https://github.com/thysultan/stylis.js/issues/99
And: https://github.com/thysultan/stylis.js/blob/master/CHANGELOG.md#350-march-08-2018