### PR TITLE
fix self-referential behavior in combo selectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - yarn test
   - yarn flow
   - yarn lint
+  - yarn size
 notifications:
   email:
     on_failure: change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Fix how ampersand is handled in self-referential selector combinations, e.g. `& + &` (see [#2071](https://github.com/styled-components/styled-components/pull/2071))
+
 ## [v4.0.0-beta.10] - 2018-10-04
 
 - Add support for `as` to be used with `attrs` for better polymorphism, by [@imbhargav5](https://github.com/imbhargav5) (see [#2055](https://github.com/styled-components/styled-components/pull/2055))

--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -60,7 +60,11 @@ export default class ComponentStyle {
     const flatCSS = flatten(this.rules, executionContext, styleSheet);
     const name = hasher(this.componentId + flatCSS.join(''));
     if (!styleSheet.hasNameForId(componentId, name)) {
-      styleSheet.inject(this.componentId, stringifyRules(flatCSS, `.${name}`), name);
+      styleSheet.inject(
+        this.componentId,
+        stringifyRules(flatCSS, `.${name}`, undefined, componentId),
+        name
+      );
     }
 
     this.lastClassName = name;

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -40,6 +40,42 @@ describe('with styles', () => {
     expectCSSMatches('.sc-a {} .b { color:blue; background:red; }');
   });
 
+  it('amperstand should refer to the static class when making a self-referential combo selector', () => {
+    const Comp = styled.div`
+      background: red;
+      color: ${p => p.color};
+
+      &[disabled] {
+        color: red;
+      }
+
+      & + & {
+        margin-left: 4px;
+      }
+
+      & ~ & {
+        margin-right: 4px;
+      }
+
+      & > & {
+        margin-top: 4px;
+      }
+
+      .foo & {
+        color: silver;
+      }
+    `;
+    TestRenderer.create(
+      <React.Fragment>
+        <Comp color="white" />
+        <Comp color="red" />
+      </React.Fragment>
+    );
+    expectCSSMatches(
+      '.sc-a{ } .b{ background:red; color:white; } .b[disabled]{ color:red; } .b + .sc-a{ margin-left:4px; } .b ~ .sc-a{ margin-right:4px; } .b > .sc-a{ margin-top:4px; } .foo .b{ color:silver; } .c{ background:red; color:red; } .c[disabled]{ color:red; } .c + .sc-a{ margin-left:4px; } .c ~ .sc-a{ margin-right:4px; } .c > .sc-a{ margin-top:4px; } .foo .c{ color:silver; }'
+    );
+  });
+
   it('should handle inline style objects', () => {
     const rule1 = {
       backgroundColor: 'blue',

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -71,9 +71,21 @@ describe('with styles', () => {
         <Comp color="red" />
       </React.Fragment>
     );
-    expectCSSMatches(
-      '.sc-a{ } .b{ background:red; color:white; } .b[disabled]{ color:red; } .b + .sc-a{ margin-left:4px; } .b ~ .sc-a{ margin-right:4px; } .b > .sc-a{ margin-top:4px; } .foo .b{ color:silver; } .c{ background:red; color:red; } .c[disabled]{ color:red; } .c + .sc-a{ margin-left:4px; } .c ~ .sc-a{ margin-right:4px; } .c > .sc-a{ margin-top:4px; } .foo .c{ color:silver; }'
-    );
+    expectCSSMatches(`
+      .sc-a{ }
+      .b{ background:red; color:white; }
+      .b[disabled]{ color:red; }
+      .b + .sc-a{ margin-left:4px; }
+      .b ~ .sc-a{ margin-right:4px; }
+      .b > .sc-a{ margin-top:4px; }
+      .foo .b{ color:silver; }
+      .c{ background:red; color:red; }
+      .c[disabled]{ color:red; }
+      .c + .sc-a{ margin-left:4px; }
+      .c ~ .sc-a{ margin-right:4px; }
+      .c > .sc-a{ margin-top:4px; }
+      .foo .c{ color:silver; }
+    `);
   });
 
   it('should handle inline style objects', () => {

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -45,6 +45,10 @@ describe('with styles', () => {
       background: red;
       color: ${p => p.color};
 
+      &&& {
+        border: 1px solid red;
+      }
+
       &[disabled] {
         color: red;
 
@@ -82,6 +86,7 @@ describe('with styles', () => {
     expectCSSMatches(`
       .sc-a{ }
       .b{ background:red; color:white; }
+      .b.b.b{ border:1px solid red; }
       .b[disabled]{ color:red; }
       .b[disabled] + .sc-a[disabled]{ margin-bottom:4px; }
       .b + .sc-a{ margin-left:4px; }
@@ -90,6 +95,7 @@ describe('with styles', () => {
       .b > .sc-a{ margin-top:4px; }
       .foo .b{ color:silver; }
       .c{ background:red; color:red; }
+      .c.c.c{ border:1px solid red; }
       .c[disabled]{ color:red; }
       .c[disabled] + .sc-a[disabled]{ margin-bottom:4px; }
       .c + .sc-a{ margin-left:4px; }

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -57,6 +57,10 @@ describe('with styles', () => {
         margin-left: 4px;
       }
 
+      & + & ~ & {
+        background: black;
+      }
+
       & ~ & {
         margin-right: 4px;
       }
@@ -81,6 +85,7 @@ describe('with styles', () => {
       .b[disabled]{ color:red; }
       .b[disabled] + .sc-a[disabled]{ margin-bottom:4px; }
       .b + .sc-a{ margin-left:4px; }
+      .b + .sc-a ~ .sc-a{ background:black; }
       .b ~ .sc-a{ margin-right:4px; }
       .b > .sc-a{ margin-top:4px; }
       .foo .b{ color:silver; }
@@ -88,6 +93,7 @@ describe('with styles', () => {
       .c[disabled]{ color:red; }
       .c[disabled] + .sc-a[disabled]{ margin-bottom:4px; }
       .c + .sc-a{ margin-left:4px; }
+      .c + .sc-a ~ .sc-a{ background:black; }
       .c ~ .sc-a{ margin-right:4px; }
       .c > .sc-a{ margin-top:4px; }
       .foo .c{ color:silver; }

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -47,6 +47,10 @@ describe('with styles', () => {
 
       &[disabled] {
         color: red;
+
+        & + & {
+          margin-bottom: 4px;
+        }
       }
 
       & + & {
@@ -75,12 +79,14 @@ describe('with styles', () => {
       .sc-a{ }
       .b{ background:red; color:white; }
       .b[disabled]{ color:red; }
+      .b[disabled] + .sc-a[disabled]{ margin-bottom:4px; }
       .b + .sc-a{ margin-left:4px; }
       .b ~ .sc-a{ margin-right:4px; }
       .b > .sc-a{ margin-top:4px; }
       .foo .b{ color:silver; }
       .c{ background:red; color:red; }
       .c[disabled]{ color:red; }
+      .c[disabled] + .sc-a[disabled]{ margin-bottom:4px; }
       .c + .sc-a{ margin-left:4px; }
       .c ~ .sc-a{ margin-right:4px; }
       .c > .sc-a{ margin-top:4px; }

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -4,7 +4,7 @@ import _insertRulePlugin from 'stylis-rule-sheet';
 import type { Interpolation } from '../types';
 
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
-const SELF_REFERENTIAL_COMBINATOR = /(&(?! *[+~>])([^{]*)[^+~>]*)?([+~>] *)&/g;
+const SELF_REFERENTIAL_COMBINATOR = /(&(?! *[+~>])([^&{][^{]+)[^+~>]*)?([+~>] *)&/g;
 
 // NOTE: This stylis instance is only used to split rules from SSR'd style tags
 const stylisSplitter = new Stylis({

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -4,7 +4,7 @@ import _insertRulePlugin from 'stylis-rule-sheet';
 import type { Interpolation } from '../types';
 
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
-const SELF_REFERENTIAL_COMBINATOR = /(&([^{]*)[^&}]*&)?( *[>~+] *)&( *{[^{}]*)/gm;
+const SELF_REFERENTIAL_COMBINATOR = /(&(?! *[+~>])([^{]*)[^+~>]*)?([+~>] *)&/g;
 
 // NOTE: This stylis instance is only used to split rules from SSR'd style tags
 const stylisSplitter = new Stylis({
@@ -56,7 +56,7 @@ const stringifyRules = (
 
   const cssStr = (selector && prefix ? `${prefix} ${selector} { ${flatCSS} }` : flatCSS).replace(
     SELF_REFERENTIAL_COMBINATOR,
-    `$1$3.${componentId}$2$4`
+    `$1$3.${componentId}$2`
   );
 
   return stylis(prefix || !selector ? '' : selector, cssStr);

--- a/src/utils/stringifyRules.js
+++ b/src/utils/stringifyRules.js
@@ -4,7 +4,7 @@ import _insertRulePlugin from 'stylis-rule-sheet';
 import type { Interpolation } from '../types';
 
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
-const SELF_REFERENTIAL_COMBINATOR = /([>~+] *)&( *{)/g;
+const SELF_REFERENTIAL_COMBINATOR = /(&([^{]*)[^&}]*&)?( *[>~+] *)&( *{[^{}]*)/gm;
 
 // NOTE: This stylis instance is only used to split rules from SSR'd style tags
 const stylisSplitter = new Stylis({
@@ -56,7 +56,7 @@ const stringifyRules = (
 
   const cssStr = (selector && prefix ? `${prefix} ${selector} { ${flatCSS} }` : flatCSS).replace(
     SELF_REFERENTIAL_COMBINATOR,
-    `$1.${componentId}$2`
+    `$1$3.${componentId}$2$4`
   );
 
   return stylis(prefix || !selector ? '' : selector, cssStr);


### PR DESCRIPTION
When a component refers to itself with the ampersand placeholder the behavior today is a bit inconsistent and won't work as intended if your component has dynamic styles.

For example:

```jsx
const Comp = styled.div`
  color: ${p => p.color};

  & + & {
    margin-left: 10px;
  }
`;

<div>
  <Comp color="red">Hello</Comp>
  <Comp color="blue">World</Comp>
</div>

// renders
// <div>
//   <div class="sc-a a">Hello</div>
//   <div class="sc-a b">Hello</div>
// </div>
```

The second instance of `Comp` will not get the `margin-left` because a different className is generated due to the different color prop, and today ampersand refers to the current styling context  className.

It effectively looks like this:

```css
// Comp -> .sc-a
// color: red -> .a
// color: blue -> .b

.sc-a {}
.a { color: red }
.a + .a { margin-left: 10px }
.b { color: blue }
.b + .b { margin-left: 10px }
```

Note how the combo is `.a + .a` and `.b + .b`, so only two adjacent components with the exact same styling props would trigger a match. This is a surprising behavior and makes compositions more troublesome.

The solution is to treat the second `&` as a reference back to the component itself (`.sc-a`), not the style of the component.

Then the styles look like this:

```css
// Comp -> .sc-a
// color: red -> .a
// color: blue -> .b

.sc-a {}
.a { color: red }
.a + .sc-a { margin-left: 10px }
.b { color: blue }
.b + .sc-a { margin-left: 10px }
```

And any `Comp` next to a `Comp` will receive the `margin-left`. Note that the reason the first ampersand isn't also switched to the static component class is that will break style isolation.

[before](https://codesandbox.io/s/xpk25v94rz):

& + & -> .b + .b
&[disabled] { & + & } -> .b[disabled] + .b[disabled]

[after](https://codesandbox.io/s/xomz3rj41q):

& + & -> .b + .sc-a
&[disabled] { & + & } -> .b[disabled] + .sc-a[disabled]

fixes #784