### PR TITLE
Updates keyframes typing to take into account the Theme / extra Props

### DIFF
--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -141,9 +141,9 @@ export interface ThemedStyledComponentsModule<T> {
   default: ThemedStyledInterface<T>
 
   css: ThemedCssFunction<T>
-  keyframes(
+  keyframes<P>(
     strings: TemplateStringsArray,
-    ...interpolations: SimpleInterpolation[]
+    ...interpolations: Interpolation<ThemedStyledProps<P, T>>[]
   ): string
   injectGlobal(
     strings: TemplateStringsArray,


### PR DESCRIPTION
I tried this locally, looks like it works.  It also allows passing in more props to merge with the theme.

![screen shot 2018-08-21 at 8 42 11 pm](https://user-images.githubusercontent.com/11984853/44441729-fa642a00-a582-11e8-8a67-d04f1424368f.png)

![screen shot 2018-08-21 at 8 42 30 pm](https://user-images.githubusercontent.com/11984853/44441728-f9cb9380-a582-11e8-9a3e-cc1062f7cfc3.png)

