### PR TITLE
Update memoize-one

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@emotion/unitless": "^0.7.0",
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^2.2.2",
-    "memoize-one": "^4.0.0",
+    "memoize-one": "^5.0.0",
     "prop-types": "^15.5.4",
     "react-is": "^16.6.0",
     "stylis": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5008,9 +5008,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memoize-one@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+memoize-one@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
+  integrity sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==
 
 memorystream@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
The `memoize-one` package recently updated its custom equality API big time, so when you install styled-components you get a warning from the package on updating. This PR just updates memoize-one 😄 

<img width="673" alt="screen shot 2018-12-19 at 2 26 06 pm" src="https://user-images.githubusercontent.com/15176096/50243089-2f9a5080-039a-11e9-8320-ff21684b3bcf.png">
