### PR TITLE
add protocol to open collective link

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,6 +3,6 @@
 /* Adapted from nodemon's postinstall: https://github.com/remy/nodemon/blob/master/package.json */
 
 var msg =
-  'Use styled-components at work? Consider supporting our development efforts at opencollective.com/styled-components';
+  'Use styled-components at work? Consider supporting our development efforts at https://opencollective.com/styled-components';
 
 console.log(msg);


### PR DESCRIPTION
without it some terminals dont understand that it is a link.
When they do it is very convenient to just click on it see what's there.
Perhaps it can drive up the conversion of donations (I hope it does at least a little bit)