### PR TITLE
Reduce GC pressure by avoiding to create new object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Fix memory leak issue when using component selector styles. (see [#2424](https://github.com/styled-components/styled-components/issues/2424)).
+
 - Make the `GlobalStyleComponent` created by `createGlobalStyle` call the base constructor with `props` (see [#2321](https://github.com/styled-components/styled-components/pull/2321)).
 
 - Move to Mono repository structure with lerna [@imbhargav5](https://github.com/imbhargav5) (see [#2326](https://github.com/styled-components/styled-components/pull/2326))
+
 
 ## [v4.1.3] - 2018-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- Fix memory leak issue when using component selector styles. (see [#2424](https://github.com/styled-components/styled-components/issues/2424)).
+- Reduced GC pressure when using component selector styles. (see [#2424](https://github.com/styled-components/styled-components/issues/2424)).
 
 - Make the `GlobalStyleComponent` created by `createGlobalStyle` call the base constructor with `props` (see [#2321](https://github.com/styled-components/styled-components/pull/2321)).
 
 - Move to Mono repository structure with lerna [@imbhargav5](https://github.com/imbhargav5) (see [#2326](https://github.com/styled-components/styled-components/pull/2326))
-
 
 ## [v4.1.3] - 2018-12-17
 

--- a/packages/styled-components/src/utils/flatten.js
+++ b/packages/styled-components/src/utils/flatten.js
@@ -2,6 +2,7 @@
 import { isElement } from 'react-is';
 import getComponentName from './getComponentName';
 import isFunction from './isFunction';
+import isStatelessFunction from './isStatelessFunction';
 import isPlainObject from './isPlainObject';
 import isStyledComponent from './isStyledComponent';
 import Keyframes from '../models/Keyframes';
@@ -55,12 +56,13 @@ export default function flatten(chunk: any, executionContext: ?Object, styleShee
 
   /* Either execute or defer the function */
   if (isFunction(chunk)) {
-    if (executionContext) {
+    if (isStatelessFunction(chunk) && executionContext) {
       let shouldThrow = false;
 
+      const result = chunk(executionContext);
+
       try {
-        // eslint-disable-next-line new-cap
-        if (isElement(new chunk(executionContext))) {
+        if (isElement(result)) {
           shouldThrow = true;
         }
       } catch (e) {
@@ -71,7 +73,7 @@ export default function flatten(chunk: any, executionContext: ?Object, styleShee
         throw new StyledError(13, getComponentName(chunk));
       }
 
-      return flatten(chunk(executionContext), executionContext, styleSheet);
+      return flatten(result, executionContext, styleSheet);
     } else return chunk;
   }
 

--- a/packages/styled-components/src/utils/flatten.js
+++ b/packages/styled-components/src/utils/flatten.js
@@ -57,19 +57,9 @@ export default function flatten(chunk: any, executionContext: ?Object, styleShee
   /* Either execute or defer the function */
   if (isFunction(chunk)) {
     if (isStatelessFunction(chunk) && executionContext) {
-      let shouldThrow = false;
-
       const result = chunk(executionContext);
 
-      try {
-        if (isElement(result)) {
-          shouldThrow = true;
-        }
-      } catch (e) {
-        /* */
-      }
-
-      if (shouldThrow) {
+      if (isElement(result)) {
         throw new StyledError(13, getComponentName(chunk));
       }
 

--- a/packages/styled-components/src/utils/flatten.js
+++ b/packages/styled-components/src/utils/flatten.js
@@ -8,7 +8,6 @@ import isStyledComponent from './isStyledComponent';
 import Keyframes from '../models/Keyframes';
 import hyphenate from './hyphenateStyleName';
 import addUnitIfNeeded from './addUnitIfNeeded';
-import StyledError from './error';
 
 /**
  * It's falsish not falsy because 0 is allowed.
@@ -59,8 +58,13 @@ export default function flatten(chunk: any, executionContext: ?Object, styleShee
     if (isStatelessFunction(chunk) && executionContext) {
       const result = chunk(executionContext);
 
-      if (isElement(result)) {
-        throw new StyledError(13, getComponentName(chunk));
+      if (process.env.NODE_ENV !== 'production' && isElement(result)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `${getComponentName(
+            chunk
+          )} is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.`
+        );
       }
 
       return flatten(result, executionContext, styleSheet);

--- a/packages/styled-components/src/utils/isStatelessFunction.js
+++ b/packages/styled-components/src/utils/isStatelessFunction.js
@@ -1,0 +1,10 @@
+// @flow
+export default function isStatelessFunction(test: any): boolean {
+  return (
+    typeof test === 'function'
+    && !(
+      test.prototype
+      && test.prototype.isReactComponent
+    )
+  );
+}

--- a/packages/styled-components/src/utils/test/flatten.test.js
+++ b/packages/styled-components/src/utils/test/flatten.test.js
@@ -117,6 +117,7 @@ describe('flatten', () => {
   });
 
   it('throws if trying to interpolate a normal React component', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     const Foo = ({ className }) => <div className={className}>hello there!</div>;
 
     const Bar = styled.div`
@@ -125,7 +126,9 @@ describe('flatten', () => {
       };
     `;
 
-    expect(() => TestRenderer.create(<Bar />)).toThrowErrorMatchingInlineSnapshot(
+    TestRenderer.create(<Bar />);
+
+    expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
       `"Foo is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details."`
     );
   });

--- a/packages/styled-components/src/utils/test/isStatelessFunction.test.js
+++ b/packages/styled-components/src/utils/test/isStatelessFunction.test.js
@@ -1,0 +1,23 @@
+// @flow
+import React, { Component } from 'react';
+import styled from '../../';
+import isStatelessFunction from '../isStatelessFunction';
+
+class MockComponent extends Component {
+  render() {
+    return <div {...this.props} />
+  }
+}
+describe('isStatelessFunction(something)', () => {
+  it('returns true if stateless', () => {
+    expect(isStatelessFunction(() => {})).toBe(true);
+
+  });
+
+  it('returns false for everything else', () => {
+    expect(isStatelessFunction(styled.div``)).toBe(false);
+    expect(isStatelessFunction(MockComponent)).toBe(false);
+    expect(isStatelessFunction({})).toBe(false);
+    expect(isStatelessFunction([])).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2424 

If you inspect the issue, you will see there is a major GC collector happening. `flatten` function is called a lot of times and every time we interpolate some style that code block is executed.

I'm avoiding to do `new chunk` and, instead, replaced with a new util called `isStatelessFunction`.