### PR TITLE
Update @emotion/is-prop-valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "homepage": "https://styled-components.com",
   "dependencies": {
-    "@emotion/is-prop-valid": "^0.6.8",
+    "@emotion/is-prop-valid": "^0.7.3",
     "@emotion/unitless": "^0.7.0",
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^2.2.2",

--- a/src/utils/test/validAttr.test.js
+++ b/src/utils/test/validAttr.test.js
@@ -568,6 +568,10 @@ describe('validAttr', () => {
     expect(validAttr('onPointerOut')).toEqual(true);
   });
 
+  it('should not allow non-handler props starting with "on"', () => {
+    expect(validAttr('onlyOneColumn')).toEqual(false);
+  })
+
   it('should not allow custom props', () => {
     expect(validAttr('isPrimary')).toEqual(false);
     expect(validAttr('primary')).toEqual(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,17 +643,17 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@emotion/is-prop-valid@^0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
-  integrity sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==
+"@emotion/is-prop-valid@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
   dependencies:
-    "@emotion/memoize" "^0.6.6"
+    "@emotion/memoize" "0.7.1"
 
-"@emotion/memoize@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
-  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
 
 "@emotion/unitless@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
fixes https://github.com/styled-components/styled-components/issues/2218
related https://github.com/emotion-js/emotion/issues/1042

This fails atm only on this test - https://github.com/styled-components/styled-components/blob/3056e3110dd7b64ecbe2dc3609e338cb7d73da91/src/utils/test/validAttr.test.js#L414-L419 . Is this something that you feel strongly about supporting? IMHO its not a real life use case (even if technically its correct) - `data-` & `aria-` are written with lowercase by convention.