### PR TITLE
WIP: fix attrs handling

### DIFF
--- a/src/constructors/constructWithOptions.js
+++ b/src/constructors/constructWithOptions.js
@@ -27,7 +27,7 @@ export default function constructWithOptions(
   templateFunction.attrs = attrs =>
     constructWithOptions(componentConstructor, tag, {
       ...options,
-      attrs: Array.prototype.concat(options.attrs, attrs).filter(Boolean),
+      attrs: Array.prototype.concat(attrs, options.attrs).filter(Boolean),
     });
 
   return templateFunction;

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -193,7 +193,7 @@ class StyledComponent extends Component<*> {
       /* eslint-disable guard-for-in */
       // $FlowFixMe
       for (key in resolvedAttrDef) {
-        if(this.attrs[key]) continue
+        if (this.attrs[key]) continue;
         attr = resolvedAttrDef[key];
 
         if (!attrDefWasFn) {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -186,13 +186,14 @@ class StyledComponent extends Component<*> {
 
       if (isFunction(resolvedAttrDef)) {
         // $FlowFixMe
-        resolvedAttrDef = resolvedAttrDef({ ...props, theme });
+        resolvedAttrDef = resolvedAttrDef(context);
         attrDefWasFn = true;
       }
 
       /* eslint-disable guard-for-in */
       // $FlowFixMe
       for (key in resolvedAttrDef) {
+        if(this.attrs[key]) continue
         attr = resolvedAttrDef[key];
 
         if (!attrDefWasFn) {
@@ -258,7 +259,7 @@ export default function createStyledComponent(target: Target, options: Object, r
   const finalAttrs =
     // $FlowFixMe
     isTargetStyledComp && target.attrs
-      ? Array.prototype.concat(target.attrs, attrs).filter(Boolean)
+      ? Array.prototype.concat(attrs, target.attrs).filter(Boolean)
       : attrs;
 
   const componentStyle = new ComponentStyle(

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -186,7 +186,7 @@ class StyledComponent extends Component<*> {
 
       if (isFunction(resolvedAttrDef)) {
         // $FlowFixMe
-        resolvedAttrDef = resolvedAttrDef(context);
+        resolvedAttrDef = resolvedAttrDef({ ...props, theme });
         attrDefWasFn = true;
       }
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -114,7 +114,7 @@ class StyledNativeComponent extends Component<*, *> {
 
       if (isFunction(resolvedAttrDef)) {
         // $FlowFixMe
-        resolvedAttrDef = resolvedAttrDef(context);
+        resolvedAttrDef = resolvedAttrDef({ ...props, theme });
         attrDefWasFn = true;
       }
 

--- a/src/models/StyledNativeComponent.js
+++ b/src/models/StyledNativeComponent.js
@@ -114,13 +114,14 @@ class StyledNativeComponent extends Component<*, *> {
 
       if (isFunction(resolvedAttrDef)) {
         // $FlowFixMe
-        resolvedAttrDef = resolvedAttrDef({ ...props, theme });
+        resolvedAttrDef = resolvedAttrDef(context);
         attrDefWasFn = true;
       }
 
       /* eslint-disable guard-for-in */
       // $FlowFixMe
       for (key in resolvedAttrDef) {
+        if (this.attrs[key]) continue;
         attr = resolvedAttrDef[key];
 
         if (!attrDefWasFn) {
@@ -196,7 +197,7 @@ export default (InlineStyle: Function) => {
     const finalAttrs =
       // $FlowFixMe
       isTargetStyledComp && target.attrs
-        ? Array.prototype.concat(target.attrs, attrs).filter(Boolean)
+        ? Array.prototype.concat(attrs, target.attrs).filter(Boolean)
         : attrs;
 
     /**

--- a/src/test/overriding.test.js
+++ b/src/test/overriding.test.js
@@ -35,31 +35,31 @@ describe('extending', () => {
   });
 
   describe('inheritance', () => {
-
     const setupParent = () => {
       const colors = {
         primary: 'red',
         secondary: 'blue',
         tertiary: 'green',
-      }
+        quaternary: 'yellow',
+      };
       const Parent = styled.h1`
         position: relative;
         color: ${props => colors[props.color]};
       `;
       return Parent;
-    }
+    };
 
     const addDefaultProps = (Parent, Child, Grandson) => {
       Parent.defaultProps = {
         color: 'primary',
-      }
+      };
       Child.defaultProps = {
         color: 'secondary',
-      }
+      };
       Grandson.defaultProps = {
         color: 'tertiary',
-      }
-    }
+      };
+    };
 
     it('should override parents defaultProps', () => {
       const Parent = setupParent();
@@ -76,12 +76,54 @@ describe('extending', () => {
       `);
     });
 
+    it('should override parents static attrs', () => {
+      const Parent = styled(setupParent()).attrs({
+        color: 'primary',
+      })``;
+      const Child = styled(Parent).attrs({
+        color: 'secondary',
+      })``;
+      const Grandson = styled(Child).attrs({
+        color: 'tertiary',
+      })``;
+      TestRenderer.create(<Parent />);
+      TestRenderer.create(<Child />);
+      TestRenderer.create(<Grandson />);
+      expectCSSMatches(`
+        .e{ position:relative; color:red; }
+        .f{ position:relative; color:blue; }
+        .g{ position:relative; color:green; }
+      `);
+    });
+
+    it('should override parents dynamic attrs', () => {
+      const Parent = styled(setupParent()).attrs(props => ({
+        color: props.color || 'primary',
+      }))``;
+      const Child = styled(Parent).attrs(props => ({
+        color: props.color || 'secondary',
+      }))``;
+      const Grandson = styled(Child).attrs(props => ({
+        color: props.color || 'tertiary',
+      }))``;
+      TestRenderer.create(<Parent />);
+      TestRenderer.create(<Child />);
+      TestRenderer.create(<Grandson />);
+      TestRenderer.create(<Grandson color="quaternary" />);
+      expectCSSMatches(`
+        .e{ position:relative; color:red; }
+        .f{ position:relative; color:blue; }
+        .g{ position:relative; color:green; }
+        .h{ position:relative; color:yellow; }
+      `);
+    });
+
     describe('when overriding with another component', () => {
       it('should override parents defaultProps', () => {
         const Parent = setupParent();
-        const Child = styled(Parent).attrs({as: 'h2'})``;
-        const Grandson = styled(Child).attrs({as: 'h3'})``;
-        console.log
+        const Child = styled(Parent).attrs({ as: 'h2' })``;
+        const Grandson = styled(Child).attrs({ as: 'h3' })``;
+        console.log;
         addDefaultProps(Parent, Child, Grandson);
         TestRenderer.create(<Parent />);
         TestRenderer.create(<Child />);
@@ -94,8 +136,8 @@ describe('extending', () => {
       });
       it('should evaluate grandsons props', () => {
         const Parent = setupParent();
-        const Child = styled(Parent).attrs({as: 'h2'})``;
-        const Grandson = styled(Child).attrs({as: 'h3'})``;
+        const Child = styled(Parent).attrs({ as: 'h2' })``;
+        const Grandson = styled(Child).attrs({ as: 'h3' })``;
         addDefaultProps(Parent, Child, Grandson);
         TestRenderer.create(<Parent />);
         TestRenderer.create(<Child />);

--- a/src/test/overriding.test.js
+++ b/src/test/overriding.test.js
@@ -123,7 +123,6 @@ describe('extending', () => {
         const Parent = setupParent();
         const Child = styled(Parent).attrs({ as: 'h2' })``;
         const Grandson = styled(Child).attrs({ as: 'h3' })``;
-        console.log;
         addDefaultProps(Parent, Child, Grandson);
         TestRenderer.create(<Parent />);
         TestRenderer.create(<Child />);


### PR DESCRIPTION
Fix muted context, introduced in `4.1.2` by #2210 

`context` was created here

https://github.com/styled-components/styled-components/blob/a41dfd0537f96b2a8572409382faedcdc936849e/src/models/StyledComponent.js#L175

passed here

https://github.com/styled-components/styled-components/blob/a41dfd0537f96b2a8572409382faedcdc936849e/src/models/StyledComponent.js#L189

and muted here

https://github.com/styled-components/styled-components/blob/a41dfd0537f96b2a8572409382faedcdc936849e/src/models/StyledComponent.js#L213

which generates side effects described and discovered while testing regarding this issue https://github.com/styled-components/styled-components/issues/2246#issuecomment-443435142

`attrs` wasn't overridable because props where created and passed between components in a reverse order.

Maybe we should add some test to prevent this in the future.