### PR TITLE
Add ability to change SC_ATTR via process.env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
-- n/a
+- Added ability to override `SC_ATTR` via `process.env.SC_ATTR`
 
 ## [v3.2.3] - 2018-03-14
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,7 @@
 
 declare var __DEV__: ?string
 
-export const SC_ATTR = 'data-styled-components'
+export const SC_ATTR = process.env.SC_ATTR || 'data-styled-components'
 export const SC_STREAM_ATTR = 'data-styled-streamed'
 export const CONTEXT_KEY = '__styled-components-stylesheet__'
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,9 @@
 
 declare var __DEV__: ?string
 
-export const SC_ATTR = process.env.SC_ATTR || 'data-styled-components'
+export const SC_ATTR =
+  (typeof process !== 'undefined' && process.env.SC_ATTR) ||
+  'data-styled-components'
 export const SC_STREAM_ATTR = 'data-styled-streamed'
 export const CONTEXT_KEY = '__styled-components-stylesheet__'
 

--- a/src/test/constants.test.js
+++ b/src/test/constants.test.js
@@ -1,0 +1,43 @@
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { expectCSSMatches } from './utils'
+import { SC_ATTR as DEFAULT_SC_ATTR } from '../constants';
+
+
+function renderAndExpect(expectedAttr) {
+  const SC_ATTR = require('../constants').SC_ATTR
+  const styled = require('./utils').resetStyled()
+
+  const Comp = styled.div`
+      color: blue;
+    `
+
+  shallow(<Comp />)
+
+  expectCSSMatches('.sc-a { } .b { color:blue; }')
+
+  expect(SC_ATTR).toEqual(expectedAttr)
+  expect(document.head.querySelectorAll(`style[${SC_ATTR}]`)).toHaveLength(1)
+}
+
+describe('constants', () => {
+  it('should work with default SC_ATTR', () => {
+    renderAndExpect(DEFAULT_SC_ATTR)
+  })
+
+  it('should work with custom SC_ATTR', () => {
+    const CUSTOM_SC_ATTR = 'data-custom-styled-components'
+    process.env.SC_ATTR = CUSTOM_SC_ATTR
+    jest.resetModules()
+
+    renderAndExpect(CUSTOM_SC_ATTR)
+
+    delete process.env.SC_ATTR
+  })
+
+  afterEach(() => {
+    jest.resetModules()
+  })
+});

--- a/src/test/constants.test.js
+++ b/src/test/constants.test.js
@@ -1,18 +1,16 @@
-
 import React from 'react'
 import { shallow } from 'enzyme'
 
 import { expectCSSMatches } from './utils'
-import { SC_ATTR as DEFAULT_SC_ATTR } from '../constants';
-
+import { SC_ATTR as DEFAULT_SC_ATTR } from '../constants'
 
 function renderAndExpect(expectedAttr) {
   const SC_ATTR = require('../constants').SC_ATTR
   const styled = require('./utils').resetStyled()
 
   const Comp = styled.div`
-      color: blue;
-    `
+    color: blue;
+  `
 
   shallow(<Comp />)
 
@@ -40,4 +38,4 @@ describe('constants', () => {
   afterEach(() => {
     jest.resetModules()
   })
-});
+})


### PR DESCRIPTION
This PR will fix https://github.com/styled-components/styled-components/issues/1032

I have similar problem when embedding our widget to sites using styled-components.
Even when StyleSheetManager used inside iframe for isolating styles, styled-components inserts empty `<style />` into main `window.head`. As @prevostc mentioned, providing custom `SC_ATTR` fix conflict and styles no longer break.