### PR TITLE
Don't generate a UID name from the macro for the import

### DIFF
--- a/src/macro/index.js
+++ b/src/macro/index.js
@@ -16,6 +16,7 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
 
   // references looks like this
   // { default: [path, path], css: [path], ... }
+  let customImportName;
   Object.keys(references).forEach(refName => {
     if (!allowedImports.includes(refName)) {
       throw new MacroError(
@@ -29,6 +30,7 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
     let name;
     if (refName === 'default') {
       name = program.scope.generateUidIdentifier('styled');
+      customImportName = name;
       imports.specifiers.push(t.importDefaultSpecifier(name));
     } else {
       name = program.scope.generateUidIdentifier(refName);
@@ -38,12 +40,12 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
     // update references with the new identifiers
     references[refName].forEach(referencePath => {
       // eslint-disable-next-line no-param-reassign
-      referencePath.node.name = name;
+      referencePath.node.name = name.name;
     });
   });
 
   // apply babel-plugin-styled-components to the file
-  const stateWithOpts = { ...state, opts: config };
+  const stateWithOpts = { ...state, opts: config, customImportName };
   program.traverse(babelPlugin({ types: t }).visitor, stateWithOpts);
 }
 

--- a/src/macro/index.js
+++ b/src/macro/index.js
@@ -27,20 +27,20 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
     }
 
     // generate new identifier and add to imports
-    let name;
+    let id;
     if (refName === 'default') {
-      name = program.scope.generateUidIdentifier('styled');
-      customImportName = name;
-      imports.specifiers.push(t.importDefaultSpecifier(name));
+      id = program.scope.generateUidIdentifier('styled');
+      customImportName = id;
+      imports.specifiers.push(t.importDefaultSpecifier(id));
     } else {
-      name = program.scope.generateUidIdentifier(refName);
-      imports.specifiers.push(t.importSpecifier(name, t.identifier(refName)));
+      id = program.scope.generateUidIdentifier(refName);
+      imports.specifiers.push(t.importSpecifier(id, t.identifier(refName)));
     }
 
     // update references with the new identifiers
     references[refName].forEach(referencePath => {
       // eslint-disable-next-line no-param-reassign
-      referencePath.node.name = name.name;
+      referencePath.node.name = id.name;
     });
   });
 

--- a/src/macro/index.js
+++ b/src/macro/index.js
@@ -28,8 +28,7 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
     // generate new identifier and add to imports
     let id;
     if (refName === 'default') {
-      id = program.scope.generateUidIdentifier('styled');
-      imports.specifiers.push(t.importDefaultSpecifier(id));
+      imports.specifiers.push(t.importDefaultSpecifier(t.identifier('styled')));
     } else {
       id = program.scope.generateUidIdentifier(refName);
       imports.specifiers.push(t.importSpecifier(id, t.identifier(refName)));

--- a/src/macro/index.js
+++ b/src/macro/index.js
@@ -28,8 +28,8 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
     // generate new identifier and add to imports
     let name;
     if (refName === 'default') {
-      name = 'styled';
-      imports.specifiers.push(t.importDefaultSpecifier(t.identifier(name)));
+      name = program.scope.generateUidIdentifier('styled');
+      imports.specifiers.push(t.importDefaultSpecifier(name));
     } else {
       name = program.scope.generateUidIdentifier(refName);
       imports.specifiers.push(t.importSpecifier(name, t.identifier(refName)));

--- a/src/macro/index.js
+++ b/src/macro/index.js
@@ -26,18 +26,19 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
     }
 
     // generate new identifier and add to imports
-    let id;
+    let name;
     if (refName === 'default') {
-      imports.specifiers.push(t.importDefaultSpecifier(t.identifier('styled')));
+      name = 'styled';
+      imports.specifiers.push(t.importDefaultSpecifier(t.identifier(name)));
     } else {
-      id = program.scope.generateUidIdentifier(refName);
-      imports.specifiers.push(t.importSpecifier(id, t.identifier(refName)));
+      name = program.scope.generateUidIdentifier(refName);
+      imports.specifiers.push(t.importSpecifier(name, t.identifier(refName)));
     }
 
     // update references with the new identifiers
     references[refName].forEach(referencePath => {
       // eslint-disable-next-line no-param-reassign
-      referencePath.node.name = id.name;
+      referencePath.node.name = name;
     });
   });
 

