### PR TITLE
should throw earlier if styleSheets.length = 0

### DIFF
--- a/src/utils/insertRuleHelpers.js
+++ b/src/utils/insertRuleHelpers.js
@@ -13,10 +13,12 @@ export const sheetForTag = (tag: HTMLStyleElement): CSSStyleSheet => {
 
   /* Firefox quirk requires us to step through all stylesheets to find one owned by the given tag */
   const size = document.styleSheets.length
-  for (let i = 0; i < size; i += 1) {
-    const sheet = document.styleSheets[i]
-    // $FlowFixMe
-    if (sheet.ownerNode === tag) return sheet
+  if (size) {
+    for (let i = 0; i < size; i += 1) {
+      const sheet = document.styleSheets[i]
+      // $FlowFixMe
+      if (sheet.ownerNode === tag) return sheet
+    }
   }
 
   /* we should always be able to find a tag */


### PR DESCRIPTION
We just accidentally encountered a case that `styleSheets.length === 0` caused by some unknow reasons (still under investigation, but pretty sure it has nothing with styled-components). Thought it would be more reasonable to handle such case rather than letting it falls into the for loop section.

<img width="628" alt="image" src="https://user-images.githubusercontent.com/5300359/45017585-85045900-b05a-11e8-952a-ea974fa328ca.png">
