### PR TITLE
Bump hoist-non-react-statics to support React 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "buffer": "^5.0.3",
     "css-to-react-native": "^2.0.3",
     "fbjs": "^0.8.9",
-    "hoist-non-react-statics": "^1.2.0",
+    "hoist-non-react-statics": "^2.5.0",
     "is-plain-object": "^2.0.1",
     "opencollective": "^1.0.3",
     "prop-types": "^15.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,9 +3629,9 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Just noticed recently in the project I'm using that `static getDerivedStateFromProps` is not being hoisted by `withTheme` and bumping `hoist-non-react-statics` fix it, because it's now supported. Hopefully it doesn't break any tests 😅.