### PR TITLE
chore: add missing typings for `isStyledComponent`

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -95,6 +95,7 @@ export function withTheme<P extends { theme?: T; }, T>(component: Component<P>):
 export function keyframes(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): string;
 export function injectGlobal(strings: TemplateStringsArray, ...interpolations: SimpleInterpolation[]): void;
 export function consolidateStreamedStyles(): void;
+export function isStyledComponent(target: string | Component<object>): boolean;
 
 export const ThemeProvider: ThemeProviderComponent<object>;
 

--- a/typings/tests/is-styled-component-test.tsx
+++ b/typings/tests/is-styled-component-test.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import styled, { isStyledComponent } from "../..";
+
+const StyledComponent = styled.h1``
+
+const StatelessComponent = () => <div />
+
+class ClassComponent extends React.Component {
+  render() {
+    return <div />
+  }
+}
+
+isStyledComponent(StyledComponent);
+isStyledComponent(StatelessComponent);
+isStyledComponent(ClassComponent);
+isStyledComponent('div');


### PR DESCRIPTION
Hey there 👋

Just noticed `isStyledComponent` helper function is missing from `.d.ts` typings. Hope that signature is correct 😅.