### PR TITLE
Add warning when using `keyframes` on React Native

### DIFF
--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -20,7 +20,9 @@ export default function keyframes(
     typeof navigator !== 'undefined' &&
     navigator.product === 'ReactNative'
   ) {
-    console.warn('Helper `keyframes` cannot be used on React Native');
+    console.warn(
+      '`keyframes` cannot be used on ReactNative, only on the web. To do animation in ReactNative please use Animated.'
+    );
   }
 
   const rules = css(strings, ...interpolations);

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -14,6 +14,15 @@ export default function keyframes(
   strings: Styles,
   ...interpolations: Array<Interpolation>
 ): Keyframes {
+  /* Warning if you've used keyframes on React Native */
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    typeof navigator !== 'undefined' &&
+    navigator.product === 'ReactNative'
+  ) {
+    console.warn('Helper `keyframes` cannot be used on React Native');
+  }
+
   const rules = css(strings, ...interpolations);
 
   const name = generateAlphabeticName(hashStr(replaceWhitespace(JSON.stringify(rules))));


### PR DESCRIPTION
Helper `keyframes` cannot be used on React Native, so we should add a corresponding warning.

https://github.com/styled-components/styled-components/pull/2029#issuecomment-423969660