### PR TITLE
Specify displayName when forwarding ref

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -207,9 +207,11 @@ export default function createStyledComponent(target: Target, options: Object, r
    * forwardRef creates a new interim component, which we'll take advantage of
    * instead of extending ParentComponent to create _another_ interim class
    */
-  const WrappedStyledComponent = React.forwardRef((props, ref) => (
-    <ParentComponent {...props} forwardedClass={WrappedStyledComponent} forwardedRef={ref} />
-  ));
+  const WrappedStyledComponent = React.forwardRef(function styledComponent(props, ref) {
+    return (
+      <ParentComponent {...props} forwardedClass={WrappedStyledComponent} forwardedRef={ref} />
+    );
+  });
 
   // $FlowFixMe
   WrappedStyledComponent.attrs = finalAttrs;


### PR DESCRIPTION
Specifying a function name improves React DevTools.
Instead of `ForwardRef`, `ForwardRef(styledComponent)` will be displayed on React DevTools

React docs: https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools

React DevTools change:
_Before_:
![image](https://user-images.githubusercontent.com/695180/46535386-89b36b80-c8ab-11e8-81b1-8b0c7981c8a3.png)

_After_:
![image](https://user-images.githubusercontent.com/695180/46535346-67215280-c8ab-11e8-9a12-9dbaf588afb2.png)

@geelen @mxstbr @kitten @probablyup Thoughts? 
