### PR TITLE
Expose ThemeContext to enable static contextType support for React 16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
   `${Comp}`; // .sc-hash
   ```
 
+- Expose ThemeContext to enable static contextType support for React 16.6, by [@imbhargav5](https://github.com/imbhargav5) (see [#2152](https://github.com/styled-components/styled-components/pull/2152))
+
 ## [v4.0.2] - 2018-10-18
 
 - Handle an edge case where an at-rule was being supplied to the self-reference stylis plugin at an incorrect context setting, by [@probablyup](https://github.com/probablyup) (see [#2114](https://github.com/styled-components/styled-components/pull/2114))

--- a/src/base.js
+++ b/src/base.js
@@ -9,7 +9,7 @@ import ServerStyleSheet from './models/ServerStyleSheet';
 import StyleSheetManager from './models/StyleSheetManager';
 
 /* Import components */
-import ThemeProvider, { ThemeConsumer } from './models/ThemeProvider';
+import ThemeProvider, { ThemeContext, ThemeConsumer } from './models/ThemeProvider';
 
 /* Import Higher Order Components */
 import withTheme from './hoc/withTheme';
@@ -61,6 +61,7 @@ export {
   createGlobalStyle,
   isStyledComponent,
   ThemeConsumer,
+  ThemeContext,
   ThemeProvider,
   withTheme,
   ServerStyleSheet,

--- a/src/models/ThemeProvider.js
+++ b/src/models/ThemeProvider.js
@@ -11,7 +11,7 @@ type Props = {
   theme: Theme | ((outerTheme: Theme) => void),
 };
 
-const ThemeContext = createContext();
+export const ThemeContext = createContext();
 
 export const ThemeConsumer = ThemeContext.Consumer;
 


### PR DESCRIPTION
This PR attempts to fix #2148 

The fix is to expose `ThemeContext` object for use as `contextType`