### PR TITLE
Make typings work with new TS 2.9 keyof behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
   },
   "devDependencies": {
     "@types/node": "9.6.4",
-    "@types/react": "^16.3.12",
+    "@types/react": "^16.3.14",
     "@types/react-dom": "^16.0.5",
-    "@types/react-native": "^0.55.7",
+    "@types/react-native": "^0.55.16",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.17.0",
     "babel-eslint": "^8.2.3",
@@ -146,7 +146,7 @@
     "rollup-plugin-uglify": "^3.0.0",
     "rollup-plugin-visualizer": "^0.1.5",
     "tslint": "^4.3.1",
-    "typescript": "^2.4.1"
+    "typescript": "^2.9.1"
   },
   "peerDependencies": {
     "react": ">= 0.14.0 < 17.0.0-0"

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -72,8 +72,8 @@ export interface ThemedCssFunction<T> {
 }
 
 // Helper type operators
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+// See https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#predefined-conditional-types
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, "theme"> & { theme?: T; };
 
 export interface ThemedStyledComponentsModule<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,15 +120,13 @@
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react-native@^0.55.7":
-  version "0.55.7"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.55.7.tgz#99c725b6d7f9870ed6de89551cc7220fb44fa74f"
-  dependencies:
-    "@types/react" "*"
+"@types/react-native@^0.55.16":
+  version "0.55.16"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.55.16.tgz#992304c2228b276c10d2b4460d824477b25d0306"
 
-"@types/react@*", "@types/react@^16.3.12":
-  version "16.3.12"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.12.tgz#68d9146f3e9797e38ffbf22f7ed1dde91a2cfd2e"
+"@types/react@*", "@types/react@^16.3.14":
+  version "16.3.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.14.tgz#f90ac6834de172e13ecca430dcb6814744225d36"
   dependencies:
     csstype "^2.2.0"
 
@@ -2253,8 +2251,8 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
     cssom "0.3.x"
 
 csstype@^2.2.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.4.0.tgz#6c7d711cc135dcd90c812a80213eab006fc1acff"
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.3.tgz#2504152e6e1cc59b32098b7f5d6a63f16294c1f7"
 
 csurf@~1.8.3:
   version "1.8.3"
@@ -8496,9 +8494,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.4.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Instead of using a copy-pasted version of `Diff`/`Omit`, use the `Omit`
implementation as recommended by the official TypeScript Release Notes here:
https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#predefined-conditional-types

That version works correctly with the new `keyof` behavior introduced in
TS 2.9