### PR TITLE
Fix import rules hoisting for ssr

### DIFF
--- a/src/test/__snapshots__/ssr.test.js.snap
+++ b/src/test/__snapshots__/ssr.test.js.snap
@@ -42,6 +42,16 @@ exports[`ssr should extract the CSS in a simple case 2`] = `
 
 exports[`ssr should handle errors while streaming 1`] = `[Invariant Violation: React.Children.only expected to receive a single React element child.]`;
 
+exports[`ssr should hoist @import rules 1`] = `
+"<style data-styled=\\"b\\" data-styled-version=\\"JEST_MOCK_VERSION\\">
+/* sc-component-id: sc-global-3693045893 */
+@import url('bla');
+/* sc-component-id: sc-global-3693045893 */
+body{margin:0;}
+/* sc-component-id: sc-a */
+.sc-a {} .b{color:red;}</style>"
+`;
+
 exports[`ssr should interleave styles with rendered HTML when chunked streaming 1`] = `
 "<style data-styled=\\"e f\\" data-styled-version=\\"JEST_MOCK_VERSION\\" data-styled-streamed=\\"true\\">
 /* sc-component-id: sc-global-2303210225 */

--- a/src/test/ssr.test.js
+++ b/src/test/ssr.test.js
@@ -354,4 +354,27 @@ describe('ssr', () => {
       });
     });
   });
+
+  it('should hoist @import rules', () => {
+    const Component = createGlobalStyle`
+      body { margin: 0; }
+      @import url('bla');
+    `;
+    const Heading = styled.h1`
+      color: red;
+    `;
+
+    const sheet = new ServerStyleSheet();
+    const html = renderToString(
+      sheet.collectStyles(
+        <React.Fragment>
+          <Component />
+          <Heading>Hello SSR!</Heading>
+        </React.Fragment>
+      )
+    );
+    const styles = sheet.getStyleTags();
+
+    expect(styles).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Unlike for browser, for ssr ```@import``` rules are not hoisted, what results with unnecessary latency on page load (e.g. font flickering on page reload even with cached fonts).