### PR TITLE
Fix type error of tagged template literal in TypeScript 2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "rollup-plugin-uglify": "^3.0.0",
     "rollup-plugin-visualizer": "^0.1.5",
     "tslint": "^4.3.1",
-    "typescript": "^2.4.1"
+    "typescript": "^2.9.1"
   },
   "peerDependencies": {
     "react": ">= 0.14.0 < 17.0.0-0"

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -40,8 +40,7 @@ export interface StyledComponentClass<P, T, O = P> extends ComponentClass<Themed
 }
 
 export interface ThemedStyledFunction<P, T, O = P> {
-  (strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P, T>>[]): StyledComponentClass<P, T, O>;
-  <U>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
+  <U = {}>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
   attrs<U, A extends Partial<P & U> = {}>(attrs: Attrs<P & U, A, T>): ThemedStyledFunction<P & A & U, T, O & U>;
 }
 

--- a/typings/tests/typed-template-literal.tsx
+++ b/typings/tests/typed-template-literal.tsx
@@ -1,0 +1,9 @@
+import styled from "../..";
+
+const plain = styled.h1`
+  color: ${props => props.className};
+`;
+
+const withTypeArgs = styled.h1<{ hello: string }>`
+  color: ${props => props.hello};
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,9 +8496,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.4.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
With TypeScript 2.9, we can provide type arguments to tagged template literals.

- https://blogs.msdn.microsoft.com/typescript/2018/05/31/announcing-typescript-2-9/#type-arguments-tagged-template-strings

It means that we no more need extra library for typing `ThemedStyledFunction`.

```typescript
const withTypeArgs = styled.h1<{ hello: string }>`
  color: ${props => props.hello};
`;
```

However, with the current typings, an error occurs:

![image](https://user-images.githubusercontent.com/1013641/40819840-3200f5e0-6598-11e8-8ae5-e15a8021780c.png)

The reason is that `ThemedStyledFunction` has overridden function types in a wrong order.

```typescript
interface ThemedStyledFunction<P, T, O = P> {
  (...): StyledComponentClass<P, T, O>;
  <U>(...): StyledComponentClass<P, T, O>;

  ...
}
```

When doing like above, the first type is applied, so type argument is not actually used and the error occurs. To fix this, we can just change the order, but I think using a default type argument is better.

```typescript
interface ThemedStyledFunction<P, T, O = P> {
  <U = {}>(...): StyledComponentClass<P, T, O>;

  ...
}
```

I've also added a test case for this. Please let me know if there is anything unclear.