### PR TITLE
Fix macro with ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 - Compatibility with react-native-web 0.11 (see [#2453](https://github.com/styled-components/styled-components/issues/2453)).
 
 - Add stack trace to .attrs warning (see [#2486](https://github.com/styled-components/styled-components/issues/2486)).
+
 - Fix functions as values for object literals. (see [2489](https://github.com/styled-components/styled-components/pull/2489))
+
+- Remove validation in Babel macro, by [@mAAdhaTTah](http://github.com/mAAdhaTTah) (see [#2427](https://github.com/styled-components/styled-components/pull/2427))
 
 ## [v4.2.0] - 2019-03-23
 

--- a/packages/styled-components/src/macro/index.js
+++ b/packages/styled-components/src/macro/index.js
@@ -1,10 +1,7 @@
 // @flow
-import { createMacro, MacroError } from 'babel-plugin-macros';
+import { createMacro } from 'babel-plugin-macros';
 import babelPlugin from 'babel-plugin-styled-components';
 import { addDefault, addNamed } from '@babel/helper-module-imports';
-import * as styled from '..';
-
-const allowedImports: Array<string> = Object.keys(styled).filter(helper => helper !== '__esModule');
 
 function styledComponentsMacro({ references, state, babel: { types: t }, config = {} }) {
   const program = state.file.path;
@@ -14,14 +11,6 @@ function styledComponentsMacro({ references, state, babel: { types: t }, config 
   // { default: [path, path], css: [path], ... }
   let customImportName;
   Object.keys(references).forEach(refName => {
-    if (!allowedImports.includes(refName)) {
-      throw new MacroError(
-        `Invalid import: ${refName}. You can only import ${allowedImports.join(
-          ', '
-        )} from 'styled-components/macro'.`
-      );
-    }
-
     // generate new identifier
     let id;
     if (refName === 'default') {

--- a/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
@@ -190,3 +190,24 @@ _styled.div.withConfig({
 })(['background:', ';'], p => p.error ? 'red' : 'green');
 "
 `;
+
+exports[`macro should work with types alongside import: should work with types alongside import 1`] = `
+"
+import styled, { DefaultTheme } from '../../macro'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { DefaultTheme as _DefaultTheme } from 'styled-components';
+import _styled from 'styled-components';
+"
+`;
+
+exports[`macro should work with types: should work with types 1`] = `
+"
+import { DefaultTheme } from '../../macro'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { DefaultTheme as _DefaultTheme } from 'styled-components';
+"
+`;

--- a/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
@@ -140,6 +140,17 @@ _styled.div.withConfig({
 "
 `;
 
+exports[`macro should work with multiple imports: should work with multiple imports 1`] = `
+"
+import styled, { css } from '../../macro'
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { css as _css } from 'styled-components';
+import _styled from 'styled-components';
+"
+`;
+
 exports[`macro should work with require() to import styled-components: should work with require() to import styled-components 1`] = `
 "
 const styled = require('../../macro')

--- a/packages/styled-components/src/macro/test/macro.test.js
+++ b/packages/styled-components/src/macro/test/macro.test.js
@@ -79,8 +79,12 @@ styled.div\`
 \`
 `;
 
-const invalidExampleCode = `
-import { UnknownImport } from '../../macro'
+const withTypeImportExampleCode = `
+import { DefaultTheme } from '../../macro'
+`;
+
+const withTypeAndStandardImportExampleCode = `
+  import styled, { DefaultTheme } from '../../macro'
 `;
 
 pluginTester({
@@ -98,11 +102,8 @@ pluginTester({
     'should work when extending a component': extendsExampleCode,
     'should work with multiple imports': multipleImportsExampleCode,
     'should work with require() to import styled-components': requireExampleCode,
-    'should throw error when importing { UnknownImport }': {
-      code: invalidExampleCode,
-      error: true,
-      snapshot: false,
-    },
+    'should work with types': withTypeImportExampleCode,
+    'should work with types alongside import': withTypeAndStandardImportExampleCode,
     'should not add componentId with a config disabling ssr': {
       code: styledExampleCode,
       setup: () => {

--- a/packages/styled-components/src/macro/test/macro.test.js
+++ b/packages/styled-components/src/macro/test/macro.test.js
@@ -67,6 +67,10 @@ styled(Hello)\`
 \`
 `;
 
+const multipleImportsExampleCode = `
+import styled, { css } from '../../macro'
+`
+
 const requireExampleCode = `
 const styled = require('../../macro')
 
@@ -92,6 +96,7 @@ pluginTester({
     'should work with { createGlobalStyle }': createGlobalStyleExampleCode,
     'should work with { ThemeProvider }': ThemeProviderExampleCode,
     'should work when extending a component': extendsExampleCode,
+    'should work with multiple imports': multipleImportsExampleCode,
     'should work with require() to import styled-components': requireExampleCode,
     'should throw error when importing { UnknownImport }': {
       code: invalidExampleCode,


### PR DESCRIPTION
Fixes #2378. That issue will mistakenly closed, as the issue lives in the macro, not in the types. I figured providing a solution would help clarify the issue.

I also added a test for multiple imports, as I didn't expect to see them split in the test I wrote, so I wanted to confirm and test that behavior before I added my change.