### PR TITLE
Tone down dev warning for deprecated injectGlobal

### DIFF
--- a/src/constructors/injectGlobal.js
+++ b/src/constructors/injectGlobal.js
@@ -13,7 +13,7 @@ let warnInjectGlobalDeprecated
 if (process.env.NODE_ENV !== 'production') {
   warnInjectGlobalDeprecated = once(() => {
     // eslint-disable-next-line no-console
-    console.error(
+    console.warn(
       'Notice: The "injectGlobal" API will be removed in the upcoming v4.0 release. Use "createGlobalStyle" instead. You can find more information here: https://github.com/styled-components/styled-components/issues/1333'
     )
   })


### PR DESCRIPTION
RE: https://github.com/styled-components/styled-components/issues/1333#issuecomment-422370844

Use `console.warn` instead of `console.error`  for `injectGlobal` deprecation notice.