### PR TITLE
Fix `innerRef` types not handling null

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -12,7 +12,7 @@ export type StyledProps<P> = ThemedStyledProps<P, any>;
 
 export type ThemedOuterStyledProps<P, T> = P & {
   theme?: T;
-  innerRef?: ((instance: object) => void) | RefObject<HTMLElement | SVGElement | ReactComponent>
+  innerRef?: ((instance: any) => void) | RefObject<HTMLElement | SVGElement | ReactComponent>
 };
 export type OuterStyledProps<P> = ThemedOuterStyledProps<P, any>;
 


### PR DESCRIPTION
Fixes #1758

Partial rollback of change in #1711

See issue for explanation of why it is necessary