### PR TITLE
Add warning for the removal of injectGlobal in v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## unreleased
 
+- Add warning for the upcoming removal of the `injectGlobal` API in v4.0, by [@rainboxx](https://github.com/rainboxx) (see [#1867](https://github.com/styled-components/styled-components/pull/1867))
+
 ## [3.4.6] - 2018-09-10
 
 - Fix an issue when streaming with very large amounts of output where sometimes styles might not make it to the client, by [@probablyup](https://github.com/probablyup) (see [#1997](https://github.com/styled-components/styled-components/pull/1997))

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -1,12 +1,23 @@
 // @flow
 import hashStr from '../vendor/glamor/hash'
 import StyleSheet from '../models/StyleSheet'
+import once from '../utils/once'
 import type { Interpolation, Stringifier } from '../types'
 
 type InjectGlobalFn = (
   strings: Array<string>,
   ...interpolations: Array<Interpolation>
 ) => void
+
+let warnInjectGlobalDeprecated
+if (process.env.NODE_ENV !== 'production') {
+  warnInjectGlobalDeprecated = once(() => {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Notice: The "injectGlobal" API will be removed in the upcoming v4.0 release. Use "createGlobalStyle" instead. You can find more information here: https://github.com/styled-components/styled-components/issues/1333'
+    )
+  })
+}
 
 export default (stringifyRules: Stringifier, css: Function) => {
   const injectGlobal: InjectGlobalFn = (...args) => {
@@ -18,6 +29,8 @@ export default (stringifyRules: Stringifier, css: Function) => {
     if (!styleSheet.hasId(id)) {
       styleSheet.inject(id, stringifyRules(rules))
     }
+
+    warnInjectGlobalDeprecated()
   }
 
   return injectGlobal


### PR DESCRIPTION
The warning about the removal of `injectGlobal` was removed in #1909 because the PR about the removal (#1867) was not yet merged. This was done about two weeks ago so I thought it might make sense to re-add the warning again.

This is simply a copy and paste of the initial version from #1909 with adapted wording.