### PR TITLE
fix regression when extending a styled(StyledComponent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- [placeholder]
+* Fixed a regression when extending a `styled(StyledComponent)` introduced in 3.3.0, by @probablyup (see #1819)
 
 ## [v3.3.2] - 2018-06-04
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -279,6 +279,12 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
     )
 
     class StyledComponent extends ParentComponent {
+      static attrs = attrs
+      static componentStyle = componentStyle
+      static displayName = displayName
+      static styledComponentId = styledComponentId
+      static target = target
+
       static contextTypes = {
         [CHANNEL]: PropTypes.func,
         [CHANNEL_NEXT]: CONTEXT_CHANNEL_SHAPE,
@@ -333,15 +339,19 @@ export default (ComponentStyle: Function, constructWithOptions: Function) => {
       StyledComponent.warnTooManyClasses = createWarnTooManyClasses(displayName)
     }
 
-    if (isClass) hoist(StyledComponent, target)
-
-    // we do this after hoisting to ensure we're overwriting existing
-    // rules when wrapping another styled component class
-    StyledComponent.displayName = displayName
-    StyledComponent.styledComponentId = styledComponentId
-    StyledComponent.attrs = attrs
-    StyledComponent.componentStyle = componentStyle
-    StyledComponent.target = target
+    if (isClass) {
+      hoist(StyledComponent, target, {
+        // all SC-specific things should not be hoisted
+        attrs: true,
+        componentStyle: true,
+        displayName: true,
+        extend: true,
+        styledComponentId: true,
+        target: true,
+        warnTooManyClasses: true,
+        withComponent: true,
+      })
+    }
 
     return StyledComponent
   }

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -197,6 +197,12 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
     )
 
     class StyledNativeComponent extends ParentComponent {
+      static attrs = attrs
+      static displayName = displayName
+      static inlineStyle = inlineStyle
+      static styledComponentId = 'StyledNativeComponent'
+      static target = target
+
       static contextTypes = {
         [CHANNEL]: PropTypes.func,
         [CHANNEL_NEXT]: CONTEXT_CHANNEL_SHAPE,
@@ -238,13 +244,18 @@ export default (constructWithOptions: Function, InlineStyle: Function) => {
       }
     }
 
-    if (isClass) hoist(StyledNativeComponent, target)
-
-    StyledNativeComponent.displayName = displayName
-    StyledNativeComponent.target = target
-    StyledNativeComponent.attrs = attrs
-    StyledNativeComponent.inlineStyle = inlineStyle
-    StyledNativeComponent.styledComponentId = 'StyledNativeComponent'
+    if (isClass) {
+      hoist(StyledNativeComponent, target, {
+        // all SC-specific things should not be hoisted
+        attrs: true,
+        displayName: true,
+        extend: true,
+        inlineStyle: true,
+        styledComponentId: true,
+        target: true,
+        withComponent: true,
+      })
+    }
 
     return StyledNativeComponent
   }

--- a/src/test/__snapshots__/extending.test.js.snap
+++ b/src/test/__snapshots__/extending.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`extending regression test for #1781, extending a Styled(StyledComponent) 1`] = `"<h1 class=\\"sc-c d\\"></h1>"`;
+exports[`extending regression test for #1781, extending a Styled(StyledComponent) 1`] = `"<h1 class=\\"sc-c d sc-a e\\"></h1>"`;

--- a/src/test/__snapshots__/extending.test.js.snap
+++ b/src/test/__snapshots__/extending.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`extending regression test for #1781, extending a Styled(StyledComponent) 1`] = `"<h1 class=\\"sc-c d\\"></h1>"`;

--- a/src/test/extending.test.js
+++ b/src/test/extending.test.js
@@ -255,7 +255,8 @@ describe('extending', () => {
 
     expect(shallow(<ExtendedExtendedTitle />).html()).toMatchSnapshot()
     expectCSSMatches(`
-      .sc-c {} .d { color:red; background-color:blue; border:2px solid green; }
+      .sc-a { } .e { color:red; }
+      .sc-c { } .d { background-color:blue; border:2px solid green; }
     `)
   })
 })

