### PR TITLE
Warn if result of `attrs` prop function is an element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Filter out invalid HTML attributes from `attrs`, by [@Fer0x](https://github.com/Fer0x) (see [#2133](https://github.com/styled-components/styled-components/pull/2133))
 
+- Add warning if an `attrs` prop is a function that returns an element, by [@timswalling](https://github.com/timswalling) (see [#2162](https://github.com/styled-components/styled-components/pull/2162))
+
 ## [v4.0.2] - 2018-10-18
 
 - Handle an edge case where an at-rule was being supplied to the self-reference stylis plugin at an incorrect context setting, by [@probablyup](https://github.com/probablyup) (see [#2114](https://github.com/styled-components/styled-components/pull/2114))

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -148,10 +148,20 @@ class StyledComponent extends Component<*> {
     for (key in attrs) {
       attr = attrs[key];
 
-      this.attrs[key] =
-        isFunction(attr) && !isDerivedReactComponent(attr) && !isStyledComponent(attr)
-          ? attr(context)
-          : attr;
+      if (isFunction(attr) && !isDerivedReactComponent(attr) && !isStyledComponent(attr)) {
+        attr = attr(context);
+
+        if (process.env.NODE_ENV !== 'production' && React.isValidElement(attr)) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `It looks like you've used a component as value for the ${key} prop in the attrs constructor.\n` +
+              "You'll need to wrap it in a function to make it available inside the styled component.\n" +
+              `For example, { ${key}: () => InnerComponent } instead of { ${key}: InnerComponent }`
+          );
+        }
+      }
+
+      this.attrs[key] = attr;
     }
     /* eslint-enable */
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -79,10 +79,20 @@ class StyledNativeComponent extends Component<*, *> {
     for (key in attrs) {
       attr = attrs[key];
 
-      this.attrs[key] =
-        isFunction(attr) && !isDerivedReactComponent(attr) && !isStyledComponent(attr)
-          ? attr(context)
-          : attr;
+      if (isFunction(attr) && !isDerivedReactComponent(attr) && !isStyledComponent(attr)) {
+        attr = attr(context);
+
+        if (process.env.NODE_ENV !== 'production' && React.isValidElement(attr)) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `It looks like you've used a component as value for the ${key} prop in the attrs constructor.\n` +
+              "You'll need to wrap it in a function to make it available inside the styled component.\n" +
+              `For example, { ${key}: () => InnerComponent } instead of { ${key}: InnerComponent }`
+          );
+        }
+      }
+
+      this.attrs[key] = attr;
     }
     /* eslint-enable */
 

--- a/src/native/test/native.test.js
+++ b/src/native/test/native.test.js
@@ -299,6 +299,10 @@ describe('native', () => {
       jest.spyOn(console, 'warn').mockImplementation(() => {});
     });
 
+    afterEach(() => {
+      console.warn.mockClear();
+    });
+
     it('warns upon use of the removed "innerRef" prop', () => {
       const Comp = styled.View``;
       const ref = React.createRef();
@@ -307,6 +311,28 @@ describe('native', () => {
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('The "innerRef" API has been removed')
       );
+    });
+
+    it('warns upon use of a Stateless Functional Component as a prop for attrs', () => {
+      const Inner = () => <Text />;
+      const Comp = styled.Text.attrs({ component: Inner })``;
+
+      TestRenderer.create(<Comp />);
+
+      expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
+"It looks like you've used a component as value for the component prop in the attrs constructor.
+You'll need to wrap it in a function to make it available inside the styled component.
+For example, { component: () => InnerComponent } instead of { component: InnerComponent }"
+`);
+    });
+
+    it('does not warn if the Stateless Functional Component is wrapped in a function', () => {
+      const Inner = () => <Text />;
+      const Comp = styled.Text.attrs({ component: () => Inner })``;
+
+      TestRenderer.create(<Comp />);
+
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -198,4 +198,32 @@ describe('attrs', () => {
     })``;
     expect(TestRenderer.create(<StyledComp />).toJSON()).toMatchSnapshot();
   });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    it('warns upon use of a Stateless Functional Component as a prop', () => {
+      const Inner = () => <div />;
+      const Comp = styled.div.attrs({ component: Inner })``;
+
+      TestRenderer.create(<Comp />);
+
+      expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
+"It looks like you've used a component as value for the component prop in the attrs constructor.
+You'll need to wrap it in a function to make it available inside the styled component.
+For example, { component: () => InnerComponent } instead of { component: InnerComponent }"
+`);
+    });
+
+    it('does not warn if the Stateless Functional Component is wrapped in a function', () => {
+      const Inner = () => <div />;
+      const Comp = styled.div.attrs({ component: () => Inner })``;
+
+      TestRenderer.create(<Comp />);
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Adds a warning if a component is used as an `attrs` prop, as discussed in #2117.