### PR TITLE
 don't warn about innerRef if wrapping a custom component 

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -128,7 +128,7 @@ class StyledComponent extends Component<*> {
     let key;
     // eslint-disable-next-line guard-for-in
     for (key in computedProps) {
-      if (process.env.NODE_ENV !== 'production' && key === 'innerRef') {
+      if (process.env.NODE_ENV !== 'production' && key === 'innerRef' && isTargetTag) {
         warnInnerRef();
       }
 

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -9,6 +9,9 @@ import { find } from '../../test-utils';
 
 let styled;
 
+// for the purpose of testing warnings we want to make sure they're always fired
+jest.mock('../utils/once', () => cb => cb);
+
 describe('basic', () => {
   /**
    * Make sure the setup is the same for every test
@@ -319,6 +322,15 @@ describe('basic', () => {
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
         `"The \\"innerRef\\" API has been removed in styled-components v4 in favor of React 16 ref forwarding, use \\"ref\\" instead like a typical component."`
       );
+    });
+
+    it('does not warn for innerRef if using a custom component', () => {
+      const InnerComp = props => <div {...props} />;
+      const Comp = styled(InnerComp)``;
+      const ref = React.createRef();
+
+      TestRenderer.create(<Comp innerRef={ref} />);
+      expect(console.warn).not.toHaveBeenCalled();
     });
 
     it('warns when a wrapped React component does not consume className', () => {


### PR DESCRIPTION
Fixes #2206