### PR TITLE
[TypeScript] Fix #1821

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -38,7 +38,8 @@ export interface StyledComponentClass<P, T, O = P> extends ComponentClass<Themed
 }
 
 export interface ThemedStyledFunction<P, T, O = P> {
-  <U = {}>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
+  (strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P, T>>[]): StyledComponentClass<P, T, O>;
+  <U>(strings: TemplateStringsArray, ...interpolations: Interpolation<ThemedStyledProps<P & U, T>>[]): StyledComponentClass<P & U, T, O & U>;
   attrs<U, A extends Partial<P & U> = {}>(attrs: Attrs<P & U, A, T>): ThemedStyledFunction<DiffBetween<A, P & U>, T, DiffBetween<A, O & U>>;
 }
 

--- a/typings/tests/issue1821.tsx
+++ b/typings/tests/issue1821.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import styled, { css } from "../..";
+
+const mixin = css`
+  color: ${props => `blue`};
+`;
+
+const UseMixin = styled.div`
+  ${mixin};
+`;
+
+<UseMixin>test</UseMixin>;

--- a/typings/tests/themed-tests/issue1821.tsx
+++ b/typings/tests/themed-tests/issue1821.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import styled, { css } from "./mytheme-styled-components";
+
+const mixin = css`
+  color: ${props => `blue`};
+`;
+
+const UseMixin = styled.div`
+  ${mixin};
+`;
+
+<UseMixin>test</UseMixin>;


### PR DESCRIPTION
This fixes #1821 by reverting #1798.

- [x] added test cases

Please note, that new syntax that was allowed by #1798 is still allowed but requires TypeScript 2.9.2 which fixed overload resolution.