### PR TITLE
Allow TypeScript 2.9.1 accept tagged template type argument

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -40,8 +40,7 @@ export interface StyledComponentClass<P, T, O = P> extends ComponentClass<Themed
 }
 
 export interface ThemedStyledFunction<P, T, O = P> {
-  (strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P, T>>[]): StyledComponentClass<P, T, O>;
-  <U>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
+  <U = {}>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
   attrs<U, A extends Partial<P & U> = {}>(attrs: Attrs<P & U, A, T>): ThemedStyledFunction<P & A & U, T, O & U>;
 }
 


### PR DESCRIPTION
This change is a workaround for TypeScript issue (Microsoft/TypeScript#24449) that prevents passing type argument to tagged template.
The workaround is simply consolidating overloads into one.

With this PR and TypeScript 2.9.1 it will be possible to write:
```ts
const Title = styled.h1<{ size: number }>`
  font-size: ${p => p.size}em;
`
```
and it will be fully type-safe,

Addresses #630