### PR TITLE
add "no-tags" entry to be used in conjunction with babel plugin

### DIFF
--- a/integration-test/styled-components-no-tags.test.js
+++ b/integration-test/styled-components-no-tags.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+import renderer from 'react-test-renderer'
+
+jest.mock('styled-components', () =>
+  require('../dist/styled-components-no-tags.cjs.js')
+)
+
+const partial = css`
+  background: blue;
+`
+
+const Button = styled('button')`
+  ${partial};
+  color: red;
+`
+
+test('it works', () => {
+  renderer.create(<Button />).toJSON()
+})

--- a/no-tags/package.json
+++ b/no-tags/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "styled-components/no-tags",
+  "private": true,
+  "main": "../dist/styled-components-no-tags.cjs.js",
+  "module": "../dist/styled-components-no-tags.esm.js",
+  "browser": {
+    "./dist/styled-components-no-tags.cjs.js": "./dist/styled-components-no-tags.browser.cjs.js",
+    "./dist/styled-components-no-tags.esm.js": "./dist/styled-components-no-tags.browser.esm.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -162,22 +162,6 @@
     {
       "path": "./dist/styled-components.min.js",
       "maxSize": "16kB"
-    },
-    {
-      "path": "./dist/styled-components.cjs.min.js",
-      "maxSize": "11kB"
-    },
-    {
-      "path": "./dist/styled-components.esm.min.js",
-      "maxSize": "10.75kB"
-    },
-    {
-      "path": "./dist/styled-components-no-tags.cjs.min.js",
-      "maxSize": "10.25kB"
-    },
-    {
-      "path": "./dist/styled-components-no-tags.esm.min.js",
-      "maxSize": "10kB"
     }
   ],
   "collective": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "CONTRIBUTING.md",
     "dist",
     "native",
+    "no-tags",
     "primitives",
     "scripts",
     "test-utils"
@@ -160,15 +161,23 @@
   "bundlesize": [
     {
       "path": "./dist/styled-components.min.js",
-      "maxSize": "16.5kB"
+      "maxSize": "16kB"
     },
     {
       "path": "./dist/styled-components.cjs.min.js",
-      "maxSize": "11.5kB"
+      "maxSize": "11kB"
     },
     {
       "path": "./dist/styled-components.esm.min.js",
-      "maxSize": "11.5kB"
+      "maxSize": "10.75kB"
+    },
+    {
+      "path": "./dist/styled-components-no-tags.cjs.min.js",
+      "maxSize": "10.25kB"
+    },
+    {
+      "path": "./dist/styled-components-no-tags.esm.min.js",
+      "maxSize": "10kB"
     }
   ],
   "collective": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -121,16 +121,6 @@ const serverConfig = {
   ),
 }
 
-const serverProdConfig = {
-  ...configBase,
-  ...serverConfig,
-  output: [
-    getESM({ file: 'dist/styled-components.esm.min.js' }),
-    getCJS({ file: 'dist/styled-components.cjs.min.js' }),
-  ],
-  plugins: serverConfig.plugins.concat(prodPlugins),
-}
-
 const browserConfig = {
   ...configBase,
   output: [
@@ -143,20 +133,6 @@ const browserConfig = {
       __SERVER__: JSON.stringify(false),
     })
   ),
-}
-
-const browserProdConfig = {
-  ...configBase,
-  ...browserConfig,
-  output: [
-    getESM({
-      file: 'dist/styled-components.browser.esm.min.js',
-    }),
-    getCJS({
-      file: 'dist/styled-components.browser.cjs.min.js',
-    }),
-  ],
-  plugins: browserConfig.plugins.concat(prodPlugins),
 }
 
 const noTagsPath = './src/index-without-tags.js'
@@ -175,24 +151,6 @@ const noTagServerConfig = {
   ),
 }
 
