### PR TITLE
Added test showing that styled-calls yield non-functions

### DIFF
--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -357,5 +357,21 @@ describe('basic', () => {
 
       expect(console.warn).not.toHaveBeenCalled();
     });
+
+    it('creates component with type function for DOM elements', () => {
+      const Comp = styled.div`
+        color: red;
+      `;
+
+      expect(typeof Comp).toEqual('function');
+    });
+
+    it('creates component with type function for wrapped components', () => {
+      const Comp = styled(({ className }) => <div className={className} />)`
+        color: red;
+      `;
+
+      expect(typeof Comp).toEqual('function');
+    });
   });
 });


### PR DESCRIPTION
I ran into some issues wrt. testing that seemed to be caused by styled components not being JS function type, somehow. Test replication was very easy - a simple styled component is of type `'object'`! A quick look at the constructors used did not yield an immediately obvious source, so I submit it here.