### PR TITLE
Keyframes refactoring

### DIFF
--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -1,28 +1,22 @@
 // @flow
 import hashStr from '../vendor/glamor/hash'
 import type { Interpolation, NameGenerator, Stringifier } from '../types'
-import StyleSheet from '../models/StyleSheet'
+import Keyframes from '../models/Keyframes'
 
 const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '')
 
 type KeyframesFn = (
   strings: Array<string>,
   ...interpolations: Array<Interpolation>
-) => string
+) => Keyframes
 
 export default (
   nameGenerator: NameGenerator,
   stringifyRules: Stringifier,
   css: Function
-): KeyframesFn => (...arr): string => {
-  const styleSheet = StyleSheet.master
+): KeyframesFn => (...arr): Keyframes => {
   const rules = css(...arr)
   const name = nameGenerator(hashStr(replaceWhitespace(JSON.stringify(rules))))
-  const id = `sc-keyframes-${name}`
 
-  if (!styleSheet.hasNameForId(id, name)) {
-    styleSheet.inject(id, stringifyRules(rules, name, '@keyframes'), name)
-  }
-
-  return name
+  return new Keyframes(name, stringifyRules(rules, name, '@keyframes'))
 }

--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -1,8 +1,12 @@
 // @flow
+import React from 'react'
+import { render } from 'enzyme'
+
 import _keyframes from '../keyframes'
 import stringifyRules from '../../utils/stringifyRules'
 import css from '../css'
 import { expectCSSMatches, resetStyled } from '../../test/utils'
+import Keyframes from '../../models/Keyframes'
 
 /**
  * Setup
@@ -16,6 +20,28 @@ describe('keyframes', () => {
     index = 0
   })
 
+  it('should return Keyframes instance', () => {
+    expect(keyframes`
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `).toBeInstanceOf(Keyframes)
+  })
+
+  it('should return its name via .getName()', () => {
+    expect(keyframes`
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `.getName()).toEqual('keyframe_0')
+  })
+
   it('should return its name', () => {
     expect(keyframes`
       0% {
@@ -24,10 +50,12 @@ describe('keyframes', () => {
       100% {
         opacity: 1;
       }
-    `).toEqual('keyframe_0')
+    `.getName()).toEqual('keyframe_0')
   })
 
   it('should insert the correct styles', () => {
+    const styled = resetStyled();
+
     const rules = `
       0% {
         opacity: 0;
@@ -37,8 +65,68 @@ describe('keyframes', () => {
       }
     `
 
-    const name = keyframes`${rules}`
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    expectCSSMatches('')
+
+    const Comp = styled.div`animation: ${animation} 2s linear infinite;`
+    render(<Comp />)
+
     expectCSSMatches(`
+      .sc-a {}
+      .b {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+    
+      @-webkit-keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+
+      @keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+    `)
+  })
+
+  it('should insert the correct styles when keyframes in props', () => {
+    const styled = resetStyled();
+
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `
+
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    expectCSSMatches('')
+
+    const Comp = styled.div`animation: ${props => props.animation} 2s linear infinite;`
+    render(<Comp animation={animation} />)
+
+    expectCSSMatches(`
+      .sc-a {}
+      .b {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+    
       @-webkit-keyframes ${name} {
         0% {
           opacity:0;

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -86,7 +86,7 @@ export default (
         return lastClassName
       }
 
-      const flatCSS = flatten(this.rules, executionContext)
+      const flatCSS = flatten(this.rules, executionContext, styleSheet)
       const name = generateRuleHash(this.componentId + flatCSS.join(''))
 
       if (!styleSheet.hasNameForId(componentId, name)) {

--- a/src/models/Keyframes.js
+++ b/src/models/Keyframes.js
@@ -1,0 +1,25 @@
+// @flow
+import StyleSheet from '../models/StyleSheet'
+
+export default class Keyframes {
+  id: string
+  name: string
+  rules: Array<string>
+
+  constructor(name: string, rules: Array<string>) {
+    this.name = name
+    this.rules = rules
+
+    this.id = `sc-keyframes-${name}`
+  }
+
+  inject = (styleSheet: StyleSheet) => {
+    if (!styleSheet.hasNameForId(this.id, this.name)) {
+      styleSheet.inject(this.id, this.rules, this.name)
+    }
+  }
+
+  getName() {
+    return this.name
+  }
+}

--- a/src/test/rehydration.test.js
+++ b/src/test/rehydration.test.js
@@ -383,20 +383,34 @@ describe('rehydration', () => {
     })
 
     it('should not regenerate keyframes', () => {
-      keyframes`
+      const fadeIn = keyframes`
         from { opacity: 0; }
       `
+
+      const A = styled.div`
+        animation: ${fadeIn} 1s both;
+      `
+      mount(<A />)
+
       expectCSSMatches(`
         @-webkit-keyframes keyframe_880 {from {opacity: 0;}}@keyframes keyframe_880 {from {opacity: 0;}}
+        .sc-a{ } .b{ -webkit-animation:keyframe_880 1s both; animation:keyframe_880 1s both; }
       `)
     })
 
     it('should still inject new keyframes', () => {
-      keyframes`
+      const fadeOut = keyframes`
         from { opacity: 1; }
       `
+
+      const A = styled.div`
+        animation: ${fadeOut} 1s both;
+      `
+      mount(<A />)
+
       expectCSSMatches(`
         @-webkit-keyframes keyframe_880 {from {opacity: 0;}}@keyframes keyframe_880 {from {opacity: 0;}}
+        .sc-a{ } .b{ -webkit-animation:keyframe_144 1s both; animation:keyframe_144 1s both; }
         @-webkit-keyframes keyframe_144 {from {opacity:1;}}@keyframes keyframe_144 {from {opacity:1;}}
       `)
     })
@@ -421,8 +435,33 @@ describe('rehydration', () => {
       expectCSSMatches(`
         @-webkit-keyframes keyframe_880 {from {opacity: 0;}}@keyframes keyframe_880 {from {opacity: 0;}}
         .sc-a { } .d { -webkit-animation:keyframe_880 1s both; animation:keyframe_880 1s both; }
-        @-webkit-keyframes keyframe_144 {from {opacity:1;}}@keyframes keyframe_144 {from {opacity:1;}}
         .sc-b { } .c { -webkit-animation:keyframe_144 1s both; animation:keyframe_144 1s both; }
+        @-webkit-keyframes keyframe_144 {from {opacity:1;}}@keyframes keyframe_144 {from {opacity:1;}}
+      `)
+    })
+
+    it('should pass the keyframes name through props along as well', () => {
+      const fadeIn = keyframes`
+        from { opacity: 0; }
+      `
+      const A = styled.div`
+        animation: ${props => props.animation} 1s both;
+      `
+      const fadeOut = keyframes`
+        from { opacity: 1; }
+      `
+      const B = styled.div`
+        animation: ${props => props.animation} 1s both;
+      `
+      /* Purposely rendering out of order to make sure the output looks right */
+      mount(<B animation={fadeOut} />)
+      mount(<A animation={fadeIn} />)
+
+      expectCSSMatches(`
+        @-webkit-keyframes keyframe_880 {from {opacity: 0;}}@keyframes keyframe_880 {from {opacity: 0;}}
+        .sc-a { } .d { -webkit-animation:keyframe_880 1s both; animation:keyframe_880 1s both; }
+        .sc-b { } .c { -webkit-animation:keyframe_144 1s both; animation:keyframe_144 1s both; }
+        @-webkit-keyframes keyframe_144 {from {opacity:1;}}@keyframes keyframe_144 {from {opacity:1;}}
       `)
     })
   })

