### PR TITLE
feature(typings): ability to define theme without creating styled wraper

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -106,9 +106,9 @@ export interface ThemedBaseStyledInterface<T>
   ): ThemedStyledFunction<P, T, WithOptionalTheme<P, T>>
 }
 export type BaseStyledInterface = ThemedBaseStyledInterface<any>
-
-export type ThemedStyledInterface<T> = ThemedBaseStyledInterface<T>
-export type StyledInterface = ThemedStyledInterface<any>
+export type ThemedStyledInterface<T> = ThemedBaseStyledInterface<Extract<keyof T, string> extends never ? any : T>;
+export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
+export interface DefaultTheme {}
 
 export interface ThemeProviderProps<T> {
   theme?: T | ((theme: T) => T)


### PR DESCRIPTION
IMO wrapping `styled` (as proposed in [docs](https://www.styled-components.com/docs/api#typescript)) only for giving TS an ability to check correctness isn't good way to go. It's easy to make a mistake and accidentally import original `styled` instead of wrapped, becuase this:
```TypeScript
import styled from 'styled-components';
```
and this:
```TypeScript
import styled from 'app/styled-components';
```
are very similar.
This approach also creates additional performance and size overhead for resulting bundle. Obviously it's very small, but it's better to avoid it.

This PR gives an ability to avoid it with using 2 TS features: [merging interfaces](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces) and [conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html).

## Proposed approach for defining theme
Augment `DefaultTheme` interface from `styled-components` lib like this:
```TypeScript
import { MyTheme } from './theme';

declare module 'styled-components' {
    export interface DefaultTheme extends MyTheme {
    }
}
```
or even this way:
```TypeScript
declare module 'styled-components' {
    export interface DefaultTheme {
        myColor: string;
        propA: number;
        // ...
    }
}
```
And just use original styled object from library.
```TypeScript
import styled from 'styled-components';

const Title = styled.h3`
    color: ${props => props.theme.myColor /* <- this theme property is checked in compile time */}
    left: ${props => props.theme.propB /* <- error here, because propB doesn't exist */}
`;
```
TypeScript will merge `DefaultTheme` from library with one you defined in your code allowing you to get Intellisense and type checking without providing runtime wrapper.

Worth to mention that because of **conditional types**, this PR is backwards-compatible for TS users.
If `DefaultTheme` has no properties (by default it's empty) `any` used instead of it, which allows to get any properties from `theme` without errors, otherwise `DefaultTheme` is used and trying to get property from `theme` which isn't declared in interface will cause compile time error.