### PR TITLE
Add `suppressClassNameWarning` prop to supress classNames usage warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
   `${Comp}`; // .sc-hash
   ```
+- Add `suppressClassNameWarning` prop to disable warning when wrapping a React component with `styled()` and the `className` isn't used, by [@Fer0x](https://github.com/Fer0x) (see [#2156](https://github.com/styled-components/styled-components/pull/2156))
 
 ## [v4.0.2] - 2018-10-18
 

--- a/src/utils/classNameUseCheckInjector.js
+++ b/src/utils/classNameUseCheckInjector.js
@@ -13,6 +13,13 @@ export default (target: Object) => {
       targetCDM.call(this);
     }
 
+    if (
+      (target.props && target.props.suppressClassNameWarning) ||
+      (target.attrs && target.attrs.suppressClassNameWarning)
+    ) {
+      return;
+    }
+
     const classNames = elementClassName
       .replace(/ +/g, ' ')
       .trim()

--- a/src/utils/test/classNameUseCheckInjector.test.js
+++ b/src/utils/test/classNameUseCheckInjector.test.js
@@ -23,4 +23,20 @@ describe('classNameUseCheckInjector', () => {
 
     ReactDOM.findDOMNode.mockRestore();
   });
+
+  it('does not show a warning if suppressClassNameWarning is passed', () => {
+    const Comp = () => <div />;
+    const StyledComp = styled(Comp)``;
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderIntoDocument(
+      <div>
+        <StyledComp />
+        <StyledComp suppressClassNameWarning />
+      </div>
+    );
+
+    expect(console.warn.mock.calls.length).toBe(1);
+  })
 });


### PR DESCRIPTION
Related to https://github.com/styled-components/styled-components/issues/2126, https://github.com/styled-components/styled-components/pull/2073