### PR TITLE
Filter suppressClassNameWarning to not to pass down to wrapped components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Move to Mono repository structure with lerna [@imbhargav5](https://github.com/imbhargav5) (see [#2326](https://github.com/styled-components/styled-components/pull/2326))
 
+- Filter `suppressClassNameWarning` to not to pass down to the wrapped components [@taneba](https://github.com/taneba) (see [#2365](https://github.com/styled-components/styled-components/pull/2365))
+
 ## [v4.1.3] - 2018-12-17
 
 - Under the hood code cleanup of the Babel macro, by [@lucleray](https://github.com/lucleray) (see [#2286](https://github.com/styled-components/styled-components/pull/2286))

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -145,9 +145,10 @@ class StyledComponent extends Component<*> {
         this.warnInnerRef(displayName);
       }
 
-      if (key === 'forwardedComponent' || key === 'as') continue;
+      if (key === 'forwardedComponent' || key === 'as' || key === 'suppressClassNameWarning')
+        {continue;}
       else if (key === 'forwardedRef') propsForElement.ref = computedProps[key];
-      else if ((!isTargetTag && key !== 'suppressClassNameWarning') || validAttr(key)) {
+      else if (!isTargetTag || validAttr(key)) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -147,7 +147,7 @@ class StyledComponent extends Component<*> {
 
       if (key === 'forwardedComponent' || key === 'as') continue;
       else if (key === 'forwardedRef') propsForElement.ref = computedProps[key];
-      else if (!isTargetTag || validAttr(key)) {
+      else if ((!isTargetTag && key !== 'suppressClassNameWarning') || validAttr(key)) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }

--- a/packages/styled-components/src/test/basic.test.js
+++ b/packages/styled-components/src/test/basic.test.js
@@ -229,6 +229,19 @@ describe('basic', () => {
       expect(wrapper.testRef.current).toBe(innerComponent);
     });
 
+    it('should not pass the suppressClassNameWarning to the wrapped child', () => {
+      const OuterComponent = styled(InnerComponent)``;
+
+      class Wrapper extends Component<*, *> {
+        render() {
+          return <OuterComponent suppressClassNameWarning />
+        }
+      }
+      
+      const wrapper = TestRenderer.create(<Wrapper />);
+      expect(wrapper.root.findByType(InnerComponent).props.suppressClassNameWarning).toBeUndefined();
+    });
+
     it('should respect the order of StyledComponent creation for CSS ordering', () => {
       const FirstComponent = styled.div`
         color: red;


### PR DESCRIPTION
fixes #2346 

Once I tried the solution that @leantide [mentioned in the related issue](https://github.com/styled-components/styled-components/issues/2346#issuecomment-459407874), but it didn't work (I think it is because React likely freezes props). 
What I did Instead is to filter suppressClassNameWarning when passing props to child component.