### PR TITLE
Make TypeScript definition compatible with TS 2.9.1

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -72,7 +72,8 @@ export interface ThemedCssFunction<T> {
 }
 
 // Helper type operators
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+type KeyofBase = keyof any;
+type Diff<T extends KeyofBase, U extends KeyofBase> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, "theme"> & { theme?: T; };
 


### PR DESCRIPTION
This is a minor fix that makes TS typings work on older and the latest version of TypeScript (up to 2.9.1).
Should supersede #1771 and fix #1772.
This is a non-breaking change, so can be released as a patch.