### PR TITLE
Use mobile first techniques in media templates examples

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -157,7 +157,7 @@ export const media = Object.keys(sizes).reduce((accumulator, label) => {
   // changing their browsers font-size: https://zellwk.com/blog/media-query-units/
   const emSize = sizes[label] / 16
   accumulator[label] = (...args) => css`
-    @media (max-width: ${emSize}em) {
+    @media (min-width: ${emSize}em) {
       ${css(...args)};
     }
   `


### PR DESCRIPTION
Given the example here:
https://zellwk.com/blog/how-to-write-mobile-first-css/

Should we not be promoting best practice by giving mobile first media queries?