### PR TITLE
Add createRef() tests, fix for react-native.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. If a contri
 
 ## Unreleased
 
+- Fix `React.createRef()` values for `innerRef` being ignored in React Native, by @simonbuchan (see [#1718](https://github.com/styled-components/styled-components/pull/1718))
 
 ## [v3.2.6] - 2018-04-17
 

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "prettier": "1.9.2",
     "puppeteer": "^0.13.0",
     "raf": "^3.4.0",
-    "react": "^16.0.0",
+    "react": "^16.3.0",
     "react-dom": "^16.0.0",
     "react-frame-component": "^2.0.2",
     "react-native": "^0.46.0",

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -130,7 +130,11 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
 
       if (typeof innerRef === 'function') {
         innerRef(node)
-      } else if (typeof innerRef === 'object' && innerRef) {
+      } else if (
+        typeof innerRef === 'object' &&
+        innerRef &&
+        innerRef.hasOwnProperty('current')
+      ) {
         innerRef.current = node
       }
     }

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -130,6 +130,8 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
 
       if (typeof innerRef === 'function') {
         innerRef(node)
+      } else if (typeof innerRef === 'object' && innerRef) {
+        innerRef.current = node
       }
     }
 

--- a/src/native/test/native.test.js
+++ b/src/native/test/native.test.js
@@ -288,7 +288,7 @@ describe('native', () => {
   })
 
   describe('innerRef', () => {
-    it('should pass the ref to the component', () => {
+    it('should pass a callback ref to the component', () => {
       const Comp = styled.View``
       const ref = jest.fn()
 
@@ -297,6 +297,19 @@ describe('native', () => {
       const comp = wrapper.find(Comp).first()
 
       expect(ref).toHaveBeenCalledWith(view.instance())
+      expect(view.prop('innerRef')).toBeFalsy()
+      expect(comp.instance().root).toBeTruthy()
+    })
+
+    it('should pass an object ref to the component', () => {
+      const Comp = styled.View``
+      const ref = React.createRef()
+
+      const wrapper = mount(<Comp innerRef={ref} />)
+      const view = wrapper.find('View').first()
+      const comp = wrapper.find(Comp).first()
+
+      expect(ref.current).toBe(view.instance())
       expect(view.prop('innerRef')).toBeFalsy()
       expect(comp.instance().root).toBeTruthy()
     })

--- a/src/primitives/test/primitives.test.js
+++ b/src/primitives/test/primitives.test.js
@@ -239,7 +239,7 @@ describe('primitives', () => {
   })
 
   describe('innerRef', () => {
-    it('should pass the ref to the component', () => {
+    it('should pass a callback ref to the component', () => {
       const Comp = styled.View``
       const ref = jest.fn()
 
@@ -248,6 +248,19 @@ describe('primitives', () => {
       const comp = wrapper.find(Comp).first()
 
       expect(ref).toHaveBeenCalledWith(view.instance())
+      expect(view.prop('innerRef')).toBeFalsy()
+      expect(comp.instance().root).toBeTruthy()
+    })
+
+    it('should pass an object ref to the component', () => {
+      const Comp = styled.View``
+      const ref = React.createRef()
+
+      const wrapper = mount(<Comp innerRef={ref} />)
+      const view = wrapper.find('View').first()
+      const comp = wrapper.find(Comp).first()
+
+      expect(ref.current).toBe(view.instance())
       expect(view.prop('innerRef')).toBeFalsy()
       expect(comp.instance().root).toBeTruthy()
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,9 +6320,9 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.3.0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Using a `React.createRef()`-created ref as `innerRef` would break under `react-native` (but not react-dom) as `StyledNativeComponent` (unlike `StyledComponent`) is already using `ref` and didn't know how to forward to the new type.

AFAIK, primitives didn't have the same issue, but I updated the test there, since they were copy pasted. I attempted to add tests for `react-dom`, but ran into what looks like an `enzyme` bug, see the follow-on #1720 for more details.

Also, I had to test under jest 22 on my machine for some reason - jest 20 just hung on (at least) test:native? I avoided including that change here.