### PR TITLE
Don't show warning if `children` in `attrs` is a component

### DIFF
--- a/src/test/attrs.test.js
+++ b/src/test/attrs.test.js
@@ -282,6 +282,15 @@ For example, { component: () => InnerComponent } instead of { component: InnerCo
 `);
     });
 
+    it('does not warn upon use of a Stateless Functional Component as children', () => {
+      const Inner = () => <div />;
+      const Comp = styled.div.attrs({ children: Inner })``;
+
+      TestRenderer.create(<Comp />);
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
     it('warns for using fns as attrs object keys', () => {
       const Comp = styled.div.attrs({ 'data-text-color': props => props.textColor })``;
 


### PR DESCRIPTION
Hi!

RIght now I get a lot of warnings when using children in `attrs`. 
> It looks like you've used a component as value for the children prop in the attrs constructor.
You'll need to wrap it in a function to make it available inside the styled component.
For example, { children: () => InnerComponent } instead of { children: InnerComponent }

E.g. here:
```
const Comp = styled(OtherComponent).attrs({
  children: props => <div>props.showYes ? "yes" : "no"</div>
})``
```

Though it seems to be a valid use case for me, and in fact it works just fine. 

I added a (failing) test to illustrate what I mean. Would it be it to add a change that prevents warnings if `children` is a Component?