--- a/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/src/macro/test/__snapshots__/macro.test.js.snap
@@ -10,10 +10,10 @@ styled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import styled from 'styled-components';
+import _styled from 'styled-components';
 
 
-styled.div.withConfig({
+_styled.div.withConfig({
   displayName: 'macrotest'
 })(['background:', ';'], p => p.error ? 'red' : 'green');
 "
@@ -32,13 +32,13 @@ styled(Hello)\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import styled from 'styled-components';
+import _styled from 'styled-components';
 import React from 'react';
 
 
 const Hello = () => React.createComponent(div, null, 'hello');
 
-styled(Hello).withConfig({
+_styled(Hello).withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:red;']);
@@ -60,7 +60,7 @@ React.createComponent(
 import { ThemeProvider as _ThemeProvider } from 'styled-components';
 
 
-React.createComponent([object Object], { theme: { color: 'red' } }, 'hello');
+React.createComponent(_ThemeProvider, { theme: { color: 'red' } }, 'hello');
 "
 `;
 
@@ -77,7 +77,7 @@ createGlobalStyle\`
 import { createGlobalStyle as _createGlobalStyle } from 'styled-components';
 
 
-[object Object]\`
+_createGlobalStyle\`
   background: red;
 \`;
 "
@@ -96,9 +96,7 @@ css\`
 import { css as _css } from 'styled-components';
 
 
-[object Object]\`
-  color: \${props => props.whiteColor ? 'white' : 'black'};
-\`;
+_css(['color:', ';'], props => props.whiteColor ? 'white' : 'black');
 "
 `;
 
@@ -116,10 +114,7 @@ keyframes\`
 import { keyframes as _keyframes } from 'styled-components';
 
 
-[object Object]\`
-  0% { opacity: 0; }
-  100% { opacity: 1; }
-\`;
+_keyframes(['0%{opacity:0;}100%{opacity:1;}']);
 "
 `;
 
@@ -134,11 +129,11 @@ myStyled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import myStyled from 'styled-components';
+import _styled from 'styled-components';
 
 import styled from 'another-package';
 
-myStyled.div.withConfig({
+_styled.div.withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:', ';'], p => p.error ? 'red' : 'green');
@@ -155,10 +150,10 @@ styled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import styled from 'styled-components';
+import _styled from 'styled-components';
 
 
-styled.div.withConfig({
+_styled.div.withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:red;']);
@@ -175,10 +170,10 @@ styled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import styled from 'styled-components';
+import _styled from 'styled-components';
 
 
-styled.div.withConfig({
+_styled.div.withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:', ';'], p => p.error ? 'red' : 'green');

--- a/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/src/macro/test/__snapshots__/macro.test.js.snap
@@ -123,11 +123,33 @@ import { keyframes as _keyframes } from 'styled-components';
 "
 `;
 
-exports[`macro should work with require() to import styled-components: should work with require() to import styled-components 1`] = `
+exports[`macro should work with custom import name: should work with custom import name 1`] = `
 "
-const myStyled = require('../../macro')
+import myStyled from '../../macro'
+import styled from 'another-package'
 
 myStyled.div\`
+  background: \${p => (p.error ? 'red' : 'green')};
+\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import myStyled from 'styled-components';
+
+import styled from 'another-package';
+
+myStyled.div.withConfig({
+  displayName: 'macrotest',
+  componentId: 'sc-11gvsec-0'
+})(['background:', ';'], p => p.error ? 'red' : 'green');
+"
+`;
+
+exports[`macro should work with require() to import styled-components: should work with require() to import styled-components 1`] = `
+"
+const styled = require('../../macro')
+
+styled.div\`
   background: red;
 \`
 

--- a/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/src/macro/test/__snapshots__/macro.test.js.snap
@@ -10,10 +10,10 @@ styled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _styled from 'styled-components';
+import styled from 'styled-components';
 
 
-_styled.div.withConfig({
+styled.div.withConfig({
   displayName: 'macrotest'
 })(['background:', ';'], p => p.error ? 'red' : 'green');
 "
@@ -32,13 +32,13 @@ styled(Hello)\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _styled from 'styled-components';
+import styled from 'styled-components';
 import React from 'react';
 
 
 const Hello = () => React.createComponent(div, null, 'hello');
 
-_styled(Hello).withConfig({
+styled(Hello).withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:red;']);
@@ -60,7 +60,7 @@ React.createComponent(
 import { ThemeProvider as _ThemeProvider } from 'styled-components';
 
 
-React.createComponent(_ThemeProvider, { theme: { color: 'red' } }, 'hello');
+React.createComponent([object Object], { theme: { color: 'red' } }, 'hello');
 "
 `;
 
@@ -77,7 +77,7 @@ createGlobalStyle\`
 import { createGlobalStyle as _createGlobalStyle } from 'styled-components';
 
 
-_createGlobalStyle\`
+[object Object]\`
   background: red;
 \`;
 "
@@ -96,7 +96,9 @@ css\`
 import { css as _css } from 'styled-components';
 
 
-_css(['color:', ';'], props => props.whiteColor ? 'white' : 'black');
+[object Object]\`
+  color: \${props => props.whiteColor ? 'white' : 'black'};
+\`;
 "
 `;
 
@@ -114,7 +116,10 @@ keyframes\`
 import { keyframes as _keyframes } from 'styled-components';
 
 
-_keyframes(['0%{opacity:0;}100%{opacity:1;}']);
+[object Object]\`
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+\`;
 "
 `;
 
@@ -128,10 +133,10 @@ myStyled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _styled from 'styled-components';
+import styled from 'styled-components';
 
 
-_styled.div.withConfig({
+styled.div.withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:red;']);
@@ -148,10 +153,10 @@ styled.div\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _styled from 'styled-components';
+import styled from 'styled-components';
 
 
-_styled.div.withConfig({
+styled.div.withConfig({
   displayName: 'macrotest',
   componentId: 'sc-11gvsec-0'
 })(['background:', ';'], p => p.error ? 'red' : 'green');

--- a/src/macro/test/macro.test.js
+++ b/src/macro/test/macro.test.js
@@ -12,6 +12,15 @@ styled.div\`
 \`
 `;
 
+const customStyledExampleCode = `
+import myStyled from '../../macro'
+import styled from 'another-package'
+
+myStyled.div\`
+  background: \${p => (p.error ? 'red' : 'green')};
+\`
+`;
+
 const cssExampleCode = `
 import { css } from '../../macro'
 
@@ -59,9 +68,9 @@ styled(Hello)\`
 `;
 
 const requireExampleCode = `
-const myStyled = require('../../macro')
+const styled = require('../../macro')
 
-myStyled.div\`
+styled.div\`
   background: red;
 \`
 `;
@@ -77,6 +86,7 @@ pluginTester({
   babelOptions: { filename: __filename },
   tests: {
     'should work with styled': styledExampleCode,
+    'should work with custom import name': customStyledExampleCode,
     'should work with { css }': cssExampleCode,
     'should work with { keyframes }': keyframesExampleCode,
     'should work with { createGlobalStyle }': createGlobalStyleExampleCode,


### PR DESCRIPTION
This is unnecessary, as the import name is already guaranteed to be unique. By not rewriting the import name, we can make the Babel plugin css prop work with the macro!

Before:

```JS
import styled from 'styled-components/macro';

// Before this was turned into
import _styled from 'styled-components';

// Now it's turned into
import styled from 'styled-components';
```

/cc @satya164