### PR TITLE
Add warning when className prop is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
   When using CRA v2, import styled components from `styled-components/macro` instead to gain all the benefits of [our babel plugin](https://github.com/styled-components/babel-plugin-styled-components).
 
+- Add a warning when wrapping a React component with `styled()` and the `className` isn't used (meaning styling isn't applied), by [@Fer0x](https://github.com/Fer0x) (see [#2073](https://github.com/styled-components/styled-components/pull/2073))
+
 ## [v4.0.0-beta.10] - 2018-10-04
 
 - Add support for `as` to be used with `attrs` for better polymorphism, by [@imbhargav5](https://github.com/imbhargav5) (see [#2055](https://github.com/styled-components/styled-components/pull/2055))

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -64,8 +64,6 @@ class StyledComponent extends Component<*> {
     this.renderInner = this.renderInner.bind(this);
 
     if (process.env.NODE_ENV !== 'production' && IS_BROWSER) {
-      // eslint-disable-next-line global-require
-
       classNameUseCheckInjector(this);
     }
   }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -18,8 +18,10 @@ import StyleSheet from './StyleSheet';
 import { ThemeConsumer, type Theme } from './ThemeProvider';
 import { StyleSheetConsumer } from './StyleSheetManager';
 import { EMPTY_OBJECT } from '../utils/empties';
+import classNameUseCheckInjector from '../utils/classNameUseCheckInjector';
 
 import type { RuleSet, Target } from '../types';
+import { IS_BROWSER } from '../constants';
 
 const identifiers = {};
 
@@ -60,6 +62,12 @@ class StyledComponent extends Component<*> {
     super();
     this.renderOuter = this.renderOuter.bind(this);
     this.renderInner = this.renderInner.bind(this);
+
+    if (process.env.NODE_ENV !== 'production' && IS_BROWSER) {
+      // eslint-disable-next-line global-require
+
+      classNameUseCheckInjector(this);
+    }
   }
 
   render() {

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -302,9 +302,46 @@ describe('basic', () => {
       const ref = React.createRef();
 
       TestRenderer.create(<Comp innerRef={ref} />);
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('The "innerRef" API has been removed')
+      expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"The \\"innerRef\\" API has been removed in styled-components v4 in favor of React 16 ref forwarding, use \\"ref\\" instead like a typical component."`
       );
+    });
+
+    it('warns when a wrapped React component does not consume className', () => {
+      const Inner = () => <div />;
+      const Comp = styled(Inner)`
+        color: red;
+      `;
+
+      renderIntoDocument(
+        <div>
+          <Comp />
+        </div>
+      );
+
+      expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"It looks like you've wrapped styled() around your React component (Inner), but the className prop is not being passed down to a child. No styles will be rendered unless className is composed within your React component."`
+      );
+    });
+
+    it('does not warn if the className is consumed by a deeper child', () => {
+      const Inner = ({ className }) => (
+        <div>
+          <span className={className} />
+        </div>
+      );
+
+      const Comp = styled(Inner)`
+        color: red;
+      `;
+
+      renderIntoDocument(
+        <div>
+          <Comp />
+        </div>
+      );
+
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/classNameUseCheckInjector.js
+++ b/src/utils/classNameUseCheckInjector.js
@@ -1,0 +1,48 @@
+// @flow
+
+import ReactDOM from 'react-dom';
+
+export default (component: Object) => {
+  let elementClassName = '';
+
+  const prevComponentDidMount = component.componentDidMount;
+
+  // eslint-disable-next-line no-param-reassign
+  component.componentDidMount = function componentDidMount() {
+    if (typeof prevComponentDidMount === 'function') {
+      prevComponentDidMount.call(this);
+    }
+
+    const classNames = elementClassName.split(' ');
+    // eslint-disable-next-line react/no-find-dom-node
+    const node = ReactDOM.findDOMNode(this);
+    const selector = classNames.map(s => `.${s}`).join('');
+
+    if (
+      node &&
+      !classNames.every(
+        className =>
+          node.classList &&
+          typeof node.classList.contains === 'function' &&
+          node.classList.contains(className)
+      ) &&
+      typeof node.querySelector === 'function' &&
+      !node.querySelector(selector)
+    ) {
+      console.warn(
+        "It looks like you've used styled() factor with React component, but prop `className` is not used"
+      );
+    }
+  };
+
+  const prevRenderInner = component.renderInner;
+
+  // eslint-disable-next-line no-param-reassign
+  component.renderInner = function renderInner(...args) {
+    const element = prevRenderInner.apply(this, args);
+
+    elementClassName = element.props.className;
+
+    return element;
+  };
+};

--- a/src/utils/classNameUseCheckInjector.js
+++ b/src/utils/classNameUseCheckInjector.js
@@ -6,28 +6,23 @@ import getComponentName from './getComponentName';
 export default (target: Object) => {
   let elementClassName = '';
 
-  const prevComponentDidMount = target.componentDidMount;
+  const targetCDM = target.componentDidMount;
 
   // eslint-disable-next-line no-param-reassign
   target.componentDidMount = function componentDidMount() {
-    if (typeof prevComponentDidMount === 'function') {
-      prevComponentDidMount.call(this);
+    if (typeof targetCDM === 'function') {
+      targetCDM.call(this);
     }
 
     const classNames = elementClassName.split(' ');
     // eslint-disable-next-line react/no-find-dom-node
-    const node = ReactDOM.findDOMNode(this);
+    const node: Element | null = (ReactDOM.findDOMNode(this): any);
     const selector = classNames.map(s => `.${s}`).join('');
 
     if (
       node &&
-      !classNames.every(
-        className =>
-          node.classList &&
-          typeof node.classList.contains === 'function' &&
-          node.classList.contains(className)
-      ) &&
-      typeof node.querySelector === 'function' &&
+      node.nodeType === 1 &&
+      !classNames.every(className => node.classList && node.classList.contains(className)) &&
       !node.querySelector(selector)
     ) {
       console.warn(

--- a/src/utils/classNameUseCheckInjector.js
+++ b/src/utils/classNameUseCheckInjector.js
@@ -1,14 +1,15 @@
 // @flow
 
 import ReactDOM from 'react-dom';
+import getComponentName from './getComponentName';
 
-export default (component: Object) => {
+export default (target: Object) => {
   let elementClassName = '';
 
-  const prevComponentDidMount = component.componentDidMount;
+  const prevComponentDidMount = target.componentDidMount;
 
   // eslint-disable-next-line no-param-reassign
-  component.componentDidMount = function componentDidMount() {
+  target.componentDidMount = function componentDidMount() {
     if (typeof prevComponentDidMount === 'function') {
       prevComponentDidMount.call(this);
     }
@@ -30,15 +31,17 @@ export default (component: Object) => {
       !node.querySelector(selector)
     ) {
       console.warn(
-        "It looks like you've used styled() factor with React component, but prop `className` is not used"
+        `It looks like you've wrapped styled() around your React component (${getComponentName(
+          this.props.forwardedClass.target
+        )}), but the className prop is not being passed down to a child. No styles will be rendered unless className is composed within your React component.`
       );
     }
   };
 
-  const prevRenderInner = component.renderInner;
+  const prevRenderInner = target.renderInner;
 
   // eslint-disable-next-line no-param-reassign
-  component.renderInner = function renderInner(...args) {
+  target.renderInner = function renderInner(...args) {
     const element = prevRenderInner.apply(this, args);
 
     elementClassName = element.props.className;


### PR DESCRIPTION
https://github.com/styled-components/styled-components/issues/349

I tried several options like using getters/Proxy but it doesn't work because of copying props inside React (https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js#L193)

Proposed code warns in such cases:
```js
const Test = () => <div />;
const StyledTest = styled(Test)`
  background: white;
`;

<StyledTest />
```

and doesn't warn in such cases:
```js
const Test2 = ({ className = '' }) => (
  <div>
    <div className={className} />
  </div>
);

const StyledTest2 = styled(Test2)`
  background: black;
`;

<StyledTest2 />
```

Tested with webpack 4: classNameUseCheckInjector.js will not present in bundle in production mode. 
