### PR TITLE
isTag() additionally check for casing of the first char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove `createGlobalStyle` multimount warning; Concurrent and Strict modes intentionally render the same component multiple times, which causes this warning to be triggered always even when usage is correct in the application (see [#2216](https://github.com/styled-components/styled-components/pull/2216))
 
+- Don't treat uppercased strings as tag-like components and don't filter out props from them (see [#2225](https://github.com/styled-components/styled-components/pull/2225))
+
 ## [v4.1.1] - 2018-11-12
 
 - Put back the try/catch guard around a part of the flattener that sometimes receives undetectable SFCs (fixes an errand hard error in an edge case)

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -150,7 +150,15 @@ describe('basic', () => {
       color: red;
     `;
     const wrapper = TestRenderer.create(<Comp customProp="abc" />);
-    expect(wrapper.root.findByType("Comp").props.customProp).toBe("abc");
+    expect(wrapper.root.findByType('Comp').props.customProp).toBe('abc');
+  });
+
+  it('creates a proper displayName for uppercased string-like components', () => {
+    const Comp = styled('Comp')`
+      color: red;
+    `;
+
+    expect(Comp.displayName).toBe('Styled(Comp)');
   });
 
   describe('jsdom tests', () => {

--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -145,6 +145,14 @@ describe('basic', () => {
     expectCSSMatches('.b { color:red; }');
   });
 
+  it('does not filter outs custom props for uppercased string-like components', () => {
+    const Comp = styled('Comp')`
+      color: red;
+    `;
+    const wrapper = TestRenderer.create(<Comp customProp="abc" />);
+    expect(wrapper.root.findByType("Comp").props.customProp).toBe("abc");
+  });
+
   describe('jsdom tests', () => {
     class InnerComponent extends Component<*, *> {
       render() {

--- a/src/utils/generateDisplayName.js
+++ b/src/utils/generateDisplayName.js
@@ -4,5 +4,5 @@ import isTag from './isTag';
 import type { Target } from '../types';
 
 export default function generateDisplayName(target: Target): string {
-  return isTag(target) ? `styled.${target}` : `Styled(${getComponentName(target)})`;
+  return isTag(target) ? `styled.${getComponentName(target)}` : `Styled(${getComponentName(target)})`;
 }

--- a/src/utils/generateDisplayName.js
+++ b/src/utils/generateDisplayName.js
@@ -4,5 +4,6 @@ import isTag from './isTag';
 import type { Target } from '../types';
 
 export default function generateDisplayName(target: Target): string {
-  return isTag(target) ? `styled.${getComponentName(target)}` : `Styled(${getComponentName(target)})`;
+  // $FlowFixMe
+  return isTag(target) ? `styled.${target}` : `Styled(${getComponentName(target)})`;
 }

--- a/src/utils/getComponentName.js
+++ b/src/utils/getComponentName.js
@@ -1,6 +1,6 @@
 // @flow
 import type { ComponentType } from 'react';
 
-export default function getComponentName(target: ComponentType<*>): string {
-  return target.displayName || target.name || 'Component';
+export default function getComponentName(target: ComponentType<*> | string): string {
+  return typeof target === "string" ? target : target.displayName || target.name || 'Component';
 }

--- a/src/utils/getComponentName.js
+++ b/src/utils/getComponentName.js
@@ -1,6 +1,11 @@
 // @flow
 import type { ComponentType } from 'react';
 
-export default function getComponentName(target: ComponentType<*> | string): string {
-  return typeof target === "string" ? target : target.displayName || target.name || 'Component';
+export default function getComponentName(target: ComponentType<*>): string {
+  return (
+    (process.env.NODE_ENV !== 'production' ? typeof target === 'string' && target : false) ||
+    target.displayName ||
+    target.name ||
+    'Component'
+  );
 }

--- a/src/utils/isTag.js
+++ b/src/utils/isTag.js
@@ -2,5 +2,5 @@
 import type { Target } from '../types';
 
 export default function isTag(target: Target) /* : %checks */ {
-  return typeof target === 'string';
+  return typeof target === 'string' && target.charAt(0) === target.charAt(0).toLowerCase();
 }

--- a/src/utils/isTag.js
+++ b/src/utils/isTag.js
@@ -1,8 +1,11 @@
 // @flow
 import type { Target } from '../types';
 
-export default function isTag(target: Target) /* : %checks */ {
-  return process.env.NODE_ENV !== 'production'
-    ? typeof target === 'string' && target.charAt(0) === target.charAt(0).toLowerCase()
-    : typeof target === 'string'
+export default function isTag(target: Target): boolean %checks {
+  return (
+    typeof target === 'string' &&
+    (process.env.NODE_ENV !== 'production'
+      ? target.charAt(0) === target.charAt(0).toLowerCase()
+      : true)
+  );
 }

--- a/src/utils/isTag.js
+++ b/src/utils/isTag.js
@@ -2,5 +2,7 @@
 import type { Target } from '../types';
 
 export default function isTag(target: Target) /* : %checks */ {
-  return typeof target === 'string' && target.charAt(0) === target.charAt(0).toLowerCase();
+  return process.env.NODE_ENV !== 'production'
+    ? typeof target === 'string' && target.charAt(0) === target.charAt(0).toLowerCase()
+    : typeof target === 'string'
 }


### PR DESCRIPTION
It's very common to write tests like this:

```jsx
jest.mock("../SomeComponent", () => "MockedComponent");

it("test", () => {
  expect(testRenderer(<Component someParam="a" />)).toMatchSnapshot();
});
```

where ```Component``` may be:
```jsx
import SomeComponent from "./SomeComponent";
export default styled(SomeComponent)` /* stuff */`;
```

In this case ```SomeComponent``` becomes string-typed internally similar to dom-like components and only name with passed props is being rendered is snapshots.

Without this fix, the ```styled-components``` thinks as ```SomeComponent``` is like dom-like component and applies props filtering to it, resulting in filtered out custom props (```someParam``` in example above) from test snapshots.