### PR TITLE
#1885: fix missing generic type arguments in .d.ts

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -176,7 +176,7 @@ export function injectGlobal(
 
 export function consolidateStreamedStyles(): void
 
-export function isStyledComponent(target: any): target is StyledComponentClass
+export function isStyledComponent(target: any): target is StyledComponentClass<{}, {}>
 
 export const ThemeProvider: ThemeProviderComponent<object>
 


### PR DESCRIPTION
fixes #1885 

Another option would be to set the default type params on the `StyledComponentClass`-type itself. But I guess that would mean that when using the `StyledComponentClass`-interface the generic types could be omitted and hence some type-safety would be lost.