### PR TITLE
Add human readable error to insertRuleHelpers' sheetForTag fn

### DIFF
--- a/src/utils/insertRuleHelpers.js
+++ b/src/utils/insertRuleHelpers.js
@@ -17,7 +17,7 @@ export const sheetForTag = (tag: HTMLStyleElement): CSSStyleSheet => {
   }
 
   /* we should always be able to find a tag */
-  throw new Error()
+  throw new Error('Cannot find sheet for given tag')
 }
 
 /* insert a rule safely and return whether it was actually injected */


### PR DESCRIPTION
Add human-readable error description.

Also, I noticed that half of throwing errors has no text for production env. What is the purpose in this?