### PR TITLE
 inject static classnames from folded components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove `createGlobalStyle` multimount warning; Concurrent and Strict modes intentionally render the same component multiple times, which causes this warning to be triggered always even when usage is correct in the application (see [#2216](https://github.com/styled-components/styled-components/pull/2216))
 
+- Folded components are now targettable via component selector as in v3 if you used the old `.extend` API (see [#2239](https://github.com/styled-components/styled-components/pull/2239))
+
 ## [v4.1.1] - 2018-11-12
 
 - Put back the try/catch guard around a part of the flattener that sometimes receives undetectable SFCs (fixes an errand hard error in an edge case)

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -100,7 +100,7 @@ class StyledComponent extends Component<*> {
 
   renderOuter(styleSheet?: StyleSheet) {
     this.styleSheet = styleSheet;
-    const { componentStyle } = this.props.forwardedClass;
+    const { componentStyle } = this.props.forwardedComponent;
 
     // No need to subscribe a static component to theme changes, it won't change anything
     if (componentStyle.isStatic) return this.renderInner();
@@ -115,7 +115,7 @@ class StyledComponent extends Component<*> {
       displayName,
       styledComponentId,
       target,
-    } = this.props.forwardedClass;
+    } = this.props.forwardedComponent;
 
     let generatedClassName;
     if (componentStyle.isStatic) {
@@ -146,7 +146,7 @@ class StyledComponent extends Component<*> {
         this.warnInnerRef(displayName);
       }
 
-      if (key === 'forwardedClass' || key === 'as') continue;
+      if (key === 'forwardedComponent' || key === 'as') continue;
       else if (key === 'forwardedRef') propsForElement.ref = computedProps[key];
       else if (!isTargetTag || validAttr(key)) {
         // Don't pass through non HTML tags through to HTML elements
@@ -197,13 +197,13 @@ class StyledComponent extends Component<*> {
         if (!attrDefWasFn) {
           if (isFunction(attr) && !isDerivedReactComponent(attr) && !isStyledComponent(attr)) {
             if (process.env.NODE_ENV !== 'production') {
-              this.warnAttrsFnObjectKeyDeprecated(key, props.forwardedClass.displayName);
+              this.warnAttrsFnObjectKeyDeprecated(key, props.forwardedComponent.displayName);
             }
 
             attr = attr(context);
 
             if (process.env.NODE_ENV !== 'production' && React.isValidElement(attr)) {
-              this.warnNonStyledComponentAttrsObjectKey(key, props.forwardedClass.displayName);
+              this.warnNonStyledComponentAttrsObjectKey(key, props.forwardedComponent.displayName);
             }
           }
         }
@@ -218,7 +218,7 @@ class StyledComponent extends Component<*> {
   }
 
   generateAndInjectStyles(theme: any, props: any, styleSheet: ?StyleSheet = StyleSheet.master) {
-    const { attrs, componentStyle, warnTooManyClasses } = props.forwardedClass;
+    const { attrs, componentStyle, warnTooManyClasses } = props.forwardedComponent;
 
     // statically styled-components don't need to build an execution context object,
     // and shouldn't be increasing the number of class names
@@ -275,7 +275,7 @@ export default function createStyledComponent(target: Target, options: Object, r
    * instead of extending ParentComponent to create _another_ interim class
    */
   const WrappedStyledComponent = React.forwardRef((props, ref) => (
-    <ParentComponent {...props} forwardedClass={WrappedStyledComponent} forwardedRef={ref} />
+    <ParentComponent {...props} forwardedComponent={WrappedStyledComponent} forwardedRef={ref} />
   ));
 
   // $FlowFixMe

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -113,6 +113,7 @@ class StyledComponent extends Component<*> {
       componentStyle,
       defaultProps,
       displayName,
+      foldedClasses,
       styledComponentId,
       target,
     } = this.props.forwardedComponent;
@@ -159,6 +160,7 @@ class StyledComponent extends Component<*> {
     }
 
     propsForElement.className = [
+      ...foldedClasses,
       this.props.className,
       styledComponentId,
       this.attrs.className,
@@ -283,6 +285,13 @@ export default function createStyledComponent(target: Target, options: Object, r
   // $FlowFixMe
   WrappedStyledComponent.componentStyle = componentStyle;
   WrappedStyledComponent.displayName = displayName;
+
+  // $FlowFixMe
+  WrappedStyledComponent.foldedClasses = isTargetStyledComp
+    ? // $FlowFixMe
+      Array.prototype.concat(target.foldedClasses, target.styledComponentId)
+    : EMPTY_ARRAY;
+
   // $FlowFixMe
   WrappedStyledComponent.styledComponentId = styledComponentId;
 
@@ -322,6 +331,7 @@ export default function createStyledComponent(target: Target, options: Object, r
       attrs: true,
       componentStyle: true,
       displayName: true,
+      foldedClasses: true,
       styledComponentId: true,
       target: true,
       withComponent: true,

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -112,7 +112,7 @@ class StyledComponent extends Component<*> {
       componentStyle,
       defaultProps,
       displayName,
-      foldedClasses,
+      foldedComponentIds,
       styledComponentId,
       target,
     } = this.props.forwardedComponent;
@@ -159,7 +159,7 @@ class StyledComponent extends Component<*> {
 
     propsForElement.className = Array.prototype
       .concat(
-        foldedClasses,
+        foldedComponentIds,
         this.props.className,
         styledComponentId,
         this.attrs.className,
@@ -286,9 +286,9 @@ export default function createStyledComponent(target: Target, options: Object, r
   WrappedStyledComponent.displayName = displayName;
 
   // $FlowFixMe
-  WrappedStyledComponent.foldedClasses = isTargetStyledComp
+  WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
     ? // $FlowFixMe
-      Array.prototype.concat(target.foldedClasses, target.styledComponentId)
+      Array.prototype.concat(target.foldedComponentIds, target.styledComponentId)
     : EMPTY_ARRAY;
 
   // $FlowFixMe
@@ -330,7 +330,7 @@ export default function createStyledComponent(target: Target, options: Object, r
       attrs: true,
       componentStyle: true,
       displayName: true,
-      foldedClasses: true,
+      foldedComponentIds: true,
       styledComponentId: true,
       target: true,
       withComponent: true,

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -64,14 +64,14 @@ class StyledNativeComponent extends Component<*, *> {
         {(theme?: Theme) => {
           const {
             as: renderAs,
-            forwardedClass,
+            forwardedComponent,
             forwardedRef,
             innerRef,
             style = [],
             ...props
           } = this.props;
 
-          const { defaultProps, displayName, target } = forwardedClass;
+          const { defaultProps, displayName, target } = forwardedComponent;
 
           let generatedStyles;
           if (theme !== undefined) {
@@ -126,13 +126,16 @@ class StyledNativeComponent extends Component<*, *> {
         if (!attrDefWasFn) {
           if (isFunction(attr) && !isDerivedReactComponent(attr) && !isStyledComponent(attr)) {
             if (process.env.NODE_ENV !== 'production') {
-              this.warnAttrsFnObjectKeyDeprecated(key, this.props.forwardedClass.displayName);
+              this.warnAttrsFnObjectKeyDeprecated(key, this.props.forwardedComponent.displayName);
             }
 
             attr = attr(context);
 
             if (process.env.NODE_ENV !== 'production' && React.isValidElement(attr)) {
-              this.warnNonStyledComponentAttrsObjectKey(key, this.props.forwardedClass.displayName);
+              this.warnNonStyledComponentAttrsObjectKey(
+                key,
+                this.props.forwardedComponent.displayName
+              );
             }
           }
         }
@@ -147,9 +150,13 @@ class StyledNativeComponent extends Component<*, *> {
   }
 
   generateAndInjectStyles(theme: any, props: any) {
-    const { inlineStyle } = props.forwardedClass;
+    const { inlineStyle } = props.forwardedComponent;
 
-    const executionContext = this.buildExecutionContext(theme, props, props.forwardedClass.attrs);
+    const executionContext = this.buildExecutionContext(
+      theme,
+      props,
+      props.forwardedComponent.attrs
+    );
 
     return inlineStyle.generateStyleObject(executionContext);
   }
@@ -181,7 +188,7 @@ export default (InlineStyle: Function) => {
     const WrappedStyledNativeComponent = React.forwardRef((props, ref) => (
       <ParentComponent
         {...props}
-        forwardedClass={WrappedStyledNativeComponent}
+        forwardedComponent={WrappedStyledNativeComponent}
         forwardedRef={ref}
       />
     ));

--- a/src/test/__snapshots__/attrs.test.js.snap
+++ b/src/test/__snapshots__/attrs.test.js.snap
@@ -8,7 +8,7 @@ exports[`attrs call an attr function 1`] = `
 
 exports[`attrs does not pass non html tags to HTML element 1`] = `
 <div
-  className="sc-b c"
+  className="sc-a sc-b c"
 />
 `;
 
@@ -22,7 +22,7 @@ exports[`attrs merge attrs 1`] = `
 
 exports[`attrs merge attrs when inheriting SC 1`] = `
 <button
-  className="sc-b c"
+  className="sc-a sc-b c"
   tabIndex={0}
   type="submit"
 />

--- a/src/test/__snapshots__/expanded-api.test.js.snap
+++ b/src/test/__snapshots__/expanded-api.test.js.snap
@@ -32,13 +32,13 @@ exports[`expanded api "as" prop transfers all styles that have been applied 4`] 
 
 exports[`expanded api "as" prop transfers all styles that have been applied 5`] = `
 <div
-  className="sc-b e"
+  className="sc-a sc-b e"
 />
 `;
 
 exports[`expanded api "as" prop transfers all styles that have been applied 6`] = `
 <span
-  className="sc-c f"
+  className="sc-a sc-b sc-c f"
 />
 `;
 

--- a/src/utils/classNameUsageCheckInjector.js
+++ b/src/utils/classNameUsageCheckInjector.js
@@ -15,7 +15,7 @@ export default (target: Object) => {
       targetCDM.call(this);
     }
 
-    const forwardTarget = this.props.forwardedClass.target;
+    const forwardTarget = this.props.forwardedComponent.target;
 
     if (
       (target.props && target.props.suppressClassNameWarning) ||


### PR DESCRIPTION
fixes #2232

this allows for interim components that have been folded to still
be targeted