### PR TITLE
[v2] Make TypeScript definition compatible with TS 2.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ node_js:
 script:
   - node --version
   - yarn --version
-  # Tests have to run before Danger runs because
-  # danger-plugin-jest references the test output
-  - yarn run test
-  - yarn run danger run -- --verbose
-  - yarn run flow
-  - yarn run lint && yarn run typescript && yarn run tslint
+  - yarn test
+  - yarn flow
+  - yarn lint
+  - yarn typescript
+  - yarn tslint
 notifications:
   email:
     on_failure: change

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -73,7 +73,8 @@ export interface ThemedCssFunction<T> {
 }
 
 // Helper type operators
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+type KeyofBase = keyof any;
+type Diff<T extends KeyofBase, U extends KeyofBase> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 type WithOptionalTheme<P extends { theme?: T; }, T> = Omit<P, "theme"> & { theme?: T; };
 


### PR DESCRIPTION
this change is a port of #1773 for 2.x. It is required for v2 users (I am one of these) to upgrade to TS 2.9.
I think we can make a patch release 2.4.1.
Supersedes #1774 