### PR TITLE
refactor: use StyleSheet.master as default value in StyleSheetContext

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -81,8 +81,8 @@ export default function createGlobalStyle(
 
       return (
         <StyleSheetConsumer>
-          {(styleSheet?: StyleSheet) => {
-            this.styleSheet = styleSheet || StyleSheet.master;
+          {(styleSheet: StyleSheet) => {
+            this.styleSheet = styleSheet;
 
             const { globalStyle } = this.state;
 

--- a/packages/styled-components/src/models/StyleSheetManager.js
+++ b/packages/styled-components/src/models/StyleSheetManager.js
@@ -12,7 +12,7 @@ type Props = {
   target?: HTMLElement,
 };
 
-const StyleSheetContext = createContext();
+const StyleSheetContext = createContext(StyleSheet.master);
 
 export const StyleSheetConsumer = StyleSheetContext.Consumer;
 

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -98,7 +98,7 @@ class StyledComponent extends Component<*> {
     return <StyleSheetConsumer>{this.renderOuter}</StyleSheetConsumer>;
   }
 
-  renderOuter(styleSheet?: StyleSheet = StyleSheet.master) {
+  renderOuter(styleSheet: StyleSheet) {
     this.styleSheet = styleSheet;
 
     // No need to subscribe a static component to theme changes, it won't change anything


### PR DESCRIPTION
I think it makes sense to use the `StyleSheet.master` as the default value in the `StyleSheetContext`. Removes some unnecessary (I think) logic in `createGlobalStyle` and `StyledComponent`. This will also make the Hooks migration (#2342) a bit simpler.

I thought this would be a pretty straight forward change – but a lot of the tests broke and I'm not 100% sure why. Could it be the `master` getter in `StyleSheet.js` that sets the `master` variable right away instead of when it's needed? 