### PR TITLE
fix: ensure nonce can be found and applied

### DIFF
--- a/packages/styled-components/src/utils/nonce.js
+++ b/packages/styled-components/src/utils/nonce.js
@@ -1,6 +1,13 @@
 // @flow
-/* eslint-disable camelcase, no-undef */
+/* eslint-disable camelcase, no-undef, no-nested-ternary */
 
 declare var __webpack_nonce__: string;
 
-export default () => (typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : null);
+export default (global => () => {
+  if (typeof global.__webpack_nonce__ !== 'undefined') {
+    return global.__webpack_nonce__;
+  } else if (typeof __webpack_nonce__ !== 'undefined') {
+    return __webpack_nonce__;
+  }
+  return null;
+})(typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : {});


### PR DESCRIPTION
fix #2363 

When applying a nonce in a client side only environment, prior to this change strict scoping in modules limits the ability to access __webpack_nonce__ if it doesn't exist on the window or global object

This change checks global and window for the presence of __webpack_nonce__ before checking the variable itself to alleviate that scoping issue, and only uses the first one that exists. 