### PR TITLE
Fix ComponentStyle caching strategy to take StyleSheet cache into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
-- Fix issue with multiple iframes and StyleSheetManager instances. @darthtrevino (see [#1634])
+-  Fix ComponentStyle caching strategy to take StyleSheet cache into account. @darthtrevino (see [#1634])
 
 ## [v3.2.3] - 2018-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
-- n/a
+- Fix issue with multiple iframes and StyleSheetManager instances. @darthtrevino (see [#1634])
 
 ## [v3.2.3] - 2018-03-14
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-frame-component": "^2.0.2",
     "react-native": "^0.46.0",
     "react-primitives": "^0.4.2",
     "react-test-renderer": "^16.0.0",

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -1,13 +1,7 @@
 // @flow
 import hashStr from '../vendor/glamor/hash'
 
-import type {
-  RuleSet,
-  NameGenerator,
-  Flattener,
-  Stringifier,
-  Interpolation,
-} from '../types'
+import type { RuleSet, NameGenerator, Flattener, Stringifier } from '../types'
 import StyleSheet from './StyleSheet'
 import { IS_BROWSER } from '../constants'
 import isStyledComponent from '../utils/isStyledComponent'
@@ -84,23 +78,20 @@ export default (
      * */
     generateAndInjectStyles(executionContext: Object, styleSheet: StyleSheet) {
       const { isStatic, componentId, lastClassName } = this
-      let flatCSSResult: ?Array<Interpolation> = null
-      const flatCSS = (): Array<Interpolation> => {
-        if (!flatCSSResult) {
-          flatCSSResult = flatten(this.rules, executionContext)
-        }
-        return flatCSSResult
+      if (
+        areStylesCacheable &&
+        isStatic &&
+        lastClassName !== undefined &&
+        styleSheet.hasNameForId(componentId, ((lastClassName: any): string))
+      ) {
+        return lastClassName
       }
 
-      const useLastClassName: boolean =
-        areStylesCacheable && isStatic && lastClassName !== undefined
-
-      const name: string = useLastClassName
-        ? ((lastClassName: any): string)
-        : generateRuleHash(this.componentId + flatCSS().join(''))
+      const flatCSS = flatten(this.rules, executionContext)
+      const name = generateRuleHash(this.componentId + flatCSS.join(''))
 
       if (!styleSheet.hasNameForId(componentId, name)) {
-        const css = stringifyRules(flatCSS(), `.${name}`)
+        const css = stringifyRules(flatCSS, `.${name}`)
         styleSheet.inject(this.componentId, css, name)
       }
 

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -1,7 +1,13 @@
 // @flow
 import hashStr from '../vendor/glamor/hash'
 
-import type { RuleSet, NameGenerator, Flattener, Stringifier } from '../types'
+import type {
+  RuleSet,
+  NameGenerator,
+  Flattener,
+  Stringifier,
+  Interpolation,
+} from '../types'
 import StyleSheet from './StyleSheet'
 import { IS_BROWSER } from '../constants'
 import isStyledComponent from '../utils/isStyledComponent'
@@ -78,17 +84,23 @@ export default (
      * */
     generateAndInjectStyles(executionContext: Object, styleSheet: StyleSheet) {
       const { isStatic, componentId, lastClassName } = this
-      const flatCSS = flatten(this.rules, executionContext)
+      let flatCSSResult: ?Array<Interpolation> = null
+      const flatCSS = (): Array<Interpolation> => {
+        if (!flatCSSResult) {
+          flatCSSResult = flatten(this.rules, executionContext)
+        }
+        return flatCSSResult
+      }
 
       const useLastClassName: boolean =
         areStylesCacheable && isStatic && lastClassName !== undefined
 
       const name: string = useLastClassName
         ? ((lastClassName: any): string)
-        : generateRuleHash(this.componentId + flatCSS.join(''))
+        : generateRuleHash(this.componentId + flatCSS().join(''))
 
       if (!styleSheet.hasNameForId(componentId, name)) {
-        const css = stringifyRules(flatCSS, `.${name}`)
+        const css = stringifyRules(flatCSS(), `.${name}`)
         styleSheet.inject(this.componentId, css, name)
       }
 

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -78,12 +78,14 @@ export default (
      * */
     generateAndInjectStyles(executionContext: Object, styleSheet: StyleSheet) {
       const { isStatic, componentId, lastClassName } = this
-      if (areStylesCacheable && isStatic && lastClassName !== undefined) {
-        return lastClassName
-      }
-
       const flatCSS = flatten(this.rules, executionContext)
-      const name = generateRuleHash(this.componentId + flatCSS.join(''))
+
+      const useLastClassName: boolean =
+        areStylesCacheable && isStatic && lastClassName !== undefined
+
+      const name: string = useLastClassName
+        ? ((lastClassName: any): string)
+        : generateRuleHash(this.componentId + flatCSS.join(''))
 
       if (!styleSheet.hasNameForId(componentId, name)) {
         const css = stringifyRules(flatCSS, `.${name}`)

--- a/src/models/test/StyleSheetManager.test.js
+++ b/src/models/test/StyleSheetManager.test.js
@@ -1,12 +1,15 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
 import React from 'react'
+import PropTypes from 'prop-types'
 import { renderToString } from 'react-dom/server'
+import { render } from 'react-dom'
 import { shallow, mount } from 'enzyme'
 import StyleSheetManager from '../StyleSheetManager'
 import StyleSheet from '../StyleSheet'
 import ServerStyleSheet from '../ServerStyleSheet'
 import { resetStyled, expectCSSMatches } from '../../test/utils'
+import Frame from 'react-frame-component'
 
 let styled
 
@@ -115,6 +118,69 @@ describe('StyleSheetManager', () => {
     // $FlowFixMe
     expect(document.body.innerHTML).toMatchSnapshot()
   })
+
+  // https://github.com/styled-components/styled-components/issues/1634
+  it('should flush styles to an iframe when the iframe is re-rendered', async () => {
+    const Title = styled.h1`
+      color: palevioletred;
+    `
+
+    // Injects the stylesheet into the document available via context
+    const SheetInjector = ({ children }, { document }) => (
+      <StyleSheetManager target={document.head}>{children}</StyleSheetManager>
+    )
+    SheetInjector.contextTypes = {
+      document: PropTypes.any,
+    }
+
+    class Child extends React.Component {
+      static contextTypes = {
+        document: PropTypes.any,
+      }
+
+      componentDidMount() {
+        // $FlowFixMe
+        const styles = this.context.document.querySelector('style').textContent
+        expect(styles.includes(`palevioletred`)).toEqual(true)
+        this.props.resolve()
+      }
+      render() {
+        return <Title />
+      }
+    }
+
+    const div = document.body.appendChild(document.createElement('div'))
+
+    let promiseA, promiseB
+    promiseA = new Promise((resolveA, reject) => {
+      promiseB = new Promise((resolveB, reject) => {
+        try {
+          // Render two iframes. each iframe should have the styles for the child injected into their head
+          render(
+            <div>
+              <Frame>
+                <SheetInjector>
+                  <Child resolve={resolveA} />
+                </SheetInjector>
+              </Frame>
+              <Frame>
+                <SheetInjector>
+                  <Child resolve={resolveB} />
+                </SheetInjector>
+              </Frame>
+            </div>,
+            div
+          )
+        } catch (e) {
+          reject(e)
+          div.parentElement.removeChild(div)
+        }
+      })
+    })
+    await Promise.all([promiseA, promiseB])
+    div.parentElement.removeChild(div)
+  })
+
 
   describe('ssr', () => {
     it('should extract CSS outside the nested StyleSheetManager', () => {

--- a/src/models/test/StyleSheetManager.test.js
+++ b/src/models/test/StyleSheetManager.test.js
@@ -120,7 +120,7 @@ describe('StyleSheetManager', () => {
   })
 
   // https://github.com/styled-components/styled-components/issues/1634
-  it('should flush styles to an iframe when the iframe is re-rendered', async () => {
+  it('should inject styles into two parallel contexts', async () => {
     const Title = styled.h1`
       color: palevioletred;
     `

--- a/yarn.lock
+++ b/yarn.lock
@@ -6162,6 +6162,10 @@ react-dom@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-frame-component@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-2.0.2.tgz#e602a980e1d78f91f471531225b61cfdbf68e614"
+
 react-native-web@0.0.x:
   version "0.0.130"
   resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.0.130.tgz#fea4843999f29cb8d8c3680fcfc71e389db28951"


### PR DESCRIPTION
Fixes #1634, Whitespace-change free version of PR #1635

When ComponentStyle.generateAndInjectStyles is invoked, the stylesheet instance should be checked even if the style name is already defined. If the component is being rendered in a sibling iframe with a separate StyleSheetManager, this allows the second iframe to receive the injected styles.