### PR TITLE
mark the library as side-effect-free

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "./dist/styled-components.esm.js": "./dist/styled-components.browser.esm.js",
     "./dist/styled-components.cjs.js": "./dist/styled-components.browser.cjs.js"
   },
+  "sideEffects": false,
   "scripts": {
     "build": "rollup -c",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
To my knowledge this is true now, given that all our helpers and
API methods create objects that must be used a second time in
JSX.