### PR TITLE
Add suppressMultiMountWarnings prop to disable warning on multiple cgs mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Add suppressMultiMountWarnings prop to disable warning on multiple cgs mount, by [@imbhargav5](https://github.com/imbhargav5) (see [#2107](https://github.com/styled-components/styled-components/pull/2107))
+
 ## [v4.0.0] - 2018-10-15
 
 This is a rollup of the highlights of beta 0-11 for convenience. See the [migration guide](https://www.styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v4) for easy updating steps and the [beta announcement blog](https://medium.com/styled-components/announcing-styled-components-v4-better-faster-stronger-3fe1aba1a112) for our summary of v4's changes, thought process, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- Add suppressMultiMountWarnings prop to disable warning on multiple cgs mount, by [@imbhargav5](https://github.com/imbhargav5) (see [#2107](https://github.com/styled-components/styled-components/pull/2107))
+- Add suppressMultiMountWarning prop to disable warning on multiple cgs mount, by [@imbhargav5](https://github.com/imbhargav5) (see [#2107](https://github.com/styled-components/styled-components/pull/2107))
 
 ## [v4.0.0] - 2018-10-15
 

--- a/src/constructors/createGlobalStyle.js
+++ b/src/constructors/createGlobalStyle.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import PropTypes from 'prop-types';
 import { IS_BROWSER, STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
 import StyleSheet from '../models/StyleSheet';
@@ -26,7 +27,13 @@ export default function createGlobalStyle(
   const style = new GlobalStyle(rules, id);
 
   class GlobalStyleComponent extends React.Component<*, *> {
-    static defaultProps: Object;
+    static propTypes = {
+      suppressMultiMountWarning: PropTypes.bool,
+    };
+
+    static defaultProps = {
+      suppressMultiMountWarning: false,
+    };
 
     styleSheet: Object;
 
@@ -60,7 +67,7 @@ export default function createGlobalStyle(
         process.env.NODE_ENV !== 'production' &&
         IS_BROWSER &&
         window.scCGSHMRCache[this.state.styledComponentId] > 1 &&
-        !this.props.suppressMultiMountWarnings
+        !this.props.suppressMultiMountWarning
       ) {
         console.warn(
           `The global style component ${

--- a/src/constructors/createGlobalStyle.js
+++ b/src/constructors/createGlobalStyle.js
@@ -59,7 +59,8 @@ export default function createGlobalStyle(
       if (
         process.env.NODE_ENV !== 'production' &&
         IS_BROWSER &&
-        window.scCGSHMRCache[this.state.styledComponentId] > 1
+        window.scCGSHMRCache[this.state.styledComponentId] > 1 &&
+        !this.props.suppressMultiMountWarnings
       ) {
         console.warn(
           `The global style component ${

--- a/src/constructors/test/createGlobalStyle.test.js
+++ b/src/constructors/test/createGlobalStyle.test.js
@@ -388,8 +388,8 @@ div{display:inline-block;-webkit-animation:a 2s linear infinite;animation:a 2s l
     `;
     render(
       <div>
-        <Component fg="red" suppressMultiMountWarnings />
-        <Component fg="blue" suppressMultiMountWarnings />
+        <Component fg="red" suppressMultiMountWarning />
+        <Component fg="blue" suppressMultiMountWarning />
       </div>
     );
 

--- a/src/constructors/test/createGlobalStyle.test.js
+++ b/src/constructors/test/createGlobalStyle.test.js
@@ -376,6 +376,25 @@ div{display:inline-block;-webkit-animation:a 2s linear infinite;animation:a 2s l
 @-webkit-keyframes a{from{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}} @keyframes a{from{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg);}to{-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg);}}"
 `);
   });
+
+  it('does not show a warning if multiple cgs are rendered with suppressMultiMountWarnings', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { render } = setup();
+    const Component = createGlobalStyle`
+      div {
+        color: ${props => props.fg};
+      }
+    `;
+    render(
+      <div>
+        <Component fg="red" suppressMultiMountWarnings />
+        <Component fg="blue" suppressMultiMountWarnings />
+      </div>
+    );
+
+    expect(console.warn.mock.calls.length).toBe(0);
+  });
 });
 
 function setup() {


### PR DESCRIPTION
This PR fixes #2082 by adding a warning to disable warning when `suppressMultiMountWarnings` prop is added. @probablyup Adding styles for all the instances of the component seems to be a bit hard to do right now. Is the warning enough or should we make the components add multiple styles for the CGS component?