### PR TITLE
Add failing test for keyframes in style objects

### DIFF
--- a/src/constructors/test/keyframes.test.js
+++ b/src/constructors/test/keyframes.test.js
@@ -135,6 +135,54 @@ describe('keyframes', () => {
     `);
   });
 
+  it('should allow keyframes in style object', () => {
+    const styled = resetStyled();
+
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    expectCSSMatches('');
+
+    const Comp = styled.div({
+      animation: css`${animation} 2s linear infinite`
+    });
+    TestRenderer.create(<Comp />);
+
+    expectCSSMatches(`
+      .b {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+
+      @-webkit-keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+
+      @keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+    `);
+  });
+
   it('should handle interpolations', () => {
     const styled = resetStyled();
 


### PR DESCRIPTION
(Based on the conversation [here](https://spectrum.chat/styled-components/help/how-can-i-use-a-custom-animation-with-the-style-object-syntax~91d624ea-a5a3-4d0e-9314-4da860059112))

This PR adds a failing test containing my attempt to use `keyframes` with the style object syntax `styled.div({ ... })`. I'm also not 100% sure that using `css` is necessary, but I'm assuming it is since the error is:

```
It seems you are interpolating a keyframe declaration (bcCCNc) into an
untagged string. This was supported in styled-components v3, but is not
longer supported in v4 as keyframes are now injected on-demand. Please
wrap your string in the css`` helper
(see https://www.styled-components.com/docs/api#css), which ensures
the styles are injected correctly.
```