### PR TITLE
[WIP] Support `.attrs({ ref: ... })`

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "prettier": "1.9.2",
     "puppeteer": "^0.13.0",
     "raf": "^3.4.0",
-    "react": "^16.0.0",
+    "react": "^16.3.0",
     "react-dom": "^16.0.0",
     "react-frame-component": "^2.0.2",
     "react-native": "^0.46.0",

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -209,15 +209,17 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
         .filter(Boolean)
         .join(' ')
 
+      const { ref: attrRef, ...attrs } = this.attrs
+
       const baseProps = {
-        ...this.attrs,
+        ...attrs,
         className,
       }
 
       if (isStyledComponent(target)) {
-        baseProps.innerRef = innerRef
+        baseProps.innerRef = innerRef || attrRef
       } else {
-        baseProps.ref = innerRef
+        baseProps.ref = innerRef || attrRef
       }
 
       const propsForElement = Object.keys(this.props).reduce(

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -130,6 +130,8 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
 
       if (typeof innerRef === 'function') {
         innerRef(node)
+      } else if (typeof innerRef === 'object' && innerRef) {
+        innerRef.current = node
       }
     }
 

--- a/src/native/test/native.test.js
+++ b/src/native/test/native.test.js
@@ -288,7 +288,7 @@ describe('native', () => {
   })
 
   describe('innerRef', () => {
-    it('should pass the ref to the component', () => {
+    it('should pass a callback ref to the component', () => {
       const Comp = styled.View``
       const ref = jest.fn()
 
@@ -297,6 +297,19 @@ describe('native', () => {
       const comp = wrapper.find(Comp).first()
 
       expect(ref).toHaveBeenCalledWith(view.instance())
+      expect(view.prop('innerRef')).toBeFalsy()
+      expect(comp.instance().root).toBeTruthy()
+    })
+
+    it('should pass an object ref to the component', () => {
+      const Comp = styled.View``
+      const ref = React.createRef()
+
+      const wrapper = mount(<Comp innerRef={ref} />)
+      const view = wrapper.find('View').first()
+      const comp = wrapper.find(Comp).first()
+
+      expect(ref.current).toBe(view.instance())
       expect(view.prop('innerRef')).toBeFalsy()
       expect(comp.instance().root).toBeTruthy()
     })

--- a/src/primitives/test/primitives.test.js
+++ b/src/primitives/test/primitives.test.js
@@ -239,7 +239,7 @@ describe('primitives', () => {
   })
 
   describe('innerRef', () => {
-    it('should pass the ref to the component', () => {
+    it('should pass a callback ref to the component', () => {
       const Comp = styled.View``
       const ref = jest.fn()
 
@@ -248,6 +248,19 @@ describe('primitives', () => {
       const comp = wrapper.find(Comp).first()
 
       expect(ref).toHaveBeenCalledWith(view.instance())
+      expect(view.prop('innerRef')).toBeFalsy()
+      expect(comp.instance().root).toBeTruthy()
+    })
+
+    it('should pass an object ref to the component', () => {
+      const Comp = styled.View``
+      const ref = React.createRef()
+
+      const wrapper = mount(<Comp innerRef={ref} />)
+      const view = wrapper.find('View').first()
+      const comp = wrapper.find(Comp).first()
+
+      expect(ref.current).toBe(view.instance())
       expect(view.prop('innerRef')).toBeFalsy()
       expect(comp.instance().root).toBeTruthy()
     })

--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import { resetStyled, expectCSSMatches } from './utils'
 
@@ -138,5 +138,51 @@ describe('attrs', () => {
       children: <span>Amazing</span>
     })``
     expect(shallow(<Comp>Something else</Comp>).html()).toEqual('<div class="sc-a b">Something else</div>')
+  })
+
+  it('should pass through callback ref', () => {
+    const ref = jest.fn()
+    const Comp = styled.div.attrs({
+      ref: () => ref
+    })``
+    const wrapper = mount(<Comp />)
+    const div = wrapper.find('div').first()
+    expect(div).toBeTruthy()
+    expect(ref).toHaveBeenCalledWith(div.instance())
+  })
+
+  it('should pass through object ref', () => {
+    const ref = React.createRef()
+    const Comp = styled.div.attrs({
+      ref: () => ref
+    })``
+    const wrapper = mount(<Comp />)
+    const div = wrapper.find('div').first()
+    expect(div).toBeTruthy()
+    expect(ref).toHaveProperty('current', div.instance())
+  })
+
+  it('should pass through callback ref through inner styled component', () => {
+    const ref = jest.fn()
+    const Inner = styled.div``;
+    const Comp = styled(Inner).attrs({
+      ref: () => ref
+    })``
+    const wrapper = mount(<Comp />)
+    const div = wrapper.find('div').first()
+    expect(div).toBeTruthy()
+    expect(ref).toHaveBeenCalledWith(div.instance())
+  })
+
+  it('should pass through object ref through inner styled component', () => {
+    const ref = React.createRef()
+    const Inner = styled.div``;
+    const Comp = styled(Inner).attrs({
+      ref: () => ref
+    })``
+    const wrapper = mount(<Comp />)
+    const div = wrapper.find('div').first()
+    expect(div).toBeTruthy()
+    expect(ref).toHaveProperty('current', div.instance())
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,9 +6320,9 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.3.0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
As a follow on to #1718, created as a separate PR due to both not being complete and the callback ref part (which is working) not depending on it.

I'm happy to rebase away the createRef() stuff if #1718 is blocking this.

Basically the goal is implementing tab order like behavior in react-native:

```js
const refList = [React.createRef(), React.createRef()]
const handleFocus = refList.map(ref => () => ref.current.focus())
const common = { refList, handleFocus, ... }

<MyInput {...common} refIndex={0} />
<MyInput {...common} refIndex={1} />

const MyInput = styled.TextInput.attrs({
  key: props => props.refList[props.refIndex],
  onSubmitEditing: props => props.handleFocus[props.refIndex + 1],
})
```

Starting with web first, since it's easier to test, but I'm running into an issue getting object refs to work. The new callback refs tests pass, and the object refs tests fail (with `ref.current` being null still), but it looks like it's an enzyme bug, since the following enzyme only test fails:

```js
test('enzyme should mount object refs', () => {
  const ref = React.createRef()
  const wrapper = mount(<div ref={ref} />)
  const div = wrapper.find('div').first()
  expect(div).toBeTruthy()
  expect(ref).toHaveProperty('current', div.instance())
})
```

Creating this as a WIP to check interest before I dig further into fixing and expanding tests.