### PR TITLE
adjust when the cGS multicompose warning is fired

### DIFF
--- a/src/constructors/createGlobalStyle.js
+++ b/src/constructors/createGlobalStyle.js
@@ -43,17 +43,23 @@ export default (stringifyRules: Stringifier, css: CSSConstructor) => {
          * not be immediate.
          */
         if (count === 0) style.removeStyles(this.styleSheet)
+        else if (
+          process.env.NODE_ENV !== 'production' &&
+          IS_BROWSER &&
+          count > 1
+        ) {
+          console.warn(
+            `The global style component ${id} was composed and rendered multiple times in your React component tree. Only the last-rendered copy will have its styles remain in <head>.`
+          )
+        }
       }
 
       render() {
-        if (process.env.NODE_ENV !== 'production') {
-          if (React.Children.count(this.props.children)) {
-            throw new StyledError(11)
-          } else if (IS_BROWSER && count > 1) {
-            console.warn(
-              `The global style component ${id} was composed and rendered multiple times in your React component tree. Only the last-rendered copy will have its styles remain in <head>.`
-            )
-          }
+        if (
+          process.env.NODE_ENV !== 'production' &&
+          React.Children.count(this.props.children)
+        ) {
+          throw new StyledError(11)
         }
 
         return (


### PR DESCRIPTION
React 16 seems to wait to unmount in some cases, which was causing
a false-positive warning to go out when there was realistically only
one instance of cGS live on the page.

Should fix the issue discussed here: https://github.com/styled-components/styled-components/issues/1969#issuecomment-419715411