--- a/src/test/extending.test.js
+++ b/src/test/extending.test.js
@@ -26,7 +26,9 @@ describe('extending', () => {
   })
 
   it('should attach styles to both classes if only parent has styles', () => {
-    const Parent = styled.div`color: blue;`
+    const Parent = styled.div`
+      color: blue;
+    `
     const Child = Parent.extend``
 
     shallow(<Parent />)
@@ -37,7 +39,9 @@ describe('extending', () => {
 
   it('should attach styles to child class if only child has styles', () => {
     const Parent = styled.div``
-    const Child = Parent.extend`color: blue;`
+    const Child = Parent.extend`
+      color: blue;
+    `
 
     shallow(<Parent />)
     shallow(<Child />)
@@ -46,8 +50,12 @@ describe('extending', () => {
   })
 
   it('should generate a class for the child with the rules of the parent', () => {
-    const Parent = styled.div`color: blue;`
-    const Child = Parent.extend`color: red;`
+    const Parent = styled.div`
+      color: blue;
+    `
+    const Child = Parent.extend`
+      color: red;
+    `
 
     shallow(<Child />)
 
@@ -55,21 +63,31 @@ describe('extending', () => {
   })
 
   it('should generate different classes for both parent and child', () => {
-    const Parent = styled.div`color: blue;`
-    const Child = Parent.extend`color: red;`
+    const Parent = styled.div`
+      color: blue;
+    `
+    const Child = Parent.extend`
+      color: red;
+    `
 
     shallow(<Parent />)
     shallow(<Child />)
 
-    expectCSSMatches('.sc-a {} .c { color:blue; } .sc-b {} .d { color:blue;color:red; }')
+    expectCSSMatches(
+      '.sc-a {} .c { color:blue; } .sc-b {} .d { color:blue;color:red; }'
+    )
   })
 
   it('should copy nested rules to the child', () => {
     const Parent = styled.div`
       color: blue;
-      > h1 { font-size: 4rem; }
+      > h1 {
+        font-size: 4rem;
+      }
     `
-    const Child = Parent.extend`color: red;`
+    const Child = Parent.extend`
+      color: red;
+    `
 
     shallow(<Parent />)
     shallow(<Child />)
@@ -86,13 +104,15 @@ describe('extending', () => {
 
   it('should keep default props from parent', () => {
     const Parent = styled.div`
-      color: ${(props) => props.color};
+      color: ${props => props.color};
     `
     Parent.defaultProps = {
-      color: 'red'
+      color: 'red',
     }
 
-    const Child = Parent.extend`background-color: green;`
+    const Child = Parent.extend`
+      background-color: green;
+    `
 
     shallow(<Parent />)
     shallow(<Child />)
@@ -105,34 +125,46 @@ describe('extending', () => {
 
   it('should keep prop types from parent', () => {
     const Parent = styled.div`
-      color: ${(props) => props.color};
+      color: ${props => props.color};
     `
     Parent.propTypes = {
-      color: PropTypes.string
+      color: PropTypes.string,
     }
 
-    const Child = Parent.extend`background-color: green;`
+    const Child = Parent.extend`
+      background-color: green;
+    `
 
     expect(Child.propTypes).toEqual(Parent.propTypes)
   })
 
   it('should keep custom static member from parent', () => {
-    const Parent = styled.div`color: red;`
+    const Parent = styled.div`
+      color: red;
+    `
 
     Parent.fetchData = () => 1
 
-    const Child = Parent.extend`color: green;`
+    const Child = Parent.extend`
+      color: green;
+    `
 
     expect(Child.fetchData).toBeTruthy()
     expect(Child.fetchData()).toEqual(1)
   })
 
   it('should keep static member in triple inheritance', () => {
-    const GrandParent = styled.div`color: red;`
+    const GrandParent = styled.div`
+      color: red;
+    `
     GrandParent.fetchData = () => 1
 
-    const Parent = GrandParent.extend`color: red;`
-    const Child = Parent.extend`color:red;`
+    const Parent = GrandParent.extend`
+      color: red;
+    `
+    const Child = Parent.extend`
+      color: red;
+    `
 
     expect(Child.fetchData).toBeTruthy()
     expect(Child.fetchData()).toEqual(1)
@@ -173,7 +205,9 @@ describe('extending', () => {
   })
 
   it('should allow changing component', () => {
-    const Parent = styled.div`color: red;`
+    const Parent = styled.div`
+      color: red;
+    `
     const Child = Parent.withComponent('span')
 
     expect(shallow(<Child />).html()).toEqual('<span class="sc-b c"></span>')
@@ -198,9 +232,30 @@ describe('extending', () => {
       color: red;
     `
     const Child = Parent.withComponent('a').extend.attrs({
-      href: '/test'
+      href: '/test',
     })``
 
-    expect(shallow(<Child />).html()).toEqual('<a href="/test" class="sc-c d"></a>')
+    expect(shallow(<Child />).html()).toEqual(
+      '<a href="/test" class="sc-c d"></a>'
+    )
+  })
+
+  it('regression test for #1781, extending a Styled(StyledComponent)', () => {
+    const Title = styled.h1`
+      color: red;
+    `
+
+    const ExtendedTitle = styled(Title)`
+      background-color: blue;
+    `
+
+    const ExtendedExtendedTitle = ExtendedTitle.extend`
+      border: 2px solid green;
+    `
+
+    expect(shallow(<ExtendedExtendedTitle />).html()).toMatchSnapshot()
+    expectCSSMatches(`
+      .sc-c {} .d { color:red; background-color:blue; border:2px solid green; }
+    `)
   })
 })


### PR DESCRIPTION
Fixes #1781

The `extend` and `withComponent` statics are getting hoisted and fubaring things since they rely on closure variables. Fixed that and switched to the [third arg way of excluding things from `hoist`](https://github.com/mridgway/hoist-non-react-statics#usage), which is easier to understand and probably will be easier to maintain.