### PR TITLE
Readd production guard on flatten function error

### DIFF
--- a/packages/styled-components/src/utils/flatten.js
+++ b/packages/styled-components/src/utils/flatten.js
@@ -56,19 +56,21 @@ export default function flatten(chunk: any, executionContext: ?Object, styleShee
   /* Either execute or defer the function */
   if (isFunction(chunk)) {
     if (executionContext) {
-      let shouldThrow = false;
+      if (process.env.NODE_ENV !== 'production') {
+        let shouldThrow = false;
 
-      try {
-        // eslint-disable-next-line new-cap
-        if (isElement(new chunk(executionContext))) {
-          shouldThrow = true;
+        try {
+          // eslint-disable-next-line new-cap
+          if (isElement(new chunk(executionContext))) {
+            shouldThrow = true;
+          }
+        } catch (e) {
+          /* */
         }
-      } catch (e) {
-        /* */
-      }
 
-      if (shouldThrow) {
-        throw new StyledError(13, getComponentName(chunk));
+        if (shouldThrow) {
+          throw new StyledError(13, getComponentName(chunk));
+        }
       }
 
       return flatten(chunk(executionContext), executionContext, styleSheet);


### PR DESCRIPTION
This production guard was removed in https://github.com/styled-components/styled-components/commit/9a2ad9db4d50752e32ee4292758968c0c4de7d22#diff-1626f8a40e7d0e93acaa5ca5370598a4.

I'm not sure why that was the case but this is causing quite a bad performance hit in our medium/large sized application. Things seem to slow down quite a bit because of the new operator usage.

Is it possible to avoid the use of the new operator here in development as well? It causes a very noticeable delay when components are mounting (And this seems to be only noticeable in large sized applications that have a lot of dynamic styled components). This was not an issue in v3.