### PR TITLE
remove jsnext:main package.json entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-* placeholder
+* Remove deprecated `jsnext:main` entry point from package.json, by [@probablyup](https://github.com/probablyup) (see [#1907](https://github.com/styled-components/styled-components/pull/1907))
 
 ## [v3.4.2] - 2018-08-07
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
   "typings": "typings/styled-components.d.ts",
   "main": "dist/styled-components.cjs.js",
-  "jsnext:main": "dist/styled-components.esm.js",
   "module": "dist/styled-components.esm.js",
   "react-native": "dist/styled-components.native.cjs.js",
   "browser": {


### PR DESCRIPTION
It's been superceded by "module"

Closes #1825 