-const noTagServerProdConfig = {
-  ...configBase,
-  ...serverConfig,
-  input: noTagsPath,
-  output: [
-    getESM({ file: 'dist/styled-components-no-tags.esm.min.js' }),
-    getCJS({ file: 'dist/styled-components-no-tags.cjs.min.js' }),
-  ],
-  plugins: serverConfig.plugins.concat(
-    replace({
-      'process.env.NODE_ENV': JSON.stringify('production'),
-    }),
-    terser({
-      sourceMap: true,
-    })
-  ),
-}
-
 const noTagBrowserConfig = {
   ...configBase,
   input: noTagsPath,
@@ -204,28 +162,6 @@ const noTagBrowserConfig = {
     replace({
       ...streamIgnore,
       __SERVER__: JSON.stringify(false),
-    })
-  ),
-}
-
-const noTagBrowserProdConfig = {
-  ...configBase,
-  ...browserConfig,
-  input: noTagsPath,
-  output: [
-    getESM({
-      file: 'dist/styled-components-no-tags.browser.esm.min.js',
-    }),
-    getCJS({
-      file: 'dist/styled-components-no-tags.browser.cjs.min.js',
-    }),
-  ],
-  plugins: browserConfig.plugins.concat(
-    replace({
-      'process.env.NODE_ENV': JSON.stringify('production'),
-    }),
-    terser({
-      sourceMap: true,
     })
   ),
 }
