### PR TITLE
Add TypeScript support for v3.3.0 style objects

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -26,6 +26,10 @@ export interface InterpolationFunction<P> {
   (props: P): Interpolation<P>;
 }
 
+type StyleObject<P extends { style?: object; }, U, T, S = P['style']> = {
+  [K in keyof S]: ((props: ThemedStyledProps<P & U, T>) => S[K]) | S[K];
+}
+
 type Attrs<P, A extends Partial<P>, T> = {
   [K in keyof A]: ((props: ThemedStyledProps<P, T>) => A[K]) | A[K];
 };
@@ -38,6 +42,7 @@ export interface StyledComponentClass<P, T, O = P> extends ComponentClass<Themed
 }
 
 export interface ThemedStyledFunction<P, T, O = P> {
+  <U = {}>(styles: StyleObject<P, U, T>): StyledComponentClass<P & U, T, O & U>;
   <U = {}>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
   attrs<U, A extends Partial<P & U> = {}>(attrs: Attrs<P & U, A, T>): ThemedStyledFunction<DiffBetween<A, P & U>, T, DiffBetween<A, O & U>>;
 }


### PR DESCRIPTION
This PR is a work in progress for addressing #1756 by adding TypeScript typings for the first-class object support introduced in v3.3.0.

Todo:
- [ ] Add tests
- [ ] Verify compatibility with React Native
- [ ] Discuss ambiguities between `TemplateStringsArray` and `StyleObject` types

Regarding the last todo, there's some ambiguity between the call signatures for tagged template literals and style objects. If there is a type error, the compiler infers that you are providing an invalid `TemplateStringsArray`. I'm not sure if there is a way around this, or if it's even something we should be concerned about. @Igorbek, do you have any input?

Example:

```typescript
const StyledDiv = styled.div({
  flexDirection: 'invalid value for flex direction'
})
```

> Argument of type '{ flexDirection: string; }' is not assignable to parameter of type 'TemplateStringsArray'.
  Object literal may only specify known properties, and 'flexDirection' does not exist in type 'TemplateStringsArray'.


