### PR TITLE
Failing test for ampersand selector

### DIFF
--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -76,6 +76,10 @@ describe('with styles', () => {
       .foo & {
         color: silver;
       }
+
+      .foo > & {
+        color: green;
+      }
     `;
     TestRenderer.create(
       <React.Fragment>
@@ -94,6 +98,7 @@ describe('with styles', () => {
       .b ~ .sc-a{ margin-right:4px; }
       .b > .sc-a{ margin-top:4px; }
       .foo .b{ color:silver; }
+      .foo > .sc-a{ color:green; }
       .c{ background:red; color:red; }
       .c.c.c{ border:1px solid red; }
       .c[disabled]{ color:red; }
@@ -103,6 +108,7 @@ describe('with styles', () => {
       .c ~ .sc-a{ margin-right:4px; }
       .c > .sc-a{ margin-top:4px; }
       .foo .c{ color:silver; }
+      .foo > .sc-a{ color:green; }
     `);
   });
 

--- a/src/test/styles.test.js
+++ b/src/test/styles.test.js
@@ -98,7 +98,7 @@ describe('with styles', () => {
       .b ~ .sc-a{ margin-right:4px; }
       .b > .sc-a{ margin-top:4px; }
       .foo .b{ color:silver; }
-      .foo > .sc-a{ color:green; }
+      .foo > .b{ color:green; }
       .c{ background:red; color:red; }
       .c.c.c{ border:1px solid red; }
       .c[disabled]{ color:red; }
@@ -108,7 +108,7 @@ describe('with styles', () => {
       .c ~ .sc-a{ margin-right:4px; }
       .c > .sc-a{ margin-top:4px; }
       .foo .c{ color:silver; }
-      .foo > .sc-a{ color:green; }
+      .foo > .c{ color:green; }
     `);
   });
 


### PR DESCRIPTION
Since beta 11 of Styled Components `4.0.0`, we've been experiencing a regression where some selectors that use the ampersand operator will not be properly converted.

Input:

```
.foo > & {}
```

Expected output:

```
.foo > .x {}
```

Actual output:

```
.x .foo > .x {}
```

The culprit appears to be this regular expression: https://github.com/styled-components/styled-components/blob/12cde61a9bb6dbbd167cbb2b3244c1354b32d566/src/utils/stringifyRules.js#L7

Unfortunately, I don't think I have enough context to fix this without breaking other things that depend on it.