### PR TITLE
extend PureComponent rather than Component

### DIFF
--- a/src/models/StyleSheetManager.js
+++ b/src/models/StyleSheetManager.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import StyleSheet from './StyleSheet'
 import ServerStyleSheet from './ServerStyleSheet'
@@ -15,7 +15,7 @@ The StyleSheetManager expects a valid target or sheet prop!
 `.trim()
     : ''
 
-class StyleSheetManager extends Component {
+class StyleSheetManager extends PureComponent {
   sheetInstance: StyleSheet
   props: {
     sheet?: StyleSheet | null,

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Component, createElement } from 'react'
+import { PureComponent, createElement } from 'react'
 import PropTypes from 'prop-types'
 
 import type { Theme } from './ThemeProvider'
@@ -53,7 +53,7 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       : componentId
   }
 
-  class BaseStyledComponent extends Component {
+  class BaseStyledComponent extends PureComponent {
     static target: Target
     static styledComponentId: string
     static attrs: Object

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -1,5 +1,5 @@
 // @flow
-import { Component, createElement } from 'react'
+import { PureComponent, createElement } from 'react'
 import PropTypes from 'prop-types'
 
 import type { Theme } from './ThemeProvider'
@@ -13,7 +13,7 @@ import type { RuleSet, Target } from '../types'
 import { CHANNEL, CHANNEL_NEXT, CONTEXT_CHANNEL_SHAPE } from './ThemeProvider'
 
 export default (constructWithOptions: Function, InlineStyle: Function) => {
-  class BaseStyledNativeComponent extends Component {
+  class BaseStyledNativeComponent extends PureComponent {
     static target: Target
     static styledComponentId: string
     static attrs: Object

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -1,6 +1,6 @@
 // @flow
 /* globals React$Element */
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import isPlainObject from 'is-plain-object'
 import createBroadcast from '../utils/create-broadcast'
@@ -39,7 +39,7 @@ const isFunction = test => typeof test === 'function'
  * Provide a theme to an entire react component tree via context and event listeners (have to do
  * both context and event emitter as pure components block context updates)
  */
-class ThemeProvider extends Component {
+class ThemeProvider extends PureComponent {
   getTheme: (theme?: Theme | ((outerTheme: Theme) => void)) => Theme
   outerTheme: Theme
   unsubscribeToOuterId: string


### PR DESCRIPTION
We found a [thread about using PureComponent](https://github.com/styled-components/styled-components/pull/619#issuecomment-290774283) and think it's a good idea.

In this PR, `BaseStyledComponent` and `BaseStyledNativeComponent` now extend `PureComponent` rather than `Component`. I've made the same change to `StyleSheetManager` and `ThemeProvider` (though it is less impactful to performance).

We're running this fork in production and haven't observed negative consequences.