### PR TITLE
add react-dom as a peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "rollup-plugin-terser": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">= 16.3.0"
+    "react": ">= 16.3.0",
+    "react-dom": ">= 16.3.0"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
bundlephobia can't process the library without it explicitly
marked