### PR TITLE
Compatibility with react-native-web 0.11

### DIFF
--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 /* eslint-disable import/no-unresolved */
-import reactNative from 'react-native';
+import * as reactNative from 'react-native';
 
 import _InlineStyle from '../models/InlineStyle';
 import _StyledNativeComponent from '../models/StyledNativeComponent';

--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 /* eslint-disable import/no-unresolved */
-import * as reactNative from 'react-native';
+import reactNative, { StyleSheet } from 'react-native';
 
 import _InlineStyle from '../models/InlineStyle';
 import _StyledNativeComponent from '../models/StyledNativeComponent';
@@ -14,7 +14,7 @@ import isStyledComponent from '../utils/isStyledComponent';
 
 import type { Target } from '../types';
 
-const InlineStyle = _InlineStyle(reactNative.StyleSheet);
+const InlineStyle = _InlineStyle(StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);
 const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag);
 


### PR DESCRIPTION
Using styled-components with react-native-web broke after upgrading to react-native-web 0.11, as they removed the legacy default export, see https://github.com/necolas/react-native-web/releases. This provides a fix by using `import * as` which seems more idiomatic anyways.