### PR TITLE
add support for first-class functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- Add first-class support for objects:
+* Add first-class support for functions that return objects, by @acjay (see #1820)
 
   ```JS
   const Comp = styled.div((({ color }) => ({
     color,
   }))
   ```
-
-  This can be useful for destructuring the props of the styled component or for inserting logic for computing the styles from props.
 
 ## [v3.3.3] - 2018-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-* placeholder, remove me
+- Add first-class support for objects:
+
+  ```JS
+  const Comp = styled.div((({ color }) => ({
+    color,
+  }))
+  ```
+
+  This can be useful for destructuring the props of the styled component or for inserting logic for computing the styles from props.
 
 ## [v3.3.3] - 2018-06-20
 

--- a/src/constructors/css.js
+++ b/src/constructors/css.js
@@ -7,7 +7,10 @@ export default (
   styles: Styles,
   ...interpolations: Array<Interpolation>
 ): RuleSet => {
-  if (!Array.isArray(styles) && typeof styles === 'object') {
+  if (
+    !Array.isArray(styles) &&
+    (typeof styles === 'object' || typeof styles === 'function')
+  ) {
     return flatten(interleave([], [styles, ...interpolations]))
   }
   return flatten(interleave(styles, interpolations))

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -121,6 +121,14 @@ describe('basic', () => {
     expectCSSMatches('.sc-a {} .b { color:blue; }')
   })
 
+  it('should allow you to pass in a function returning a style object', () => {
+    const Comp = styled.div(({ color }) => ({
+      color,
+    }))
+    shallow(<Comp color='blue' />)
+    expectCSSMatches('.sc-a {} .b { color:blue; }')
+  })
+
   describe('jsdom tests', () => {
     it('should pass the ref to the component', () => {
       const Comp = styled.div``

--- a/src/types.js
+++ b/src/types.js
@@ -9,7 +9,10 @@ export type Interpolation =
 
 export type RuleSet = Array<Interpolation>
 
-export type Styles = Array<string> | Object
+export type Styles =
+  | Array<string>
+  | Object
+  | ((executionContext: Object) => Interpolation)
 
 /* eslint-disable no-undef */
 export type Target = string | ComponentType<*>


### PR DESCRIPTION
Closes #1620

Inspired by @probablyup's comment, I checkout out #1732 to see if I could solve my problem in #1620. Turns out, it was really straightforward.

To get a feel for the syntax this enables:

<img width="882" alt="image" src="https://user-images.githubusercontent.com/1256382/41698216-1a0abf9a-74eb-11e8-9397-9ab2b6ef0f64.png">

or alternatively

<img width="875" alt="image" src="https://user-images.githubusercontent.com/1256382/41698382-0d1a9eee-74ec-11e8-9cbc-02eacfcd6e40.png">

This is particularly useful for DRYing up repetitive logic mapping props to styles and not having to repeatedly reference the props object.