### PR TITLE
move special builds to their top level folders, add back jsnext:main entries

### DIFF
--- a/native/index.js
+++ b/native/index.js
@@ -1,2 +1,0 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
-module.exports = require('../dist/styled-components.native.cjs')

--- a/native/package.json
+++ b/native/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "styled-components/native",
+  "private": true,
+  "main": "./dist/styled-components.native.cjs.js",
+  "jsnext:main": "./dist/styled-components.native.esm.js",
+  "module": "./dist/styled-components.native.esm.js"
+}

--- a/no-tags/package.json
+++ b/no-tags/package.json
@@ -1,8 +1,9 @@
 {
   "name": "styled-components/no-tags",
   "private": true,
-  "main": "../dist/styled-components-no-tags.cjs.js",
-  "module": "../dist/styled-components-no-tags.esm.js",
+  "main": "./dist/styled-components-no-tags.cjs.js",
+  "jsnext:main": "./dist/styled-components-no-tags.esm.js",
+  "module": "./dist/styled-components-no-tags.esm.js",
   "browser": {
     "./dist/styled-components-no-tags.cjs.js": "./dist/styled-components-no-tags.browser.cjs.js",
     "./dist/styled-components-no-tags.esm.js": "./dist/styled-components-no-tags.browser.esm.js"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "4.0.0-beta.0",
   "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
   "main": "dist/styled-components.cjs.js",
+  "jsnext:main": "dist/styled-components.esm.js",
   "module": "dist/styled-components.esm.js",
-  "react-native": "dist/styled-components.native.cjs.js",
+  "react-native": "native/dist/styled-components.native.cjs.js",
   "browser": {
     "./dist/styled-components.esm.js": "./dist/styled-components.browser.esm.js",
     "./dist/styled-components.cjs.js": "./dist/styled-components.browser.cjs.js"

--- a/primitives/package.json
+++ b/primitives/package.json
@@ -1,7 +1,7 @@
 {
   "name": "styled-components/primitives",
   "private": true,
-  "main": "../dist/styled-components-primitives.cjs.js",
-  "module": "../dist/styled-components-primitives.esm.js",
-  "jsnext:main": "../dist/styled-components-primitives.esm.js"
+  "main": "./dist/styled-components-primitives.cjs.js",
+  "module": "./dist/styled-components-primitives.esm.js",
+  "jsnext:main": "./dist/styled-components-primitives.esm.js"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -143,8 +143,8 @@ const noTagServerConfig = {
   ...configBase,
   input: noTagsPath,
   output: [
-    getESM({ file: 'dist/styled-components-no-tags.esm.js' }),
-    getCJS({ file: 'dist/styled-components-no-tags.cjs.js' }),
+    getESM({ file: 'no-tags/dist/styled-components-no-tags.esm.js' }),
+    getCJS({ file: 'no-tags/dist/styled-components-no-tags.cjs.js' }),
   ],
   plugins: configBase.plugins.concat(
     replace({
@@ -157,8 +157,8 @@ const noTagBrowserConfig = {
   ...configBase,
   input: noTagsPath,
   output: [
-    getESM({ file: 'dist/styled-components-no-tags.browser.esm.js' }),
-    getCJS({ file: 'dist/styled-components-no-tags.browser.cjs.js' }),
+    getESM({ file: 'no-tags/dist/styled-components-no-tags.browser.esm.js' }),
+    getCJS({ file: 'no-tags/dist/styled-components-no-tags.browser.cjs.js' }),
   ],
   plugins: configBase.plugins.concat(
     replace({
@@ -171,18 +171,23 @@ const noTagBrowserConfig = {
 const nativeConfig = {
   ...configBase,
   input: './src/native/index.js',
-  output: getCJS({
-    file: 'dist/styled-components.native.cjs.js',
-  }),
+  output: [
+    getCJS({
+      file: 'native/dist/styled-components.native.cjs.js',
+    }),
+    getESM({
+      file: 'native/dist/styled-components.native.esm.js',
+    }),
+  ],
 }
 
 const primitivesConfig = {
   ...configBase,
   input: './src/primitives/index.js',
   output: [
-    getESM({ file: 'dist/styled-components-primitives.esm.js' }),
+    getESM({ file: 'primitives/dist/styled-components-primitives.esm.js' }),
     getCJS({
-      file: 'dist/styled-components-primitives.cjs.js',
+      file: 'primitives/dist/styled-components-primitives.cjs.js',
     }),
   ],
   plugins: configBase.plugins.concat(


### PR DESCRIPTION
> add back jsnext:main entries

Doing this since codesandbox seems to have some issue with ESM + "module". We had this before so hopefully adding it back will fix things.

This should fix the CRA issue with relative pathing.