### PR TITLE
Switch from .attrs to interpolations in benchmarks

### DIFF
--- a/benchmarks/src/implementations/styled-components/Dot.js
+++ b/benchmarks/src/implementations/styled-components/Dot.js
@@ -3,12 +3,6 @@ import styled from 'styled-components';
 import View from './View';
 
 const Dot = styled(View)`
-  margin-left: ${props => props.x + 'px'};
-  margin-top: ${props => props.y + 'px'};
-  border-right-width: ${props => props.size / 2 + 'px'};
-  border-bottom-width: ${props => props.size / 2 + 'px'};
-  border-left-width: ${props => props.size / 2 + 'px'};
-  border-bottom-color: ${props => props.color};
   position: absolute;
   cursor: pointer;
   width: 0;
@@ -17,6 +11,12 @@ const Dot = styled(View)`
   border-style: solid;
   border-top-width: 0;
   transform: translate(50%, 50%);
+  margin-left: ${props => props.x + 'px'};
+  margin-top: ${props => props.y + 'px'};
+  border-right-width: ${props => props.size / 2 + 'px'};
+  border-bottom-width: ${props => props.size / 2 + 'px'};
+  border-left-width: ${props => props.size / 2 + 'px'};
+  border-bottom-color: ${props => props.color};
 `;
 
 export default Dot;

--- a/benchmarks/src/implementations/styled-components/Dot.js
+++ b/benchmarks/src/implementations/styled-components/Dot.js
@@ -2,16 +2,13 @@
 import styled from 'styled-components';
 import View from './View';
 
-const Dot = styled(View).attrs({
-  style: props => ({
-    marginLeft: `${props.x}px`,
-    marginTop: `${props.y}px`,
-    borderRightWidth: `${props.size / 2}px`,
-    borderBottomWidth: `${props.size / 2}px`,
-    borderLeftWidth: `${props.size / 2}px`,
-    borderBottomColor: `${props.color}`
-  })
-})`
+const Dot = styled(View)`
+  margin-left: ${props => props.x + 'px'};
+  margin-top: ${props => props.y + 'px'};
+  border-right-width: ${props => props.size / 2 + 'px'};
+  border-bottom-width: ${props => props.size / 2 + 'px'};
+  border-left-width: ${props => props.size / 2 + 'px'};
+  border-bottom-color: ${props => props.color};
   position: absolute;
   cursor: pointer;
   width: 0;


### PR DESCRIPTION
For some reason this was built using `.attrs`, which skewed the update dynamic styles benchmark. This PR switches it back to props interpolations.

~~EDIT: This actually crashes the update dynamic styles benchmark! :scream: We should probably fix that performance...~~ Nevermind I'm just a dummy.

Here are the new results that accurately reflect lib speed:

<img width="725" alt="screen shot 2018-07-18 at 10 55 43" src="https://user-images.githubusercontent.com/7525670/42853355-3a023a14-8a79-11e8-8bc1-162b4fd7a494.png">