--- a/src/types.js
+++ b/src/types.js
@@ -19,9 +19,14 @@ export type Target = string | ComponentType<*>
 
 export type NameGenerator = (hash: number) => string
 
+export type StyleSheet = {
+  create: Function,
+}
+
 export type Flattener = (
   chunks: Array<Interpolation>,
-  executionContext: ?Object
+  executionContext: ?Object,
+  styleSheet: ?Object
 ) => Array<Interpolation>
 
 export type Stringifier = (
@@ -29,7 +34,3 @@ export type Stringifier = (
   selector: ?string,
   prefix: ?string
 ) => Array<string>
-
-export type StyleSheet = {
-  create: Function,
-}

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -3,6 +3,7 @@ import hyphenate from 'fbjs/lib/hyphenateStyleName'
 import isPlainObject from './isPlainObject'
 
 import type { Interpolation } from '../types'
+import Keyframes from '../models/Keyframes'
 
 export const objToCss = (obj: Object, prevKey?: string): string => {
   const css = Object.keys(obj)
@@ -26,7 +27,8 @@ export const objToCss = (obj: Object, prevKey?: string): string => {
 
 const flatten = (
   chunks: Array<Interpolation>,
-  executionContext: ?Object
+  executionContext: ?Object,
+  styleSheet: ?Object
 ): Array<Interpolation> =>
   chunks.reduce((ruleSet: Array<Interpolation>, chunk: ?Interpolation) => {
     /* Remove falsey values */
@@ -41,7 +43,7 @@ const flatten = (
 
     /* Flatten ruleSet */
     if (Array.isArray(chunk)) {
-      ruleSet.push(...flatten(chunk, executionContext))
+      ruleSet.push(...flatten(chunk, executionContext, styleSheet))
       return ruleSet
     }
 
@@ -55,10 +57,21 @@ const flatten = (
     /* Either execute or defer the function */
     if (typeof chunk === 'function') {
       if (executionContext) {
-        ruleSet.push(...flatten([chunk(executionContext)], executionContext))
+        ruleSet.push(
+          ...flatten([chunk(executionContext)], executionContext, styleSheet)
+        )
       } else ruleSet.push(chunk)
 
       return ruleSet
+    }
+
+    if (chunk instanceof Keyframes) {
+      if (styleSheet) {
+        chunk.inject(styleSheet)
+        return ruleSet.concat(chunk.getName())
+      }
+
+      return ruleSet.concat(chunk)
     }
 
     /* Handle objects */

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -68,10 +68,10 @@ const flatten = (
     if (chunk instanceof Keyframes) {
       if (styleSheet) {
         chunk.inject(styleSheet)
-        return ruleSet.concat(chunk.getName())
-      }
+        ruleSet.push(chunk.getName())
+      } else ruleSet.push(chunk)
 
-      return ruleSet.concat(chunk)
+      return ruleSet
     }
 
     /* Handle objects */


### PR DESCRIPTION
Re-implement code from https://github.com/styled-components/styled-components/pull/1700 which ideas was taken from https://github.com/styled-components/styled-components/issues/1496

Based on current develop branch (I hope to ship this with 4.0 together with new global styling API)

Changelog:

 - keyframes`` helper  now returns Keyframes model
 - keyframes styles now inserting only with component rendering
 - To get animation name use `.getName()` method
 - some tests was changed to proper work with new `keyframes` helper

