### PR TITLE
Add error to keyframes when interpolated into raw string

### DIFF
--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -197,4 +197,12 @@ describe('keyframes', () => {
 @-webkit-keyframes dHUfhi{from{opacity:0;}to{opacity:1;}} @keyframes dHUfhi{from{opacity:0;}to{opacity:1;}}"
 `);
   });
+
+  it('should throw an error when interpolated in a vanilla string', () => {
+    const styled = resetStyled();
+
+    const animation = keyframes``;
+
+    expect(() => `animation-name: ${animation};`).toThrow();
+  });
 });

--- a/src/models/Keyframes.js
+++ b/src/models/Keyframes.js
@@ -1,5 +1,6 @@
 // @flow
 import StyleSheet from './StyleSheet';
+import StyledError from '../utils/error';
 
 export default class Keyframes {
   id: string;
@@ -19,6 +20,10 @@ export default class Keyframes {
     if (!styleSheet.hasNameForId(this.id, this.name)) {
       styleSheet.inject(this.id, this.rules, this.name);
     }
+  };
+
+  toString = () => {
+    throw new StyledError(12, String(this.name));
   };
 
   getName() {

--- a/src/utils/errors.md
+++ b/src/utils/errors.md
@@ -63,4 +63,4 @@ _This error was replaced with a dev-time warning, it will be deleted for v4 fina
 
 ## 12
 
-It seems you are interpolating a keyframe declaration (%s) into a vanilla string. This was supported in styled-components v3, but is not longer supported in v4. Please wrap your string in the css\`\` helper (see https://www.styled-components.com/docs/api#css).
+It seems you are interpolating a keyframe declaration (%s) into an untagged string. This was supported in styled-components v3, but is not longer supported in v4 as keyframes are now injected on-demand. Please wrap your string in the css\`\` helper (see https://www.styled-components.com/docs/api#css), which ensures the styles are injected correctly.

--- a/src/utils/errors.md
+++ b/src/utils/errors.md
@@ -60,3 +60,7 @@ Cannot find a StyleSheet instance. Usually this happens if there are multiple co
 ## 11
 
 _This error was replaced with a dev-time warning, it will be deleted for v4 final._ [createGlobalStyle] received children which will not be rendered. Please use the component without passing children elements.
+
+## 12
+
+It seems you are interpolating a keyframe declaration (%s) into a vanilla string. This was supported in styled-components v3, but is not longer supported in v4. Please wrap your string in the css\`\` helper (see https://www.styled-components.com/docs/api#css).


### PR DESCRIPTION
This will now throw an error, prompting the user to use the css\`\`
helper as is required in v4 (but wasn't in v3):

```
const rotate = keyframes``

const styles = `
  animation-name: ${rotate};
`

```