### PR TITLE
Add SSR chunked streaming test

### DIFF
--- a/src/test/ssr.test.js
+++ b/src/test/ssr.test.js
@@ -270,7 +270,7 @@ describe('ssr', () => {
   })
 
   it('should interleave styles with rendered HTML when chunked streaming', () => {
-    injectGlobal`
+    const Component = createGlobalStyle`
       body { background: papayawhip; }
     `
     const Heading = styled.h1`
@@ -291,7 +291,8 @@ describe('ssr', () => {
 
     const sheet = new ServerStyleSheet()
     const jsx = sheet.collectStyles(
-      <div>
+      <React.Fragment>
+        <Component />
         <Heading>Hello SSR!</Heading>
         <Body>
         {new Array(1000)
@@ -300,7 +301,7 @@ describe('ssr', () => {
         </Body>
         <SideBar>SideBar</SideBar>
         <Footer>Footer</Footer>
-      </div>
+      </React.Fragment>
     )
     const stream = sheet.interleaveWithNodeStream(renderToNodeStream(jsx))
 


### PR DESCRIPTION
Issue #1982 

I add this test for SSR multi chunked streaming.
As I mentioned the issue, I think it should pass, but it was failed (v3.4.5). 
Following `received` stream data do not contain the style for `Footer`.

If you add this 1 line, this test succeeded.
ServerStyleSheet instance property `tagMap` might have unneeded data.

```
    const sheet = new ServerStyleSheet()
+   sheet.instance.tagMap = {}
    const jsx = sheet.collectStyles(
```