### PR TITLE
Fix rule-injection with deferred rules being mutated while used across clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-* placeholder
+* Fix a regression from [#1843](https://github.com/styled-components/pull/1892) that breaks deferred injection and duplicates rules (see [#1892](https://github.com/styled-components/pull/1892))
 
 ## [v3.4.1] - 2018-08-04
 

--- a/src/models/StyleSheet.js
+++ b/src/models/StyleSheet.js
@@ -275,13 +275,16 @@ export default class StyleSheet {
     const tag = this.getTagForId(id)
 
     /* add deferred rules for component */
-    if (this.deferred[id]) {
-      this.deferred[id].push(...cssRules)
-
-      // $FlowFixMe
-      tag.insertRules(id, this.deferred[id], name)
+    if (this.deferred[id] !== undefined) {
+      // Combine passed cssRules with previously deferred CSS rules
+      // NOTE: We cannot mutate the deferred array itself as all clones
+      // do the same (see clones[i].inject)
+      const rules = this.deferred[id].concat(cssRules)
+      tag.insertRules(id, rules, name)
       this.deferred[id] = undefined
-    } else tag.insertRules(id, cssRules, name)
+    } else {
+      tag.insertRules(id, cssRules, name)
+    }
   }
 
   /* removes all rules for a given id, which doesn't remove its marker but resets it */

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -217,4 +217,28 @@ describe('with styles', () => {
       expect(el.getAttribute('nonce')).toBe('foo')
     })
   })
+
+  it('should handle deferredInject and inject correctly', () => {
+    const cloneA = StyleSheet.master.clone()
+    const cloneB = StyleSheet.master.clone()
+    const rules = ['.testA {}']
+
+    StyleSheet.master.deferredInject('test', rules)
+
+    expect(StyleSheet.master.deferred.test).toBe(rules)
+    expect(cloneA.deferred.test).toBe(rules)
+    expect(cloneB.deferred.test).toBe(rules)
+
+    StyleSheet.master.inject('test', ['.testB {}'])
+
+    const inspectTag = sheet => {
+      const tag = sheet.getTagForId('test')
+      return tag.css()
+    }
+
+    const masterCss = inspectTag(StyleSheet.master)
+
+    expect(masterCss).toEqual(inspectTag(cloneA))
+    expect(masterCss).toEqual(inspectTag(cloneB))
+  })
 })


### PR DESCRIPTION
Fix #1890 

A regression was introduced and not caught in time in #1843 which has gone out recently.

What happens is:

- Components are created and call `deferredInject` on a `StyleSheet`
- Some clones are created from StyleSheet.master which inherit all deferred arrays
- The prior two steps might also be in reverse order; doesn't matter
- `inject` is called on render which takes deferred rules into account
- During the injection the `deferred[id]` array is mutated (to avoid `concat`)
- The mutated array is then used in the same manner in other stylesheets, which add the rules that need to be injected again

Hence the outcome is that rules are duplicated for each subsequent clone that injects them.