### PR TITLE
Make the GlobalStyleComponent call the base constructor with props.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- Make the `GlobalStyleComponent` call the base constructor with `props`.
+- Make the `GlobalStyleComponent` created by `createGlobalStyle` call the base constructor with `props`.
 
 ## [v4.1.2] - 2018-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Make the `GlobalStyleComponent` call the base constructor with `props`.
+
 ## [v4.1.2] - 2018-11-28
 
 - Fix function-form attrs to receive the full execution context (including theme) (see [#2210](https://github.com/styled-components/styled-components/pull/2210))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- Make the `GlobalStyleComponent` created by `createGlobalStyle` call the base constructor with `props`.
+- Make the `GlobalStyleComponent` created by `createGlobalStyle` call the base constructor with `props` (see [#2321](https://github.com/styled-components/styled-components/pull/2321)).
 
 ## [v4.1.2] - 2018-11-28
 

--- a/src/constructors/createGlobalStyle.js
+++ b/src/constructors/createGlobalStyle.js
@@ -14,8 +14,6 @@ import type { Interpolation } from '../types';
 
 type GlobalStyleComponentPropsType = Object;
 
-type GlobalStyleComponentStateType = Object;
-
 // place our cache into shared context so it'll persist between HMRs
 if (IS_BROWSER) {
   window.scCGSHMRCache = {};
@@ -29,7 +27,7 @@ export default function createGlobalStyle(
   const id = `sc-global-${hashStr(JSON.stringify(rules))}`;
   const style = new GlobalStyle(rules, id);
 
-  class GlobalStyleComponent extends React.Component<GlobalStyleComponentPropsType, GlobalStyleComponentStateType> {
+  class GlobalStyleComponent extends React.Component<GlobalStyleComponentPropsType, *> {
     styleSheet: Object;
 
     static globalStyle = style;

--- a/src/constructors/createGlobalStyle.js
+++ b/src/constructors/createGlobalStyle.js
@@ -12,6 +12,10 @@ import css from './css';
 
 import type { Interpolation } from '../types';
 
+type GlobalStyleComponentPropsType = Object;
+
+type GlobalStyleComponentStateType = Object;
+
 // place our cache into shared context so it'll persist between HMRs
 if (IS_BROWSER) {
   window.scCGSHMRCache = {};
@@ -25,15 +29,15 @@ export default function createGlobalStyle(
   const id = `sc-global-${hashStr(JSON.stringify(rules))}`;
   const style = new GlobalStyle(rules, id);
 
-  class GlobalStyleComponent extends React.Component<*, *> {
+  class GlobalStyleComponent extends React.Component<GlobalStyleComponentPropsType, GlobalStyleComponentStateType> {
     styleSheet: Object;
 
     static globalStyle = style;
 
     static styledComponentId = id;
 
-    constructor() {
-      super();
+    constructor(props: GlobalStyleComponentPropsType) {
+      super(props);
 
       const { globalStyle, styledComponentId } = this.constructor;
 


### PR DESCRIPTION
This PR ensures the `GlobalStyleComponent` created by `createGlobalStyle` calls the base constructor with `props`.

This is a React best practice for class components:

> Class components should always call the base constructor with `props`.
> — https://reactjs.org/docs/state-and-lifecycle.html#adding-local-state-to-a-class

Not doing so can cause issues with `this.props` being undefined when rendered by libraries that are not very fault tolerant.

React's `renderToString` accounts for it here: https://github.com/facebook/react/blob/v16.7.0/packages/react-dom/src/server/ReactPartialRenderer.js#L532

Apollo's `getDataFromTree` used to account for it here: https://github.com/apollographql/react-apollo/blob/v2.2.4/src/getDataFromTree.ts#L80

Fixes https://github.com/jaydenseric/graphql-react/issues/17 .