### PR TITLE
rename base component to make devtools tree nicer

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -58,7 +58,7 @@ const warnInnerRef = once(() =>
 )
 
 // $FlowFixMe
-class BaseStyledComponent extends PureComponent<*> {
+class StyledComponent extends PureComponent<*> {
   renderOuter: Function
   renderInner: Function
   styleSheet: ?StyleSheet
@@ -222,7 +222,7 @@ export default function createStyledComponent(
       options.displayName,
       options.parentComponentId
     ),
-    ParentComponent = BaseStyledComponent,
+    ParentComponent = StyledComponent,
     attrs,
   } = options
 
@@ -250,28 +250,28 @@ export default function createStyledComponent(
    * forwardRef creates a new interim component, which we'll take advantage of
    * instead of extending ParentComponent to create _another_ interim class
    */
-  const StyledComponent = React.forwardRef((props, ref) => (
+  const WrappedStyledComponent = React.forwardRef((props, ref) => (
     <ParentComponent
       {...props}
-      forwardedClass={StyledComponent}
+      forwardedClass={WrappedStyledComponent}
       forwardedRef={ref}
     />
   ))
 
   // $FlowFixMe
-  StyledComponent.attrs = finalAttrs
+  WrappedStyledComponent.attrs = finalAttrs
   // $FlowFixMe
-  StyledComponent.componentStyle = componentStyle
-  StyledComponent.displayName = displayName
+  WrappedStyledComponent.componentStyle = componentStyle
+  WrappedStyledComponent.displayName = displayName
   // $FlowFixMe
-  StyledComponent.styledComponentId = styledComponentId
+  WrappedStyledComponent.styledComponentId = styledComponentId
 
   // fold the underlying StyledComponent target up since we folded the styles
   // $FlowFixMe
-  StyledComponent.target = isTargetStyledComp ? target.target : target
+  WrappedStyledComponent.target = isTargetStyledComp ? target.target : target
 
   // $FlowFixMe
-  StyledComponent.withComponent = function withComponent(tag: Target) {
+  WrappedStyledComponent.withComponent = function withComponent(tag: Target) {
     const { componentId: previousComponentId, ...optionsToCopy } = options
 
     const newComponentId =
@@ -292,11 +292,13 @@ export default function createStyledComponent(
 
   if (process.env.NODE_ENV !== 'production') {
     // $FlowFixMe
-    StyledComponent.warnTooManyClasses = createWarnTooManyClasses(displayName)
+    WrappedStyledComponent.warnTooManyClasses = createWarnTooManyClasses(
+      displayName
+    )
   }
 
   if (isClass) {
-    hoist(StyledComponent, target, {
+    hoist(WrappedStyledComponent, target, {
       // all SC-specific things should not be hoisted
       attrs: true,
       componentStyle: true,
@@ -308,5 +310,5 @@ export default function createStyledComponent(
     })
   }
 
-  return StyledComponent
+  return WrappedStyledComponent
 }

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -22,7 +22,7 @@ const warnInnerRef = once(() =>
 )
 
 // $FlowFixMe
-class BaseStyledNativeComponent extends PureComponent<*, *> {
+class StyledNativeComponent extends PureComponent<*, *> {
   root: ?Object
 
   attrs = {}
@@ -131,16 +131,16 @@ export default (InlineStyle: Function) => {
     const {
       attrs,
       displayName = generateDisplayName(target),
-      ParentComponent = BaseStyledNativeComponent,
+      ParentComponent = StyledNativeComponent,
     } = options
 
     const isClass = !isTag(target)
     const isTargetStyledComp = isStyledComponent(target)
 
-    const StyledNativeComponent = React.forwardRef((props, ref) => (
+    const WrappedStyledNativeComponent = React.forwardRef((props, ref) => (
       <ParentComponent
         {...props}
-        forwardedClass={StyledNativeComponent}
+        forwardedClass={WrappedStyledNativeComponent}
         forwardedRef={ref}
       />
     ))
@@ -155,22 +155,27 @@ export default (InlineStyle: Function) => {
      */
 
     // $FlowFixMe
-    StyledNativeComponent.attrs = finalAttrs
+    WrappedStyledNativeComponent.attrs = finalAttrs
 
-    StyledNativeComponent.displayName = displayName
+    WrappedStyledNativeComponent.displayName = displayName
 
     // $FlowFixMe
-    StyledNativeComponent.inlineStyle = new InlineStyle(
+    WrappedStyledNativeComponent.inlineStyle = new InlineStyle(
       // $FlowFixMe
       isTargetStyledComp ? target.inlineStyle.rules.concat(rules) : rules
     )
 
     // $FlowFixMe
-    StyledNativeComponent.styledComponentId = 'StyledNativeComponent'
+    WrappedStyledNativeComponent.styledComponentId = 'StyledNativeComponent'
     // $FlowFixMe
-    StyledNativeComponent.target = isTargetStyledComp ? target.target : target
+    WrappedStyledNativeComponent.target = isTargetStyledComp
+      ? // $FlowFixMe
+        target.target
+      : target
     // $FlowFixMe
-    StyledNativeComponent.withComponent = function withComponent(tag: Target) {
+    WrappedStyledNativeComponent.withComponent = function withComponent(
+      tag: Target
+    ) {
       const { displayName: _, componentId: __, ...optionsToCopy } = options
       const newOptions = {
         ...optionsToCopy,
@@ -183,7 +188,7 @@ export default (InlineStyle: Function) => {
 
     if (isClass) {
       // $FlowFixMe
-      hoist(StyledNativeComponent, target, {
+      hoist(WrappedStyledNativeComponent, target, {
         // all SC-specific things should not be hoisted
         attrs: true,
         displayName: true,
@@ -195,7 +200,7 @@ export default (InlineStyle: Function) => {
       })
     }
 
-    return StyledNativeComponent
+    return WrappedStyledNativeComponent
   }
 
   return createStyledNativeComponent

--- a/src/utils/errors.md
+++ b/src/utils/errors.md
@@ -55,7 +55,7 @@ Missing document `<head>`
 
 ## 10
 
-Cannot find sheet for given tag
+Cannot find a StyleSheet instance. Usually this happens if there are multiple copies of styled-components loaded at once. Check out this issue for how to troubleshoot and fix the common cases where this situation can happen: https://github.com/styled-components/styled-components/issues/1941#issuecomment-417862021
 
 ## 11
 


### PR DESCRIPTION
Once the devtools forwardRef displayName PR is merged, the output should look a little more tidy