### PR TITLE
Escape closing style tag in SSR to prevent XSS

### DIFF
--- a/src/models/StyleTags.js
+++ b/src/models/StyleTags.js
@@ -124,7 +124,7 @@ const wrapAsHtmlTag = (css: () => string, names: Names) => (
   ]
 
   const htmlAttr = attrs.filter(Boolean).join(' ')
-  const safeCSS = css().replace(/<\/style>/g, '<\\/style>')
+  const safeCSS = css().replace(/<\/(style)>/gi, '<\\/$1>')
   return `<style ${htmlAttr}>${safeCSS}</style>`
 }
 

--- a/src/models/StyleTags.js
+++ b/src/models/StyleTags.js
@@ -124,7 +124,8 @@ const wrapAsHtmlTag = (css: () => string, names: Names) => (
   ]
 
   const htmlAttr = attrs.filter(Boolean).join(' ')
-  return `<style ${htmlAttr}>${css()}</style>`
+  const safeCSS = css().replace(/<\/style>/g, '<\\/style>')
+  return `<style ${htmlAttr}>${safeCSS}</style>`
 }
 
 /* takes a css factory function and outputs an element factory */


### PR DESCRIPTION
When using untrusted input to create styled components nothing bad can happen client-side because the content of the inline style is set using DOM methods. However, when using SSR the values of all `rule.cssText` are simply concatenated, which is unsafe. Similar to how closing script tags need to be escaped for initial SSR state we need to escape style as well. See https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0

I'm probably opening up a jar here that can lead to endless discussions about whose responsibility it is to escape said untrusted user input. However, right now SSR behaves different from the client thing and that is not correct. Also if I legitimately want my pseudo element to have a content of `</style><script>¯\_(ツ)_/¯</script>` then nothing should keep me from doing so. Escaping the closing `</style>` at least offers some sort of protection against the most trivial injection. Albeit style injections are a hot topic and far from trivial and out of scope of style-components I guess (e.g. think injecting something like https://github.com/maxchehab/CSS-Keylogging).

Maybe styled-components could offer a helper function to escape style values? E.g.

```js
import style, { escapeValue } from 'styled-components';

const Button = style.button`
    color: ${({color}) => escapeValue(color)};
`;
```

This would make it impossible to break out of the value-context.