### PR TITLE
Fix styled components causing update problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@emotion/is-prop-valid": "^0.6.8",
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^2.2.2",
+    "fbjs": "^0.8.17",
     "memoize-one": "^4.0.0",
     "prop-types": "^15.5.4",
     "react-is": "^16.6.0",

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -2,6 +2,8 @@
 
 import validAttr from '@emotion/is-prop-valid';
 import React, { createElement, Component } from 'react';
+// $FlowFixMe
+import shallowEqual from 'fbjs/lib/shallowEqual';
 import ComponentStyle from './ComponentStyle';
 import createWarnTooManyClasses from '../utils/createWarnTooManyClasses';
 import determineTheme from '../utils/determineTheme';
@@ -66,6 +68,12 @@ class StyledComponent extends Component<*> {
     if (process.env.NODE_ENV !== 'production' && IS_BROWSER) {
       classNameUsageCheckInjector(this);
     }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState)
+    );
   }
 
   render() {

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -1,5 +1,7 @@
 // @flow
 import React, { createElement, Component } from 'react';
+// $FlowFixMe
+import shallowEqual from 'fbjs/lib/shallowEqual';
 import determineTheme from '../utils/determineTheme';
 import { EMPTY_OBJECT } from '../utils/empties';
 import generateDisplayName from '../utils/generateDisplayName';
@@ -26,6 +28,12 @@ class StyledNativeComponent extends Component<*, *> {
   root: ?Object;
 
   attrs = {};
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      !shallowEqual(this.props, nextProps) || !shallowEqual(this.state, nextState)
+    );
+  }
 
   render() {
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3625,7 +3625,7 @@ fbjs@0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.17, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=


### PR DESCRIPTION
In certain situations styled components react component seems to be
updating when it shouldn't this is a regression from v3 which does don't
have this behaviour. Since PureComponent is too new this patch implements
the basic behaviour of it. This fixes the error we are getting which is in
our big app a deeply nested SurveyJs inputs aren't being updated because
before we can update them we have rendered a new version.

Fixes #2195