### PR TITLE
[Typescript] Migrate native types with keeping native dir exports left

### DIFF
--- a/native/index.d.ts
+++ b/native/index.d.ts
@@ -1,8 +1,7 @@
-import * as ReactNative from "react-native";
-import * as React from "react";
-import { StatelessComponent, ComponentClass } from "react";
-
 export {
+  default,
+  ReactNativeStyledFunction,
+  StyledInterface,
   ThemeProps,
   ThemeProvider,
   Interpolation,
@@ -14,56 +13,3 @@ export {
   css,
   withTheme,
 } from "..";
-
-import { StyledFunction, BaseStyledInterface } from "..";
-
-type Component<P> = ComponentClass<P> | StatelessComponent<P>;
-
-export type ReactNativeStyledFunction<P> = StyledFunction<P>;
-
-export interface StyledInterface extends BaseStyledInterface {
-  ActivityIndicator: ReactNativeStyledFunction<ReactNative.ActivityIndicatorProperties>;
-  ActivityIndicatorIOS: ReactNativeStyledFunction<ReactNative.ActivityIndicatorProperties>;
-
-  // ART: StyledFunction<ReactNative.ART>;
-  Button: ReactNativeStyledFunction<ReactNative.ButtonProperties>;
-  DatePickerIOS: ReactNativeStyledFunction<ReactNative.DatePickerIOSProperties>;
-  DrawerLayoutAndroid: ReactNativeStyledFunction<ReactNative.DrawerLayoutAndroidProperties>;
-  Image: ReactNativeStyledFunction<ReactNative.ImageProperties>;
-  ImageBackground: ReactNativeStyledFunction<ReactNative.ImageBackgroundProperties>;
-
-  KeyboardAvoidingView: ReactNativeStyledFunction<ReactNative.KeyboardAvoidingViewProps>;
-  ListView: ReactNativeStyledFunction<ReactNative.ListViewProperties>;
-  MapView: ReactNativeStyledFunction<ReactNative.MapViewProperties>;
-  Modal: ReactNativeStyledFunction<ReactNative.ModalProperties>;
-  NavigatorIOS: ReactNativeStyledFunction<ReactNative.NavigatorIOSProperties>;
-  Picker: ReactNativeStyledFunction<ReactNative.PickerProperties>;
-  PickerIOS: ReactNativeStyledFunction<ReactNative.PickerIOSProperties>;
-  ProgressBarAndroid: ReactNativeStyledFunction<ReactNative.ProgressBarAndroidProperties>;
-  ProgressViewIOS: ReactNativeStyledFunction<ReactNative.ProgressViewIOSProperties>;
-  ScrollView: ReactNativeStyledFunction<ReactNative.ScrollViewProps>;
-  SegmentedControlIOS: ReactNativeStyledFunction<ReactNative.SegmentedControlIOSProperties>;
-  Slider: ReactNativeStyledFunction<ReactNative.SliderProperties>;
-  SliderIOS: ReactNativeStyledFunction<ReactNative.SliderPropertiesIOS>;
-  SnapshotViewIOS: ReactNativeStyledFunction<ReactNative.SnapshotViewIOSProperties>;
-  RecyclerViewBackedScrollView: ReactNativeStyledFunction<ReactNative.RecyclerViewBackedScrollViewProperties>;
-  RefreshControl: ReactNativeStyledFunction<ReactNative.RefreshControlProperties>;
-  SafeAreaView: ReactNativeStyledFunction<ReactNative.SafeAreaView>;
-  StatusBar: ReactNativeStyledFunction<ReactNative.StatusBarProperties>;
-  SwipeableListView: ReactNativeStyledFunction<ReactNative.SwipeableListViewProps>;
-  Switch: ReactNativeStyledFunction<ReactNative.SwitchProperties>;
-  SwitchIOS: ReactNativeStyledFunction<ReactNative.SwitchIOSProperties>;
-  Text: ReactNativeStyledFunction<ReactNative.TextProperties>;
-  TextInput: ReactNativeStyledFunction<ReactNative.TextInputProperties>;
-  TouchableHighlight: ReactNativeStyledFunction<ReactNative.TouchableHighlightProperties>;
-  TouchableNativeFeedback: ReactNativeStyledFunction<ReactNative.TouchableNativeFeedbackProperties>;
-  TouchableOpacity: ReactNativeStyledFunction<ReactNative.TouchableOpacityProperties>;
-  TouchableWithoutFeedback: ReactNativeStyledFunction<ReactNative.TouchableWithoutFeedbackProps>;
-  View: ReactNativeStyledFunction<ReactNative.ViewProperties>;
-  ViewPagerAndroid: ReactNativeStyledFunction<ReactNative.ViewPagerAndroidProperties>;
-  WebView: ReactNativeStyledFunction<ReactNative.WebViewProperties>;
-}
-
-declare const styled: StyledInterface;
-
-export default styled;

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -57,7 +57,6 @@ export interface ThemedBaseStyledInterface<T> extends ThemedStyledComponentFacto
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>;
 
 export type ThemedStyledInterface<T> = ThemedBaseStyledInterface<T>;
-export type StyledInterface = ThemedStyledInterface<any>;
 
 export interface ThemeProviderProps<T> {
   theme?: T | ((theme: T) => T);
@@ -86,6 +85,55 @@ export interface ThemedStyledComponentsModule<T> {
 
   ThemeProvider: ThemeProviderComponent<T>;
 }
+
+/**
+ *  native-extension types
+ **/
+export type ReactNativeStyledFunction<P> = StyledFunction<P>;
+
+export interface StyledInterface extends ThemedStyledInterface<any> {
+  ActivityIndicator: ReactNativeStyledFunction<ReactNative.ActivityIndicatorProperties>;
+  ActivityIndicatorIOS: ReactNativeStyledFunction<ReactNative.ActivityIndicatorProperties>;
+
+  // ART: StyledFunction<ReactNative.ART>;
+  Button: ReactNativeStyledFunction<ReactNative.ButtonProperties>;
+  DatePickerIOS: ReactNativeStyledFunction<ReactNative.DatePickerIOSProperties>;
+  DrawerLayoutAndroid: ReactNativeStyledFunction<ReactNative.DrawerLayoutAndroidProperties>;
+  Image: ReactNativeStyledFunction<ReactNative.ImageProperties>;
+  ImageBackground: ReactNativeStyledFunction<ReactNative.ImageBackgroundProperties>;
+
+  KeyboardAvoidingView: ReactNativeStyledFunction<ReactNative.KeyboardAvoidingViewProps>;
+  ListView: ReactNativeStyledFunction<ReactNative.ListViewProperties>;
+  MapView: ReactNativeStyledFunction<ReactNative.MapViewProperties>;
+  Modal: ReactNativeStyledFunction<ReactNative.ModalProperties>;
+  NavigatorIOS: ReactNativeStyledFunction<ReactNative.NavigatorIOSProperties>;
+  Picker: ReactNativeStyledFunction<ReactNative.PickerProperties>;
+  PickerIOS: ReactNativeStyledFunction<ReactNative.PickerIOSProperties>;
+  ProgressBarAndroid: ReactNativeStyledFunction<ReactNative.ProgressBarAndroidProperties>;
+  ProgressViewIOS: ReactNativeStyledFunction<ReactNative.ProgressViewIOSProperties>;
+  ScrollView: ReactNativeStyledFunction<ReactNative.ScrollViewProps>;
+  SegmentedControlIOS: ReactNativeStyledFunction<ReactNative.SegmentedControlIOSProperties>;
+  Slider: ReactNativeStyledFunction<ReactNative.SliderProperties>;
+  SliderIOS: ReactNativeStyledFunction<ReactNative.SliderPropertiesIOS>;
+  SnapshotViewIOS: ReactNativeStyledFunction<ReactNative.SnapshotViewIOSProperties>;
+  RecyclerViewBackedScrollView: ReactNativeStyledFunction<ReactNative.RecyclerViewBackedScrollViewProperties>;
+  RefreshControl: ReactNativeStyledFunction<ReactNative.RefreshControlProperties>;
+  SafeAreaView: ReactNativeStyledFunction<ReactNative.SafeAreaView>;
+  StatusBar: ReactNativeStyledFunction<ReactNative.StatusBarProperties>;
+  SwipeableListView: ReactNativeStyledFunction<ReactNative.SwipeableListViewProps>;
+  Switch: ReactNativeStyledFunction<ReactNative.SwitchProperties>;
+  SwitchIOS: ReactNativeStyledFunction<ReactNative.SwitchIOSProperties>;
+  Text: ReactNativeStyledFunction<ReactNative.TextProperties>;
+  TextInput: ReactNativeStyledFunction<ReactNative.TextInputProperties>;
+  TouchableHighlight: ReactNativeStyledFunction<ReactNative.TouchableHighlightProperties>;
+  TouchableNativeFeedback: ReactNativeStyledFunction<ReactNative.TouchableNativeFeedbackProperties>;
+  TouchableOpacity: ReactNativeStyledFunction<ReactNative.TouchableOpacityProperties>;
+  TouchableWithoutFeedback: ReactNativeStyledFunction<ReactNative.TouchableWithoutFeedbackProps>;
+  View: ReactNativeStyledFunction<ReactNative.ViewProperties>;
+  ViewPagerAndroid: ReactNativeStyledFunction<ReactNative.ViewPagerAndroidProperties>;
+  WebView: ReactNativeStyledFunction<ReactNative.WebViewProperties>;
+}
+/****/
 
 declare const styled: StyledInterface;
 

--- a/typings/tests/native-test.tsx
+++ b/typings/tests/native-test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import styled from "../../native";
+import styledFromNative from "../../native";
+import styled from "../..";
 
 const StyledView = styled.View`
   background-color: papayawhip;
@@ -10,6 +11,22 @@ const StyledText = styled.Text`
 `;
 
 class MyReactNativeComponent extends React.Component<{}, {}> {
+  render() {
+    return <StyledView>
+      <StyledText>Hello World!</StyledText>
+    </StyledView>;
+  }
+}
+
+const StyledViewFromNative = styledFromNative.View`
+  background-color: papayawhip;
+`;
+
+const StyledTextFromNative = styledFromNative.Text`
+  color: palevioletred;
+`;
+
+class MyReactNativeComponentFromNativeDir extends React.Component<{}, {}> {
   render() {
     return <StyledView>
       <StyledText>Hello World!</StyledText>


### PR DESCRIPTION
I found that using typescript, completion doesn't work and build failed because not resolving native type definitions due to ambient file located  in /native directory if you use `import from 'styled-components'` though `import from 'styled-components/native'` works well. I fixed them with keeping compatibility of styled-components/native because original code already implements native feature codes.

I saw the discussion in https://github.com/styled-components/styled-components/issues/1442 so, close this request if you don't need this.