### PR TITLE
ADD tests for multiple styleFns & styleObjs

### DIFF
--- a/packages/styled-components/src/test/basic.test.js
+++ b/packages/styled-components/src/test/basic.test.js
@@ -127,6 +127,33 @@ describe('basic', () => {
     expectCSSMatches('.b { color:blue; }');
   });
 
+  it('should allow you to pass in multiple functions returning a style objects', () => {
+    const Comp = styled.div(
+      ({ color }) => ({ color }),
+      ({ color }) => ({ borderColor: color })
+    );
+    TestRenderer.create(<Comp color="blue" />);
+    expectCSSMatches('.b { color:blue; border-color:blue; }');
+  });
+
+  it('should allow you to pass in multiple style objects', () => {
+    const Comp = styled.div(
+      { color: 'blue' },
+      { borderColor: 'blue' }
+    );
+    TestRenderer.create(<Comp />);
+    expectCSSMatches('.b { color:blue; border-color:blue; }');
+  });
+
+  it('should allow you to pass in a combination functions and style objects', () => {
+    const Comp = styled.div(
+      ({ color }) => ({ color }),
+      { borderColor: 'blue' }
+    );
+    TestRenderer.create(<Comp color="blue" />);
+    expectCSSMatches('.b { color:blue; border-color:blue; }');
+  });
+
   it('emits the correct selector when a StyledComponent is interpolated into a template string', () => {
     const Comp = styled.div`
       color: red;


### PR DESCRIPTION
Styled-components supports this right?

```js
styled.div(
  ({ color }) => ({ color }),
  ({ color }) => ({ borderColor: color })
);
```

&

```js
styled.div(
  { color: 'blue' },
  { borderColor: 'blue' }
);
```

I couldn't find any tests for this behavior.