### PR TITLE
add Themed* interfaces for react-native

### DIFF
--- a/native/index.d.ts
+++ b/native/index.d.ts
@@ -101,3 +101,67 @@ export interface StyledInterface extends BaseStyledInterface {
 declare const styled: StyledInterface
 
 export default styled
+
+// Themed version of StyledInterface
+
+import {
+  ThemedStyledFunction,
+  ThemedBaseStyledInterface,
+  ThemedCssFunction,
+  ThemeProviderComponent,
+  WithOptionalTheme,
+} from '..'
+
+export type ThemedReactNativeStyledFunction<P, T> = ThemedStyledFunction<P, T>
+export interface ThemedStyledInterface<T> extends ThemedBaseStyledInterface<T> {
+  ActivityIndicator: ThemedReactNativeStyledFunction<ReactNative.ActivityIndicatorProperties, T>
+  ActivityIndicatorIOS: ThemedReactNativeStyledFunction<ReactNative.ActivityIndicatorProperties, T>
+  Button: ThemedReactNativeStyledFunction<ReactNative.ButtonProperties, T>
+  DatePickerIOS: ThemedReactNativeStyledFunction<ReactNative.DatePickerIOSProperties, T>
+  DrawerLayoutAndroid: ThemedReactNativeStyledFunction<ReactNative.DrawerLayoutAndroidProperties, T>
+  Image: ThemedReactNativeStyledFunction<ReactNative.ImageProperties, T>
+  ImageBackground: ThemedReactNativeStyledFunction<ReactNative.ImageBackgroundProperties, T>
+  KeyboardAvoidingView: ThemedReactNativeStyledFunction<ReactNative.KeyboardAvoidingViewProps, T>
+  ListView: ThemedReactNativeStyledFunction<ReactNative.ListViewProperties, T>
+  MapView: ThemedReactNativeStyledFunction<ReactNative.MapViewProperties, T>
+  Modal: ThemedReactNativeStyledFunction<ReactNative.ModalProperties, T>
+  NavigatorIOS: ThemedReactNativeStyledFunction<ReactNative.NavigatorIOSProperties, T>
+  Picker: ThemedReactNativeStyledFunction<ReactNative.PickerProperties, T>
+  PickerIOS: ThemedReactNativeStyledFunction<ReactNative.PickerIOSProperties, T>
+  ProgressBarAndroid: ThemedReactNativeStyledFunction<ReactNative.ProgressBarAndroidProperties, T>
+  ProgressViewIOS: ThemedReactNativeStyledFunction<ReactNative.ProgressViewIOSProperties, T>
+  RecyclerViewBackedScrollView: ThemedReactNativeStyledFunction<ReactNative.RecyclerViewBackedScrollViewProperties, T>
+  RefreshControl: ThemedReactNativeStyledFunction<ReactNative.RefreshControlProperties, T>
+  SafeAreaView: ThemedReactNativeStyledFunction<ReactNative.SafeAreaView, T>
+  ScrollView: ThemedReactNativeStyledFunction<ReactNative.ScrollViewProps, T>
+  SegmentedControlIOS: ThemedReactNativeStyledFunction<ReactNative.SegmentedControlIOSProperties, T>
+  Slider: ThemedReactNativeStyledFunction<ReactNative.SliderProperties, T>
+  SliderIOS: ThemedReactNativeStyledFunction<ReactNative.SliderPropertiesIOS, T>
+  SnapshotViewIOS: ThemedReactNativeStyledFunction<ReactNative.SnapshotViewIOSProperties, T>
+  StatusBar: ThemedReactNativeStyledFunction<ReactNative.StatusBarProperties, T>
+  SwipeableListView: ThemedReactNativeStyledFunction<ReactNative.SwipeableListViewProps, T>
+  Switch: ThemedReactNativeStyledFunction<ReactNative.SwitchProperties, T>
+  SwitchIOS: ThemedReactNativeStyledFunction<ReactNative.SwitchIOSProperties, T>
+  Text: ThemedReactNativeStyledFunction<ReactNative.TextProperties, T>
+  TextInput: ThemedReactNativeStyledFunction<ReactNative.TextInputProperties, T>
+  TouchableHighlight: ThemedReactNativeStyledFunction<ReactNative.TouchableHighlightProperties, T>
+  TouchableNativeFeedback: ThemedReactNativeStyledFunction<ReactNative.TouchableNativeFeedbackProperties, T>
+  TouchableOpacity: ThemedReactNativeStyledFunction<ReactNative.TouchableOpacityProperties, T>
+  TouchableWithoutFeedback: ThemedReactNativeStyledFunction<ReactNative.TouchableWithoutFeedbackProps, T>
+  View: ThemedReactNativeStyledFunction<ReactNative.ViewProperties, T>
+  ViewPagerAndroid: ThemedReactNativeStyledFunction<ReactNative.ViewPagerAndroidProperties, T>
+  WebView: ThemedReactNativeStyledFunction<ReactNative.WebViewProperties, T>
+}
+
+// Useful for https://www.styled-components.com/docs/api#define-a-theme-interface
+export interface ThemedStyledComponentsModule<T> {
+  default: ThemedStyledInterface<T>
+
+  css: ThemedCssFunction<T>
+
+  withTheme<P extends { theme?: T }>(
+    component: React.ComponentType<P>
+  ): ComponentClass<WithOptionalTheme<P, T>>
+
+  ThemeProvider: ThemeProviderComponent<T>
+}

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -133,7 +133,7 @@ type Diff<T extends KeyofBase, U extends KeyofBase> = ({ [P in T]: P } &
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
 type DiffBetween<T, U> = Pick<T, Diff<keyof T, keyof U>> &
   Pick<U, Diff<keyof U, keyof T>>
-type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
+export type WithOptionalTheme<P extends { theme?: T }, T> = Omit<P, 'theme'> & {
   theme?: T
 }
 


### PR DESCRIPTION
This addresses https://github.com/styled-components/styled-components-website/issues/216


**Explanation**

Basically, https://www.styled-components.com/docs/api#define-a-theme-interface doesn't work for React Native. The reason is that `native/index.d.ts` is missing interfaces such as `ThemedStyledInterface`, `ThemedReactNativeStyledFunction` and `ThemedStyledComponentsModule`.

**Defining a theme after this PR**

https://www.styled-components.com/docs/api#define-a-theme-interface

```
// styled-components.ts
import * as styledComponents from 'styled-components/native'
import { ThemedStyledComponentsModule } from 'styled-components/native'

import ThemeInterface from './theme';

const {
  default: styled,
  css,
  ThemeProvider
} = styledComponents as ThemedStyledComponentsModule<ThemeInterface>;

export { css, ThemeProvider };
export default styled;
```