### PR TITLE
fix: Define StyleSheet and change Node to React.ReactNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-components",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
   "typings": "typings/styled-components.d.ts",
   "main": "dist/styled-components.cjs.js",

--- a/typings/styled-components.d.ts
+++ b/typings/styled-components.d.ts
@@ -184,9 +184,11 @@ interface StylesheetComponentProps {
   sheet: ServerStyleSheet
 }
 
+export class StyleSheet {}
+
 interface StyleSheetManagerProps {
-  sheet?: StyleSheet
-  target?: Node
+  sheet?: StyleSheet;
+  target?: React.ReactNode;
 }
 
 export class StyleSheetManager extends React.Component<


### PR DESCRIPTION
This is parallel to [a PR in the DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29022). From that PR:
> As referenced [here](https://github.com/styled-components/styled-components/issues/1952), the `StyleSheet` and `Node` types were undefined. This PR defines `StyleSheet`, and replaces `Node` with `React.ReactNode`, following the example found [here](https://github.com/styled-components/styled-components/pull/1954).

TODO:
- [ ] Make sure that the tests still pass: `npm test` and `npm run flow` (for the type checks)