### PR TITLE
React native errors

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "main": "./dist/styled-components.native.cjs.js",
   "jsnext:main": "./dist/styled-components.native.esm.js",
-  "module": "./dist/styled-components.native.esm.js"
+  "module": "./dist/styled-components.native.esm.js",
+  "peerDependencies": {"react-native": ">= 0.44"}
 }

--- a/src/base.js
+++ b/src/base.js
@@ -13,13 +13,10 @@ import ThemeProvider, { ThemeContext, ThemeConsumer } from './models/ThemeProvid
 
 /* Import Higher Order Components */
 import withTheme from './hoc/withTheme';
+import isReactNative from './utils/isReactNative';
 
 /* Warning if you've imported this file on React Native */
-if (
-  process.env.NODE_ENV !== 'production' &&
-  typeof navigator !== 'undefined' &&
-  navigator.product === 'ReactNative'
-) {
+if (process.env.NODE_ENV !== 'production' && isReactNative) {
   // eslint-disable-next-line no-console
   console.warn(
     "It looks like you've imported 'styled-components' on React Native.\n" +

--- a/src/constructors/keyframes.js
+++ b/src/constructors/keyframes.js
@@ -6,6 +6,8 @@ import stringifyRules from '../utils/stringifyRules';
 import hashStr from '../vendor/glamor/hash';
 import Keyframes from '../models/Keyframes';
 
+import { errorKeyFramesInNative } from '../utils/error';
+import isReactNative from '../utils/isReactNative';
 import type { Interpolation, Styles } from '../types';
 
 const replaceWhitespace = (str: string): string => str.replace(/\s|\\n/g, '');
@@ -15,14 +17,8 @@ export default function keyframes(
   ...interpolations: Array<Interpolation>
 ): Keyframes {
   /* Warning if you've used keyframes on React Native */
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    typeof navigator !== 'undefined' &&
-    navigator.product === 'ReactNative'
-  ) {
-    console.warn(
-      '`keyframes` cannot be used on ReactNative, only on the web. To do animation in ReactNative please use Animated.'
-    );
+  if (process.env.NODE_ENV !== 'production' && isReactNative) {
+    errorKeyFramesInNative();
   }
 
   const rules = css(strings, ...interpolations);

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -12,11 +12,28 @@ import ThemeProvider, { ThemeConsumer, ThemeContext } from '../models/ThemeProvi
 import withTheme from '../hoc/withTheme';
 import isStyledComponent from '../utils/isStyledComponent';
 
+import { errorKeyFramesInNative } from '../utils/error';
 import type { Target } from '../types';
 
 const InlineStyle = _InlineStyle(reactNative.StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);
 const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag);
+const keyframes = errorKeyFramesInNative;
+function createGlobalStyle() {
+  throw new Error(
+    '`createGlobalStyle` cannot be used on ReactNative, only on the web.' +
+      '\n' +
+      'To use global styles in ReactNative you can create rules with `css` and compose with other styles like' +
+      `\n\n` +
+      `import { globalTextStyle } from '../global'` +
+      '\n' +
+      `
+const ButtonText = styled.Text\`
+  $\{globalTextStyle};
+  font-size: 20px;
+\`.`
+  );
+}
 
 /* React native lazy-requires each of these modules for some reason, so let's
  *  assume it's for a good reason and not eagerly load them all */
@@ -40,5 +57,14 @@ aliases.split(/\s+/m).forEach(alias =>
   })
 );
 
-export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme };
+export {
+  css,
+  isStyledComponent,
+  ThemeProvider,
+  ThemeConsumer,
+  ThemeContext,
+  withTheme,
+  keyframes,
+  createGlobalStyle,
+};
 export default styled;

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -20,6 +20,10 @@ const ERRORS =
     `
     : {};
 
+export function errorKeyFramesInNative() {
+  throw new Error('`keyframes` cannot be used on ReactNative, only on the web. To do animation in ReactNative please use `Animated` https://bit.ly/2VzGVqs.')
+};
+
 /**
  * super basic version of sprintf
  */

--- a/src/utils/isReactNative.js
+++ b/src/utils/isReactNative.js
@@ -1,0 +1,3 @@
+const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
+
+export default isReactNative;


### PR DESCRIPTION
I spent a few hours when first time trying react-native with styled-component, it was an adaptation web version, and I don't know about these cases like not working keyframes and global styles. What I see an only error like `keyframes` is not a function I guess. I was not helpful. Maybe I wrong make installation or wrong import module. Hope this friendly errors will help for next-gen react-native devs :).
Chooses `throw new Error`, not the `console.warn`, because stack traces will help to find where exactly you import `keyframes` or `createGlobalStyle`
Also added peerDependencies react-native in `native/package.json`, I dont know will it work with instalation.