### PR TITLE
fix standalone browser build

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,6 +14,8 @@
 .*/lib/.*
 .*/src/test/.*
 .*/src/.*/test/.*
+.*/example/.*
+.*/integration-test/.*
 
 [include]
 

--- a/example/devServer.js
+++ b/example/devServer.js
@@ -5,25 +5,26 @@ const watch = require('node-watch')
 
 import fs from 'fs'
 import React from 'react'
-import { renderToString } from  'react-dom/server'
-import { ServerStyleSheet } from '../dist/styled-components'
-import getExample from "./example"
+import { renderToString } from 'react-dom/server'
+import { ServerStyleSheet } from '..'
+import getExample from './example'
 
 const HTML = fs.readFileSync(__dirname + '/index.html').toString()
 
-const srcPath = __dirname.split('/example')[0] + '/src';
+const srcPath = __dirname.split('/example')[0] + '/src'
 
-const hotBuild = () => exec('npm run build:dist', (err, stdout, stderr) => {
-  if (err) throw err
-  if (stdout) {
-    console.log(`npm run build:dist --- ${stdout}`)
-  }
-  if (stderr) {
-    console.log(`npm run build:dist --- ${stderr}`)
-  }
-})
+const hotBuild = () =>
+  exec('npm run build:dist', (err, stdout, stderr) => {
+    if (err) throw err
+    if (stdout) {
+      console.log(`npm run build:dist --- ${stdout}`)
+    }
+    if (stderr) {
+      console.log(`npm run build:dist --- ${stderr}`)
+    }
+  })
 
