### PR TITLE
Include falsey values in InterpolationValue

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -16,9 +16,10 @@ export type ThemedOuterStyledProps<P, T> = P & {
 };
 export type OuterStyledProps<P> = ThemedOuterStyledProps<P, any>;
 
+export type FalseyValue = undefined | null | false | "";
 export type Interpolation<P> = FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P>>>;
 export type FlattenInterpolation<P> = InterpolationValue | InterpolationFunction<P>;
-export type InterpolationValue = string | number | Styles | StyledComponentClass<any, any>;
+export type InterpolationValue = string | number | Styles | FalseyValue | StyledComponentClass<any, any>;
 export type SimpleInterpolation = InterpolationValue | ReadonlyArray<InterpolationValue | ReadonlyArray<InterpolationValue>>;
 export interface Styles {
   [ruleOrSelector: string]: string | number | Styles;

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -16,7 +16,7 @@ export type ThemedOuterStyledProps<P, T> = P & {
 };
 export type OuterStyledProps<P> = ThemedOuterStyledProps<P, any>;
 
-export type FalseyValue = undefined | null | false | "";
+export type FalseyValue = undefined | null | false;
 export type Interpolation<P> = FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P> | ReadonlyArray<FlattenInterpolation<P>>>;
 export type FlattenInterpolation<P> = InterpolationValue | InterpolationFunction<P>;
 export type InterpolationValue = string | number | Styles | FalseyValue | StyledComponentClass<any, any>;


### PR DESCRIPTION
Current [home page](https://www.styled-components.com) example shows this code.

```js
const Button = styled.a`
  ....
  /* The GitHub button is a primary button
   * edit this to target it specifically! */
  ${props => props.primary && css`
    background: white;
    color: palevioletred;
  `}
`
```

This PR makes it type-check in TypeScript with `strictNullChecks` on. Right now type-checking fails with:

```
src/sample.tsx(72,7): error TS2345: Argument of type '(props: { primary: boolean; }) => false | InterpolationValue[]' is not assignable to parameter of type 'Interpolation<ThemedStyledProps<ClassAttributes<HTMLDivElement> & HTMLAttributes<HTMLDivElement> ...'.
  Type '(props: { primary: boolean; }) => false | InterpolationValue[]' is not assignable to type 'ReadonlyArray<string | number | Styles | StyledComponentClass<any, any, any> | InterpolationFunct...'.
    Property 'concat' is missing in type '(props: { primary: boolean; }) => false | InterpolationValue[]'.
```