### PR TITLE
Noop on injectGlobal deprecation warning by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## unreleased
 
+- Fix an issue where the `injectGlobal` deprecation warning errors for production, by [@benmagyar](https://github.com/BenMagyar) (see [#2015](https://github.com/styled-components/styled-components/pull/2015))
+
 ## [3.4.7] - 2018-09-17
 
 - Add warning for the upcoming removal of the `injectGlobal` API in v4.0, by [@rainboxx](https://github.com/rainboxx) (see [#1867](https://github.com/styled-components/styled-components/pull/1867))

--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -9,7 +9,7 @@ type InjectGlobalFn = (
   ...interpolations: Array<Interpolation>
 ) => void
 
-let warnInjectGlobalDeprecated
+let warnInjectGlobalDeprecated = () => {}
 if (process.env.NODE_ENV !== 'production') {
   warnInjectGlobalDeprecated = once(() => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
This resolves #2014 where the deprecation warning for `injectGlobal` fails production builds. Followed the noop pattern from [warnExtendDeprecated](https://github.com/styled-components/styled-components/blob/104fc5565d5a9b6a02c50ceebab60257691b7b1b/src/models/StyledNativeComponent.js#L21).