### PR TITLE
fix: typo copmonent => component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
+- Fix typo in `ComponentStyle.js` comments (see [#1678](https://github.com/styled-components/styled-components/pull/1678))
+
 - Accept ref forwarding components in styled constructor (see [#1658](https://github.com/styled-components/styled-components/pull/1658))
 
 - Fix onInvalid check in validAttrs, by [@slootsantos](https://github.com/slootsantos) (see [#1668](https://github.com/styled-components/styled-components/pull/1668))

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -17,7 +17,7 @@ const isStaticRules = (rules: RuleSet, attrs?: Object): boolean => {
       return false
     } else if (typeof rule === 'function' && !isStyledComponent(rule)) {
       // functions are allowed to be static if they're just being
-      // used to get the classname of a nested styled copmonent
+      // used to get the classname of a nested styled component
       return false
     }
   }


### PR DESCRIPTION
Found this little guy when browsing the codebase.