### PR TITLE
Allowing `forwardedRef` prop to drill through `styled(Wrapper)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove `createGlobalStyle` multimount warning; Concurrent and Strict modes intentionally render the same component multiple times, which causes this warning to be triggered always even when usage is correct in the application (see [#2216](https://github.com/styled-components/styled-components/pull/2216))
 
+- Allow externally controlled `forwardedRef` prop to be passed along through component wrapped by `styled` (see [#2223](https://github.com/styled-components/styled-components/pull/2223))
+
 ## [v4.1.1] - 2018-11-12
 
 - Put back the try/catch guard around a part of the flattener that sometimes receives undetectable SFCs (fixes an errand hard error in an edge case)

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -147,8 +147,13 @@ class StyledComponent extends Component<*> {
       }
 
       if (key === 'forwardedClass' || key === 'as') continue;
-      else if (key === 'forwardedRef') propsForElement.ref = computedProps[key];
-      else if (!isTargetTag || validAttr(key)) {
+      else if (key === 'forwardedRef') {
+        if (computedProps.isRefExternal) {
+          propsForElement[key] = computedProps[key];
+        } else {
+          propsForElement.ref = computedProps[key];
+        }
+      } else if (!isTargetTag || validAttr(key)) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }
@@ -275,7 +280,12 @@ export default function createStyledComponent(target: Target, options: Object, r
    * instead of extending ParentComponent to create _another_ interim class
    */
   const WrappedStyledComponent = React.forwardRef((props, ref) => (
-    <ParentComponent {...props} forwardedClass={WrappedStyledComponent} forwardedRef={ref} />
+    <ParentComponent
+      {...props}
+      forwardedClass={WrappedStyledComponent}
+      forwardedRef={ref !== null ? ref : props.forwardedRef}
+      isRefExternal={ref === null && props.forwardedRef !== undefined}
+    />
   ));
 
   // $FlowFixMe

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -66,6 +66,7 @@ class StyledNativeComponent extends Component<*, *> {
             as: renderAs,
             forwardedClass,
             forwardedRef,
+            isRefExternal,
             innerRef,
             style = [],
             ...props
@@ -87,7 +88,13 @@ class StyledNativeComponent extends Component<*, *> {
             style: [generatedStyles].concat(style),
           };
 
-          if (forwardedRef) propsForElement.ref = forwardedRef;
+          if (forwardedRef) {
+            if (isRefExternal) {
+              propsForElement.forwardedRef = forwardedRef;
+            } else {
+              propsForElement.ref = forwardedRef;
+            }
+          }
 
           if (process.env.NODE_ENV !== 'production' && innerRef) {
             this.warnInnerRef(displayName);
@@ -182,7 +189,8 @@ export default (InlineStyle: Function) => {
       <ParentComponent
         {...props}
         forwardedClass={WrappedStyledNativeComponent}
-        forwardedRef={ref}
+        forwardedRef={ref !== null ? ref : props.forwardedRef}
+        isRefExternal={ref === null && props.forwardedRef !== undefined}
       />
     ));
 

--- a/src/test/__snapshots__/expanded-api.test.js.snap
+++ b/src/test/__snapshots__/expanded-api.test.js.snap
@@ -55,6 +55,7 @@ exports[`expanded api "as" prop transfers all styles that have been applied 7`] 
 exports[`expanded api "as" prop works with custom components 1`] = `
 <figure
   className="sc-a b"
+  isRefExternal={false}
 />
 `;
 
@@ -127,5 +128,6 @@ exports[`expanded api componentId should work with \`.withComponent\` 1`] = `
 exports[`expanded api componentId should work with \`.withComponent\` 2`] = `
 <div
   className="Comp2-OMFG-Dummy b"
+  isRefExternal={false}
 />
 `;

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -213,6 +213,35 @@ describe('basic', () => {
       expect(wrapper.testRef.current).toBe(innerComponent);
     });
 
+    it('should pass along forwardedRef to the wrapped styled component', () => {
+      const InnerComponent = styled.div``;
+
+      class OuterComponent extends React.Component {
+        render() {
+          return <InnerComponent className={this.props.className} ref={this.props.forwardedRef} />;
+        }
+      }
+
+      const WrappedOuterComponent = styled(OuterComponent)``;
+
+      class Wrapper extends Component<*, *> {
+        testRef: any = React.createRef();
+
+        render() {
+          return (
+            <div>
+              <WrappedOuterComponent forwardedRef={this.testRef} />
+            </div>
+          );
+        }
+      }
+
+      const wrapper = renderIntoDocument(<Wrapper />);
+      const outerComponent = findRenderedComponentWithType(wrapper, OuterComponent);
+
+      expect(wrapper.testRef).toBe(outerComponent.props.forwardedRef);
+    });
+
     it('should respect the order of StyledComponent creation for CSS ordering', () => {
       const FirstComponent = styled.div`
         color: red;


### PR DESCRIPTION
Let's say you have a `<FancyButton />` component with a `forwardedRef` prop like the following:

```jsx
const Button = styled.button`
  font-size: 16px;
  color: blue;
`;

const FancyButton = { forwardedRef, className, text, onClick } => (
  <Button ref={forwardedRef} className={className} onClick={onClick}>{text}</Button>;
);
```

Now let's say a consumer of `<FancyButton />` does something like the following:
```jsx
const StyledFancyButton = styled(FancyButton)`
  color: green;
`

<StyledFancyButton forwardedRef={someRef} text="Foo" onClick={() => {}} />
```

**In this scenario, doing `styled(WrappableComponent)` makes `forwardedRef` `null` down the chain.**

My proposal is simple - to allow drilling of the `forwardedRef` prop if `ref` is not defined.

This prop name is somewhat encouraged by [the React refs docs](https://reactjs.org/docs/forwarding-refs.html) - take a look at the code example right above the section titled "Displaying a custom name in DevTools".

I'm looking forward to hearing some feedback about this issue and this PR.

Keep up the great work on this amazing library!