### PR TITLE
check styledContext is not undefined

### DIFF
--- a/src/hoc/withTheme.js
+++ b/src/hoc/withTheme.js
@@ -43,7 +43,7 @@ export default (Component: ComponentType<any>) => {
         )
       } else if (styledContext === undefined && themeProp !== undefined) {
         this.setState({ theme: themeProp })
-      } else {
+      } else if (styledContext !== undefined) {
         const { subscribe } = styledContext
         this.unsubscribeId = subscribe(nextTheme => {
           const theme = determineTheme(this.props, nextTheme, defaultProps)


### PR DESCRIPTION
Chekc styledContext is not undefined before get value from it. Otherwise, if a component is wrapped by `withTheme` without `ThemeProvider` wrapped may cause crashed in production mode.