### PR TITLE
make use of already destructured values to get the styledComponentId constant

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -239,6 +239,7 @@ class StyledComponent extends Component<*> {
 }
 
 export default function createStyledComponent(target: Target, options: Object, rules: RuleSet) {
+  
   const isTargetStyledComp = isStyledComponent(target);
   const isClass = !isTag(target);
 
@@ -250,9 +251,9 @@ export default function createStyledComponent(target: Target, options: Object, r
   } = options;
 
   const styledComponentId =
-    options.displayName && options.componentId
-      ? `${escape(options.displayName)}-${options.componentId}`
-      : options.componentId || componentId;
+    displayName && componentId
+      ? `${escape(displayName)}-${componentId}`
+      : componentId;
 
   // fold the underlying StyledComponent attrs up (implicit extend)
   const finalAttrs =


### PR DESCRIPTION
this PR aims to simplify code to generate the `styledComponentId` constant. it basically does 2 main things:
1. make usage of already destructured/(defaulted) `options` properties
2. remove some duplicate from the `else` block in that condition. as far as I can see this is not needed as the `componentId` already has a default value at that (run)time. 