### PR TITLE
add defaultProps folding

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -298,6 +298,31 @@ export default function createStyledComponent(target: Target, options: Object, r
   // $FlowFixMe
   WrappedStyledComponent.target = isTargetStyledComp ? target.target : target;
 
+  // fold defaultProps
+  // $FlowFixMe
+  WrappedStyledComponent._defaultProps = EMPTY_OBJECT;
+  // $FlowFixMe
+  Object.defineProperty(WrappedStyledComponent, 'defaultProps', {
+    enumerable: true,
+    get() {
+      return this._defaultProps;
+    },
+    set(defaultProps) {
+      this._defaultProps = {
+        ...this._defaultProps,
+        ...defaultProps,
+        ...(this._defaultProps.style || defaultProps.style
+          ? {
+              style: {
+                ...(this._defaultProps.style || EMPTY_OBJECT),
+                ...(defaultProps.style || EMPTY_OBJECT),
+              },
+            }
+          : EMPTY_OBJECT),
+      };
+    },
+  });
+
   // $FlowFixMe
   WrappedStyledComponent.withComponent = function withComponent(tag: Target) {
     const { componentId: previousComponentId, ...optionsToCopy } = options;

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -222,6 +222,32 @@ export default (InlineStyle: Function) => {
       ? // $FlowFixMe
         target.target
       : target;
+
+    // fold defaultProps
+    // $FlowFixMe
+    WrappedStyledNativeComponent._defaultProps = EMPTY_OBJECT;
+    // $FlowFixMe
+    Object.defineProperty(WrappedStyledNativeComponent, 'defaultProps', {
+      enumerable: true,
+      get() {
+        return this._defaultProps;
+      },
+      set(defaultProps) {
+        this._defaultProps = {
+          ...this._defaultProps,
+          ...defaultProps,
+          ...(this._defaultProps.style || defaultProps.style
+            ? {
+                style: {
+                  ...(this._defaultProps.style || EMPTY_OBJECT),
+                  ...(defaultProps.style || EMPTY_OBJECT),
+                },
+              }
+            : EMPTY_OBJECT),
+        };
+      },
+    });
+
     // $FlowFixMe
     WrappedStyledNativeComponent.withComponent = function withComponent(tag: Target) {
       const { displayName: _, componentId: __, ...optionsToCopy } = options;

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -297,6 +297,74 @@ describe('native', () => {
     });
   });
 
+  describe('defaultProps' , () => {
+    it('should extends parents defaultProps', () => {
+      const Parent = styled.Text({}, props => ({
+        color: props.color,
+        backgroundColor: props.backgroundColor,
+        borderColor: props.borderColor
+      }));
+      Parent.defaultProps = {
+        color: 'red',
+      };
+      const Child = styled(Parent)``;
+      Child.defaultProps = {
+        backgroundColor: 'blue',
+      };
+      const Grandson = styled(Child)``;
+      Grandson.defaultProps = {
+        borderColor: 'green',
+      };
+
+      const parentWrapper = TestRenderer.create(<Parent />);
+      const childWrapper = TestRenderer.create(<Child />);
+      const grandsonWrapper = TestRenderer.create(<Grandson />);
+
+      const parentText = parentWrapper.root.findByType('Text');
+      const childText = childWrapper.root.findByType('Text');
+      const grandsonText = grandsonWrapper.root.findByType('Text');
+
+      expect(parentText.props.style).toMatchObject([{
+        color: 'red'
+      }]);
+      expect(childText.props.style).toMatchObject([{
+        color: 'red',
+        backgroundColor: 'blue'
+      }]);
+      expect(grandsonText.props.style).toMatchObject([{
+        color: 'red',
+        backgroundColor: 'blue',
+        borderColor: 'green'
+      }]);
+    });
+
+    it('should extends parents default style', () => {
+      const Parent = styled.Text``;
+      Parent.defaultProps = {
+        style: { color: 'blue' },
+      };
+
+      const Child = styled(Parent)``;
+      Child.defaultProps = {
+        style: { backgroundColor: 'red' },
+      };
+
+      const parentWrapper = TestRenderer.create(<Parent />);
+      const childWrapper = TestRenderer.create(<Child />);
+
+      const parentText = parentWrapper.root.findByType('Text');
+      const childText = childWrapper.root.findByType('Text');
+
+      expect(parentText.props.style).toMatchObject([{}, {
+        color: 'blue',
+      }]);
+      expect(childText.props.style).toMatchObject([{}, {
+        color: 'blue',
+        backgroundColor: 'red',
+      }]);
+    });
+  })
+
   describe('expanded API', () => {
     it('should attach a displayName', () => {
       View.displayName = 'View';

--- a/packages/styled-components/src/test/defaultProps.test.js
+++ b/packages/styled-components/src/test/defaultProps.test.js
@@ -1,0 +1,89 @@
+import { expectCSSMatches, resetStyled } from './utils';
+
+// @flow
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+
+let styled;
+
+describe('defaultProps', () => {
+  /**
+   * Make sure the setup is the same for every test
+   */
+  beforeEach(() => {
+    styled = resetStyled();
+  });
+
+  describe('inheritance', () => {
+    const setupParent = () => {
+      const colors = {
+        primary: 'red',
+        secondary: 'blue',
+        tertiary: 'green',
+      };
+      const Parent = styled.h1`
+        position: relative;
+        color: ${props => colors[props.color]};
+        background-color: ${props => colors[props.backgroundColor]};
+        border-color: ${props => colors[props.borderColor]};
+      `;
+      return Parent;
+    };
+
+    it('should extends parents defaultProps', () => {
+      const Parent = setupParent();
+      Parent.defaultProps = {
+        color: 'primary',
+      };
+      const Child = styled(Parent)``;
+      Child.defaultProps = {
+        backgroundColor: 'secondary',
+      };
+      const Grandson = styled(Child)``;
+      Grandson.defaultProps = {
+        borderColor: 'tertiary',
+      };
+      TestRenderer.create(<Parent />);
+      TestRenderer.create(<Child />);
+      TestRenderer.create(<Grandson />);
+      expectCSSMatches(`
+        .d{ position:relative; color:red; }
+        .e{ position:relative; color:red; background-color:blue; }
+        .f{ position:relative; color:red; background-color:blue; border-color: green; }
+      `);
+    });
+
+    it('should extends parents default style', () => {
+      const Parent = styled.div``;
+      Parent.defaultProps = {
+        style: { color: 'blue' },
+      };
+
+      const Child = styled(Parent)``;
+      Child.defaultProps = {
+        style: { background: 'red' },
+      };
+
+      expect(TestRenderer.create(<Parent />).toJSON().props.style).toEqual({
+        color: 'blue',
+      });
+      expect(TestRenderer.create(<Child />).toJSON().props.style).toEqual({
+        color: 'blue',
+        background: 'red',
+      });
+    });
+
+    it('should override default styles with styles', () => {
+      const Comp = styled.div``;
+      Comp.defaultProps = {
+        style: { color: 'blue' },
+      };
+
+      expect(
+        TestRenderer.create(<Comp style={{ border: 'none' }} />).toJSON().props.style
+      ).toEqual({
+        border: 'none',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix #2246 

Attempt to fold defaultProps.

```js
const Text = styled.p`
  font-family: ${props => props.font};
`
Text.defaultProps = {
  font: 'sans-serif'
}

const Heading = styled(Text)``
Heading.defaultProps = {
  as: 'h2'
}
```

`Heading` is rendered with `font: 'sans-serif'`

@probablyup you mentionned that `defaultProps.style` should have a special case. Which one?

I didn't make the changes for Native, I'm waiting for some feedback.

