### PR TITLE
add SC_DISABLE_SPEEDY environment attribute

### DIFF
--- a/.jest.native.json
+++ b/.jest.native.json
@@ -1,8 +1,5 @@
 {
   "rootDir": ".",
-  "globals": {
-    "__DEV__": true
-  },
   "testRegex": "./src/native/test/.*.js$",
   "preset": "react-native",
   "testURL": "http://localhost",

--- a/.jest.primitives.json
+++ b/.jest.primitives.json
@@ -1,8 +1,5 @@
 {
   "rootDir": ".",
-  "globals": {
-    "__DEV__": true
-  },
   "testRegex": "./src/primitives/test/.*.js$",
   "moduleFileExtensions": [
     "ios.js",

--- a/.jest.web.json
+++ b/.jest.web.json
@@ -1,6 +1,3 @@
 {
-  "globals": {
-    "__DEV__": true
-  },
   "testEnvironment": "jsdom"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Fix an edge case error caused by `classNameUseCheckInjector` creating invalid CSS selectors with multiple subsequent dots when `className` contains spaces (see [#2080](https://github.com/styled-components/styled-components/pull/2080)
 
+- Add `process.env.SC_DISABLE_SPEEDY` environment override (see [#2089](https://github.com/styled-components/styled-components/pull/2089))
+
+  Setting this attribute to anything truthy will disable "speedy" mode. Note that you'll want to use
+  something like `webpack.DefinePlugin` to write the variable since most bundlers don't write any environment variables other than `NODE_ENV` by default:
+
+  ```js
+  // webpack.config.js
+
+  {
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env.SC_DISABLE_SPEEDY': true,
+      })
+    ]
+  }
+  ```
+
 ## [v4.0.0-beta.11] - 2018-10-08
 
 - Add warning when component is not a styled component and cannot be referred via component selector, by [@egdbear](https://github.com/egdbear) (see [#2070](https://github.com/styled-components/styled-components/pull/2070))

--- a/package.json
+++ b/package.json
@@ -134,9 +134,6 @@
     "react": ">= 16.3.0"
   },
   "jest": {
-    "globals": {
-      "__DEV__": true
-    },
     "testURL": "http://localhost",
     "clearMocks": true,
     "roots": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,6 @@ const commonPlugins = [
     },
   }),
   replace({
-    __DEV__: JSON.stringify(false), // disable flag indicating a Jest run
     __VERSION__: JSON.stringify(pkg.version),
   }),
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -105,7 +105,10 @@ const standaloneProdConfig = {
     ...standaloneBaseConfig.output,
     file: 'dist/styled-components.min.js',
   },
-  plugins: standaloneBaseConfig.plugins.concat(prodPlugins),
+  plugins: standaloneBaseConfig.plugins.concat(
+    prodPlugins,
+    replace({ 'process.env.SC_DISABLE_SPEEDY': false })
+  ),
 };
 
 const serverConfig = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,5 @@
 // @flow
 
-declare var __DEV__: ?string;
-
 export const SC_ATTR = (typeof process !== 'undefined' && process.env.SC_ATTR) || 'data-styled';
 
 export const SC_VERSION_ATTR = 'data-styled-version';
@@ -10,8 +8,7 @@ export const SC_STREAM_ATTR = 'data-styled-streamed';
 
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
-export const DISABLE_SPEEDY =
-  (typeof __DEV__ === 'boolean' && __DEV__) || process.env.NODE_ENV !== 'production';
+export const DISABLE_SPEEDY = process.env.NODE_ENV !== 'production';
 
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,9 @@ export const SC_STREAM_ATTR = 'data-styled-streamed';
 
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
-export const DISABLE_SPEEDY = process.env.NODE_ENV !== 'production';
+export const DISABLE_SPEEDY =
+  (typeof process !== 'undefined' && !!process.env.SC_DISABLE_SPEEDY) ||
+  process.env.NODE_ENV !== 'production';
 
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/src/test/constants.test.js
+++ b/src/test/constants.test.js
@@ -6,7 +6,7 @@ import { expectCSSMatches } from './utils';
 import { SC_ATTR as DEFAULT_SC_ATTR } from '../constants';
 
 function renderAndExpect(expectedAttr) {
-  const SC_ATTR = require('../constants').SC_ATTR;
+  const { SC_ATTR } = require('../constants');
   const styled = require('./utils').resetStyled();
 
   const Comp = styled.div`
@@ -20,6 +20,8 @@ function renderAndExpect(expectedAttr) {
   expect(SC_ATTR).toEqual(expectedAttr);
   expect(document.head.querySelectorAll(`style[${SC_ATTR}]`)).toHaveLength(1);
 }
+
+afterEach(jest.resetModules);
 
 describe('constants', () => {
   it('should work with default SC_ATTR', () => {
@@ -36,7 +38,27 @@ describe('constants', () => {
     delete process.env.SC_ATTR;
   });
 
-  afterEach(() => {
-    jest.resetModules();
+  describe('DISABLE_SPEEDY', () => {
+    it('defaults to true in development / testing', () => {
+      const { DISABLE_SPEEDY } = require('../constants');
+
+      expect(DISABLE_SPEEDY).toBe(true);
+    });
+
+    it('is true if a SC_DISABLE_SPEEDY env variable is set', () => {
+      process.env.SC_DISABLE_SPEEDY = 'true';
+      const { DISABLE_SPEEDY } = require('../constants');
+
+      expect(DISABLE_SPEEDY).toBe(true);
+
+      delete process.env.SC_DISABLE_SPEEDY;
+    });
+
+    it('is false in production', () => {
+      process.env.NODE_ENV = 'production';
+      const { DISABLE_SPEEDY } = require('../constants');
+
+      expect(DISABLE_SPEEDY).toBe(false);
+    });
   });
 });

--- a/src/utils/test/error.test.js
+++ b/src/utils/test/error.test.js
@@ -16,8 +16,14 @@ describe('development', () => {
 });
 
 describe('production', () => {
+  let prevValue = process.env.NODE_ENV;
+
   beforeEach(() => {
     process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = prevValue;
   });
 
   it('returns an error link', () => {


### PR DESCRIPTION
Workaround for #2038

Setting this attribute to anything truthy will disable "speedy" mode. Note that you'll want to use
  something like `webpack.DefinePlugin` to write the variable since most bundlers don't write any environment variables other than `NODE_ENV` by default:

  ```js
  // webpack.config.js

  {
    plugins: [
      new webpack.DefinePlugin({
        'process.env.SC_DISABLE_SPEEDY': true,
      })
    ]
  }
  ```