### PR TITLE
Add ReactRef as a type option for innerRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@types/node": "9.6.4",
-    "@types/react": "^16",
+    "@types/react": "16.3.12",
     "@types/react-dom": "^16",
     "@types/react-native": "^0.50.7",
     "babel-cli": "^6.22.2",

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { StatelessComponent, ComponentClass, PureComponent, ReactElement } from "react";
+import { StatelessComponent, ComponentClass, PureComponent, ReactElement, RefObject } from "react";
 
 type Component<P> = ComponentClass<P> | StatelessComponent<P>;
 
@@ -12,7 +12,7 @@ export type StyledProps<P> = ThemedStyledProps<P, any>;
 
 export type ThemedOuterStyledProps<P, T> = P & {
   theme?: T;
-  innerRef?: (instance: any) => void;
+  innerRef?: ((instance: any) => void) | RefObject<HTMLElement | SVGElement>
 };
 export type OuterStyledProps<P> = ThemedOuterStyledProps<P, any>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,9 +23,15 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16":
+"@types/react@*":
   version "16.0.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.34.tgz#7a8f795afd8a404a9c4af9539b24c75d3996914e"
+
+"@types/react@16.3.12":
+  version "16.3.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.12.tgz#68d9146f3e9797e38ffbf22f7ed1dde91a2cfd2e"
+  dependencies:
+    csstype "^2.2.0"
 
 abab@^1.0.3:
   version "1.0.4"
@@ -2032,6 +2038,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.4.0.tgz#6c7d711cc135dcd90c812a80213eab006fc1acff"
 
 csurf@~1.8.3:
   version "1.8.3"


### PR DESCRIPTION
The new `React.createRef` syntax (more information in ["Refs and the DOM"](https://reactjs.org/docs/refs-and-the-dom.html)) is not reflected in the typescript typings.

To do so, i had to update `@types/react` and then adjust the `styled-components` typings by allowing the `innerRef` to be one of two variations: Either the functional reference that was already reflected in typings before, or `React.RefObject<HTMLElement | SVGElement>` 

Can someone cc this to @styled-components/typers please?