### PR TITLE
Fix undefined warnExtendDeprecated call in production mode

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -66,7 +66,7 @@ const generateId = (
     : componentId
 }
 
-let warnExtendDeprecated
+let warnExtendDeprecated = () => {}
 if (process.env.NODE_ENV !== 'production') {
   warnExtendDeprecated = once(() => {
     // eslint-disable-next-line no-console

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -18,7 +18,7 @@ type State = {
   generatedStyles: any,
 }
 
-let warnExtendDeprecated
+let warnExtendDeprecated = () => {}
 if (process.env.NODE_ENV !== 'production') {
   warnExtendDeprecated = once(() => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
In production mode, the function was undefined. This change makes it a noop when `NODE_ENV=production`.