### PR TITLE
Add svg marker tag to domElements.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Add svg tag `marker` to domElements.js (see [#2389](https://github.com/styled-components/styled-components/pull/2389))
+
 - Make the `GlobalStyleComponent` created by `createGlobalStyle` call the base constructor with `props` (see [#2321](https://github.com/styled-components/styled-components/pull/2321)).
 
 - Move to Mono repository structure with lerna [@imbhargav5](https://github.com/imbhargav5) (see [#2326](https://github.com/styled-components/styled-components/pull/2326))

--- a/packages/styled-components/src/utils/domElements.js
+++ b/packages/styled-components/src/utils/domElements.js
@@ -127,6 +127,7 @@ export default [
   'image',
   'line',
   'linearGradient',
+  'marker',
   'mask',
   'path',
   'pattern',


### PR DESCRIPTION
`TypeError: styled_components__WEBPACK_IMPORTED_MODULE_8__.default.marker is not a function`

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker