### PR TITLE
fix error caused by repeated spaces in className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Wrap the React component detector dev check in `flatten` with a try/catch to handle use cases where the chunk being inspected cannot be called with `new` (see [#2079](https://github.com/styled-components/styled-components/pull/2079))
 
+- Fix an edge case error caused by `classNameUseCheckInjector` creating invalid CSS selectors with multiple subsequent dots when `className` contains spaces (see [#2080](https://github.com/styled-components/styled-components/pull/2080)
+
 ## [v4.0.0-beta.11] - 2018-10-08
 
 - Add warning when component is not a styled component and cannot be referred via component selector, by [@egdbear](https://github.com/egdbear) (see [#2070](https://github.com/styled-components/styled-components/pull/2070))

--- a/src/utils/classNameUseCheckInjector.js
+++ b/src/utils/classNameUseCheckInjector.js
@@ -14,7 +14,10 @@ export default (target: Object) => {
       targetCDM.call(this);
     }
 
-    const classNames = elementClassName.split(' ');
+    const classNames = elementClassName
+      .replace(/ +/g, ' ')
+      .trim()
+      .split(' ');
     // eslint-disable-next-line react/no-find-dom-node
     const node: Element | null = (ReactDOM.findDOMNode(this): any);
     const selector = classNames.map(s => `.${s}`).join('');

--- a/src/utils/test/classNameUseCheckInjector.test.js
+++ b/src/utils/test/classNameUseCheckInjector.test.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { renderIntoDocument } from 'react-dom/test-utils';
+import styled from '../../constructors/styled';
+
+describe('classNameUseCheckInjector', () => {
+  it('should generate valid selectors', () => {
+    const div = document.createElement('div');
+    const StyledDiv = styled.div``;
+
+    // Avoid the console.warn
+    jest.spyOn(div, 'querySelector').mockImplementationOnce(() => true);
+    jest.spyOn(ReactDOM, 'findDOMNode').mockImplementationOnce(() => div);
+
+    renderIntoDocument(<StyledDiv className="   foo    bar  " />);
+
+    const [selector] = div.querySelector.mock.calls[0];
+
+    // Css selectors should not have multiple dots after each other
+    expect(selector).not.toMatch(/\.{2,}/);
+    expect(selector).toMatch(/^\.foo\.bar\.sc-/);
+
+    ReactDOM.findDOMNode.mockRestore();
+  });
+});


### PR DESCRIPTION
Adding, e.g., `className="foo bar  "` caused the `classNameUseCheckInjector`
to build a selector with multiple dots (`.foo...bar`) which causes an error
in Chrome. This commit changes the classNames to be trimmed and excess spaces
removed before the selector is constructed.

Error could be something like the following:
```
Error: Failed to execute 'querySelector' on 'Element': '.foo.bar...sc-bwzfXH.hHwLpk' is not a valid selector.
```