-watch(srcPath, (filename) => {
+watch(srcPath, filename => {
   console.log(`${filename} file has changed`)
   hotBuild()
 })
@@ -41,12 +42,10 @@ app.get('/ssr.html', (req, res) => {
   const Example = getExample()
 
   const sheet = new ServerStyleSheet()
-  const html = renderToString(sheet.collectStyles(<Example/>))
+  const html = renderToString(sheet.collectStyles(<Example />))
   const css = sheet.getStyleTags()
   res.send(
-    HTML
-      .replace(/<!-- SSR:HTML -->/, html)
-      .replace(/<!-- SSR:CSS -->/, css)
+    HTML.replace(/<!-- SSR:HTML -->/, html).replace(/<!-- SSR:CSS -->/, css)
   )
 })
 

--- a/example/example.js
+++ b/example/example.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled, { injectGlobal, keyframes } from '../dist/styled-components'
+import styled, { injectGlobal, keyframes } from '..'
 
 export default () => {
   injectGlobal`
@@ -15,14 +15,14 @@ export default () => {
     text-align: center;
     color: palevioletred;
     animation: ${keyframes`from { opacity: 0; }`} 1s both;
-  `;
+  `
 
   // Create a <Wrapper> react component that renders a <section> with
   // some padding and a papayawhip background
   const Wrapper = styled.section`
     padding: 4em;
     background: papayawhip;
-  `;
+  `
 
   return class Example extends React.Component {
     render() {

--- a/example/index.html
+++ b/example/index.html
@@ -1,19 +1,23 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Basic Example</title>
-    <!-- SSR:CSS -->
-  </head>
-  <body>
-    <h1>Basic Example</h1>
-    <div id="container"><!-- SSR:HTML --></div>
-    <script src="https://unpkg.com/react@16.3.0/umd/react.production.min.js"></script>
-    <script src="https://unpkg.com/react-dom@16.3.0/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/react-dom@16.3.0/umd/react-dom-server.browser.production.min.js"></script>
-    <script src="https://unpkg.com/babel-standalone@6.26.0/babel.min.js"></script>
-    <script src="/styled-components.js"></script>
-    <script type="text/babel">
+
+<head>
+  <meta charset="utf-8">
+  <title>Basic Example</title>
+  <!-- SSR:CSS -->
+</head>
+
+<body>
+  <h1>Basic Example</h1>
+  <div id="container">
+    <!-- SSR:HTML -->
+  </div>
+  <script src="https://unpkg.com/react@16.3.0/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@16.3.0/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@16.3.0/umd/react-dom-server.browser.production.min.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6.26.0/babel.min.js"></script>
+  <script src="/styled-components.js"></script>
+  <script type="text/babel">
       styled.injectGlobal`
     body {
       font-family: sans-serif;
@@ -22,7 +26,7 @@
 
       // Create a <Title> react component that renders an <h1> which is
       // centered, palevioletred and sized at 1.5em
-      const Title = styled.default.h1`
+      const Title = styled.h1`
     font-size: 1.5em;
     text-align: center;
     color: palevioletred;
@@ -31,7 +35,7 @@
 
       // Create a <Wrapper> react component that renders a <section> with
       // some padding and a papayawhip background
-      const Wrapper = styled.default.section`
+      const Wrapper = styled.section`
     padding: 4em;
     background: papayawhip;
   `;
@@ -51,5 +55,6 @@
         document.getElementById('container')
       );
     </script>
-  </body>
+</body>
+
 </html>

--- a/integration-test/jest-styled-components.test.js
+++ b/integration-test/jest-styled-components.test.js
@@ -1,9 +1,10 @@
+// @flow
 import React from 'react'
-import styled from 'styled-components'
+import styled from '..'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 
-jest.mock('styled-components', () => require('../dist/styled-components'))
+// jest.mock('styled-components', () => require('../dist/styled-components.cjs'))
 
 const Button = styled.button`
   color: red;

--- a/integration-test/styled-components-no-tags.test.js
+++ b/integration-test/styled-components-no-tags.test.js
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components'
 import renderer from 'react-test-renderer'
 
 jest.mock('styled-components', () =>
-  require('../dist/styled-components-no-tags.cjs.js')
+  require('../dist/styled-components-no-tags.cjs')
 )
 
 const partial = css`

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -72,12 +72,13 @@ const configBase = {
 
 const globals = { react: 'React' }
 
-const umdBaseConfig = {
+const standaloneBaseConfig = {
   ...configBase,
+  input: './src/index-standalone.js',
   output: {
-    exports: 'named',
     file: 'dist/styled-components.js',
-    format: 'umd',
+    format: 'iife',
+    footer: ';window.styled = styled;',
     globals,
     name: 'styled',
     sourcemap: true,
@@ -91,21 +92,22 @@ const umdBaseConfig = {
   ),
 }
 
-const umdConfig = {
-  ...umdBaseConfig,
-  plugins: umdBaseConfig.plugins.concat(
+const standaloneConfig = {
+  ...standaloneBaseConfig,
+  plugins: standaloneBaseConfig.plugins.concat(
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),
     })
   ),
 }
 
-const umdProdConfig = {
-  ...umdBaseConfig,
-  output: Object.assign({}, umdBaseConfig.output, {
+const standaloneProdConfig = {
+  ...standaloneBaseConfig,
+  output: {
+    ...standaloneBaseConfig.output,
     file: 'dist/styled-components.min.js',
-  }),
-  plugins: umdBaseConfig.plugins.concat(prodPlugins),
+  },
+  plugins: standaloneBaseConfig.plugins.concat(prodPlugins),
 }
 
 const serverConfig = {
@@ -191,8 +193,8 @@ const primitivesConfig = {
 }
 
 export default [
-  umdConfig,
-  umdProdConfig,
+  standaloneConfig,
+  standaloneProdConfig,
   serverConfig,
   browserConfig,
   noTagServerConfig,

--- a/src/index-standalone.js
+++ b/src/index-standalone.js
@@ -1,0 +1,38 @@
+// @flow
+
+/* Import singletons */
+import flatten from './utils/flatten'
+import stringifyRules from './utils/stringifyRules'
+import generateAlphabeticName from './utils/generateAlphabeticName'
+import css from './constructors/css'
+
+/* Import singleton constructors */
+import _StyledComponent from './models/StyledComponent'
+import _ComponentStyle from './models/ComponentStyle'
+import _styled from './constructors/styled'
+import _constructWithOptions from './constructors/constructWithOptions'
+
+import * as secondary from './base'
+
+/* Instantiate singletons */
+const ComponentStyle = _ComponentStyle(
+  generateAlphabeticName,
+  flatten,
+  stringifyRules
+)
+
+const constructWithOptions = _constructWithOptions(css)
+const StyledComponent = _StyledComponent(ComponentStyle)
+
+const styled = _styled(StyledComponent, constructWithOptions)
+
+/**
+ * eliminates the need to do styled.default since the other APIs
+ * are directly assigned as properties to the main function
+ * */
+// eslint-disable-next-line guard-for-in
+for (const key in secondary) {
+  styled[key] = secondary[key]
+}
+
+export default styled


### PR DESCRIPTION
something about the "umd" setting in recent versions of rollup
just doesn't work properly

verified this fixes things as expected and allows browser users to not have to do `styled.default` anymore: https://codesandbox.io/s/9q3pm157jw

closes #1870 