### PR TITLE
add SC_DISABLE_SPEEDY runtime override for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file. If a contri
 
 _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/)._
 
-## unreleased
+## Unreleased
+
+- Allow disabling "speedy" mode via global `SC_DISABLE_SPEEDY` variable, by [@devrelm](https://github.com/devrelm) (see [#2185](https://github.com/styled-components/styled-components/pull/2185))
 
 ## [3.4.10] - 2018-10-09
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,11 +1,14 @@
 // @flow
 
 declare var __DEV__: ?string
+declare var SC_DISABLE_SPEEDY: ?boolean
 
 export const SC_ATTR =
   (typeof process !== 'undefined' && process.env.SC_ATTR) ||
   'data-styled-components'
+
 export const SC_STREAM_ATTR = 'data-styled-streamed'
+
 export const CONTEXT_KEY = '__styled-components-stylesheet__'
 
 export const IS_BROWSER =
@@ -13,4 +16,8 @@ export const IS_BROWSER =
 
 export const DISABLE_SPEEDY =
   (typeof __DEV__ === 'boolean' && __DEV__) ||
+  (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
   process.env.NODE_ENV !== 'production'
+
+// Shared empty execution context when generating static styles
+export const STATIC_EXECUTION_CONTEXT = {}

--- a/src/test/constants.test.js
+++ b/src/test/constants.test.js
@@ -1,41 +1,101 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
-import { expectCSSMatches } from './utils'
-import { SC_ATTR as DEFAULT_SC_ATTR } from '../constants'
-
-function renderAndExpect(expectedAttr) {
-  const SC_ATTR = require('../constants').SC_ATTR
-  const styled = require('./utils').resetStyled()
-
-  const Comp = styled.div`
-    color: blue;
-  `
-
-  shallow(<Comp />)
-
-  expectCSSMatches('.sc-a { } .b { color:blue; }')
-
-  expect(SC_ATTR).toEqual(expectedAttr)
-  expect(document.head.querySelectorAll(`style[${SC_ATTR}]`)).toHaveLength(1)
-}
+import { expectCSSMatches } from './utils';
+import { SC_ATTR as DEFAULT_SC_ATTR } from '../constants';
 
 describe('constants', () => {
-  it('should work with default SC_ATTR', () => {
-    renderAndExpect(DEFAULT_SC_ATTR)
-  })
-
-  it('should work with custom SC_ATTR', () => {
-    const CUSTOM_SC_ATTR = 'data-custom-styled-components'
-    process.env.SC_ATTR = CUSTOM_SC_ATTR
-    jest.resetModules()
-
-    renderAndExpect(CUSTOM_SC_ATTR)
-
-    delete process.env.SC_ATTR
-  })
-
   afterEach(() => {
-    jest.resetModules()
-  })
-})
+    jest.resetModules();
+  });
+
+  describe('SC_ATTR', () => {
+    function renderAndExpect(expectedAttr) {
+      const SC_ATTR = require('../constants').SC_ATTR;
+      const styled = require('./utils').resetStyled();
+
+      const Comp = styled.div`
+        color: blue;
+      `;
+
+      shallow(<Comp />);
+
+      expectCSSMatches('.sc-a { } .b { color:blue; }');
+
+      expect(SC_ATTR).toEqual(expectedAttr);
+      expect(document.head.querySelectorAll(`style[${SC_ATTR}]`)).toHaveLength(1);
+    }
+
+    it('should work with default SC_ATTR', () => {
+      renderAndExpect(DEFAULT_SC_ATTR);
+    });
+
+    it('should work with custom SC_ATTR', () => {
+      const CUSTOM_SC_ATTR = 'data-custom-styled-components';
+      process.env.SC_ATTR = CUSTOM_SC_ATTR;
+      jest.resetModules();
+
+      renderAndExpect(CUSTOM_SC_ATTR);
+
+      delete process.env.SC_ATTR;
+    });
+  });
+
+  describe('DISABLE_SPEEDY', () => {
+    const oldDev = window.__DEV__;
+
+    function renderAndExpect(expectedDisableSpeedy, expectedCss) {
+      const DISABLE_SPEEDY = require('../constants').DISABLE_SPEEDY;
+      const styled = require('./utils').resetStyled();
+
+      const Comp = styled.div`
+        color: blue;
+      `;
+
+      shallow(<Comp />);
+
+      expect(DISABLE_SPEEDY).toEqual(expectedDisableSpeedy);
+      expectCSSMatches(expectedCss);
+    }
+
+    beforeEach(() => {
+      window.__DEV__ = false;
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterEach(() => {
+      window.__DEV__ = oldDev;
+      process.env.NODE_ENV = 'test';
+      delete process.env.DISABLE_SPEEDY;
+    });
+
+    it('should be false in production NODE_ENV when SC_DISABLE_SPEEDY is not set', () => {
+      renderAndExpect(false, '');
+    });
+
+    it('should be false in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to false', () => {
+      window.SC_DISABLE_SPEEDY = false;
+      renderAndExpect(false, '');
+    });
+
+    it('should be false in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to truthy value', () => {
+      window.SC_DISABLE_SPEEDY = 'true';
+      renderAndExpect(false, '');
+    });
+
+    it('should be true in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to true', () => {
+      window.SC_DISABLE_SPEEDY = true;
+      renderAndExpect(true, '.b { color:blue; }');
+    });
+
+    it('should be true in test NODE_ENV', () => {
+      process.env.NODE_ENV = 'test';
+      renderAndExpect(true, '.sc-a { } .b { color:blue; }');
+    });
+
+    it('should be true in development NODE_ENV', () => {
+      process.env.NODE_ENV = 'development';
+      renderAndExpect(true, '.sc-a { } .b { color:blue; }');
+    });
+  });
+});


### PR DESCRIPTION
This is cherry picked from #2185 to backport this functionality to v3. We will need a new branch for v3 to target.

* add SC_DISABLE_SPEEDY runtime override

* refactor SC_ATTR tests into their own 'describe' section

* add tests for DISABLE_SPEEDY and SC_DISABLE_SPEEDY global variable

* add CHANGELOG entry

# Resolve Conflicts:
#	CHANGELOG.md
#	src/constants.js
#	src/test/constants.test.js