@@ -258,13 +194,9 @@ export default [
   umdConfig,
   umdProdConfig,
   serverConfig,
-  serverProdConfig,
   browserConfig,
-  browserProdConfig,
   noTagServerConfig,
-  noTagServerProdConfig,
   noTagBrowserConfig,
-  noTagBrowserProdConfig,
   nativeConfig,
   primitivesConfig,
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -159,6 +159,77 @@ const browserProdConfig = {
   plugins: browserConfig.plugins.concat(prodPlugins),
 }
 
+const noTagsPath = './src/index-without-tags.js'
+
+const noTagServerConfig = {
+  ...configBase,
+  input: noTagsPath,
+  output: [
+    getESM({ file: 'dist/styled-components-no-tags.esm.js' }),
+    getCJS({ file: 'dist/styled-components-no-tags.cjs.js' }),
+  ],
+  plugins: configBase.plugins.concat(
+    replace({
+      __SERVER__: JSON.stringify(true),
+    })
+  ),
+}
+
+const noTagServerProdConfig = {
+  ...configBase,
+  ...serverConfig,
+  input: noTagsPath,
+  output: [
+    getESM({ file: 'dist/styled-components-no-tags.esm.min.js' }),
+    getCJS({ file: 'dist/styled-components-no-tags.cjs.min.js' }),
+  ],
+  plugins: serverConfig.plugins.concat(
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+    terser({
+      sourceMap: true,
+    })
+  ),
+}
+
+const noTagBrowserConfig = {
+  ...configBase,
+  input: noTagsPath,
+  output: [
+    getESM({ file: 'dist/styled-components-no-tags.browser.esm.js' }),
+    getCJS({ file: 'dist/styled-components-no-tags.browser.cjs.js' }),
+  ],
+  plugins: configBase.plugins.concat(
+    replace({
+      ...streamIgnore,
+      __SERVER__: JSON.stringify(false),
+    })
+  ),
+}
+
+const noTagBrowserProdConfig = {
+  ...configBase,
+  ...browserConfig,
+  input: noTagsPath,
+  output: [
+    getESM({
+      file: 'dist/styled-components-no-tags.browser.esm.min.js',
+    }),
+    getCJS({
+      file: 'dist/styled-components-no-tags.browser.cjs.min.js',
+    }),
+  ],
+  plugins: browserConfig.plugins.concat(
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+    terser({
+      sourceMap: true,
+    })
+  ),
+}
+
 const nativeConfig = {
   ...configBase,
   input: './src/native/index.js',
@@ -190,6 +261,10 @@ export default [
   serverProdConfig,
   browserConfig,
   browserProdConfig,
+  noTagServerConfig,
+  noTagServerProdConfig,
+  noTagBrowserConfig,
+  noTagBrowserProdConfig,
   nativeConfig,
   primitivesConfig,
 ]

--- a/src/base.js
+++ b/src/base.js
@@ -1,0 +1,77 @@
+// @flow
+
+/* Import singletons */
+import stringifyRules from './utils/stringifyRules'
+import isStyledComponent from './utils/isStyledComponent'
+import generateAlphabeticName from './utils/generateAlphabeticName'
+import css from './constructors/css'
+import ServerStyleSheet from './models/ServerStyleSheet'
+import StyleSheetManager from './models/StyleSheetManager'
+
+/* Import singleton constructors */
+import _keyframes from './constructors/keyframes'
+import _injectGlobal from './constructors/injectGlobal'
+
+/* Import components */
+import ThemeProvider from './models/ThemeProvider'
+
+/* Import Higher Order Components */
+import withTheme from './hoc/withTheme'
+
+/* Warning if you've imported this file on React Native */
+if (
+  process.env.NODE_ENV !== 'production' &&
+  typeof navigator !== 'undefined' &&
+  navigator.product === 'ReactNative'
+) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "It looks like you've imported 'styled-components' on React Native.\n" +
+      "Perhaps you're looking to import 'styled-components/native'?\n" +
+      'Read more about this at https://www.styled-components.com/docs/basics#react-native'
+  )
+}
+
+/* Warning if there are several instances of styled-components */
+if (
+  process.env.NODE_ENV !== 'production' &&
+  process.env.NODE_ENV !== 'test' &&
+  typeof window !== 'undefined' &&
+  typeof navigator !== 'undefined' &&
+  typeof navigator.userAgent === 'string' &&
+  navigator.userAgent.indexOf('Node.js') === -1 &&
+  navigator.userAgent.indexOf('jsdom') === -1
+) {
+  window['__styled-components-init__'] =
+    window['__styled-components-init__'] || 0
+
+  if (window['__styled-components-init__'] === 1) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "It looks like there are several instances of 'styled-components' initialized in this application. " +
+        'This may cause dynamic styles not rendering properly, errors happening during rehydration process ' +
+        'and makes your application bigger without a good reason.\n\n' +
+        'See https://s-c.sh/2BAXzed for more info.'
+    )
+  }
+
+  window['__styled-components-init__'] += 1
+}
+
+/* Instantiate exported singletons */
+const keyframes = _keyframes(generateAlphabeticName, stringifyRules, css)
+const injectGlobal = _injectGlobal(stringifyRules, css)
+
+/* Export everything */
+
+export * from './secretInternals'
+export {
+  css,
+  keyframes,
+  injectGlobal,
+  isStyledComponent,
+  ThemeProvider,
+  withTheme,
+  ServerStyleSheet,
+  StyleSheetManager,
+}

--- a/src/index-without-tags.js
+++ b/src/index-without-tags.js
@@ -9,8 +9,9 @@ import css from './constructors/css'
 /* Import singleton constructors */
 import _StyledComponent from './models/StyledComponent'
 import _ComponentStyle from './models/ComponentStyle'
-import _styled from './constructors/styled'
 import _constructWithOptions from './constructors/constructWithOptions'
+
+import type { Target } from './types'
 
 export * from './base'
 
@@ -24,4 +25,4 @@ const ComponentStyle = _ComponentStyle(
 const constructWithOptions = _constructWithOptions(css)
 const StyledComponent = _StyledComponent(ComponentStyle)
 
-export default _styled(StyledComponent, constructWithOptions)
+export default (tag: Target) => constructWithOptions(StyledComponent, tag)


### PR DESCRIPTION
This allows babel users to drop the element whitelist and save some bytes.

Related to https://github.com/styled-components/babel-plugin-styled-components/issues/125