### PR TITLE
add test for #2333

### DIFF
--- a/packages/styled-components/src/utils/classNameUsageCheckInjector.js
+++ b/packages/styled-components/src/utils/classNameUsageCheckInjector.js
@@ -28,7 +28,7 @@ export default (target: Object) => {
     didWarnAboutClassNameUsage.add(forwardTarget);
 
     const classNames = elementClassName
-      .replace(/ +/g, ' ')
+      .replace(/\s+/g, ' ')
       .trim()
       .split(' ');
     // eslint-disable-next-line react/no-find-dom-node

--- a/packages/styled-components/src/utils/test/classNameUsageCheckInjector.test.js
+++ b/packages/styled-components/src/utils/test/classNameUsageCheckInjector.test.js
@@ -10,7 +10,30 @@ describe('classNameUsageCheckInjector', () => {
   beforeEach(() => {
     styled = resetStyled();
   });
+  
+  it('should generate valid selectors when there are some line break in className', () => {
+    const div = document.createElement('div');
+    const Comp = props => <div {...props} />;
+    const StyledComp = styled(Comp)``;
 
+    // Avoid the console.warn
+    jest.spyOn(div, 'querySelector').mockImplementationOnce(() => true);
+    jest.spyOn(ReactDOM, 'findDOMNode').mockImplementationOnce(() => div);
+
+    renderIntoDocument(
+      <StyledComp
+        className="   foo
+        bar  "
+      />
+    );
+
+    const [selector] = div.querySelector.mock.calls[0];
+
+    // Css selectors should not have multiple dots after each other
+    expect(selector).not.toMatch(/\.{2,}/);
+    expect(selector).toMatch(/^\.foo\.bar\.sc-/);
+  });
+  
   it('should generate valid selectors', () => {
     const div = document.createElement('div');
     const StyledDiv = styled.div``;


### PR DESCRIPTION
Here's a new problem:
At first, I think it's an easy test, just copy the #2080's test and rewrite several words.
But it not works?!
`styled.div` used for two times will break the test. 
I can't understand why, can anyone help me?
And why `renderIntoDocument(components)` return null while components created by styled-components?

Here's my local test result , if I copy the same code, it failed
![2](https://user-images.githubusercontent.com/19583202/51378118-7de07200-1b47-11e9-8e2f-e7408c15f3de.png)
![1](https://user-images.githubusercontent.com/19583202/51378120-7f119f00-1b47-11e9-8dac-ba0290f5e08a.png)

