### PR TITLE
Add stack trace to .attrs warning

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -73,7 +73,8 @@ class StyledComponent extends Component<*> {
         (key, displayName): void =>
           // eslint-disable-next-line no-console
           console.warn(
-            `Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "${key}" on component "${displayName}".`
+            `Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "${key}" on component "${displayName}".`,
+            `\n ${(new Error()).stack}`
           )
       );
 

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -41,7 +41,8 @@ class StyledNativeComponent extends Component<*, *> {
         (key, displayName): void =>
           // eslint-disable-next-line no-console
           console.warn(
-            `Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "${key}" on component "${displayName}".`
+            `Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "${key}" on component "${displayName}".`,
+            `\n ${(new Error()).stack}`
           )
       );
 

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -390,6 +390,9 @@ For example, { component: () => InnerComponent } instead of { component: InnerCo
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
         `"Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is \\"data-text-color\\" on component \\"Styled(View)\\"."`
       );
+      expect(console.warn.mock.calls[0][1]).toEqual(
+        expect.stringMatching(/^\s+Error\s+at/)
+      );
     });
   });
 });

--- a/packages/styled-components/src/primitives/test/primitives.test.js
+++ b/packages/styled-components/src/primitives/test/primitives.test.js
@@ -357,6 +357,9 @@ For example, { component: () => InnerComponent } instead of { component: InnerCo
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
         `"Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is \\"data-text-color\\" on component \\"Styled(View)\\"."`
       );
+      expect(console.warn.mock.calls[0][1]).toEqual(
+        expect.stringMatching(/^\s+Error\s+at/)
+      );
     });
   });
 });

--- a/packages/styled-components/src/test/attrs.test.js
+++ b/packages/styled-components/src/test/attrs.test.js
@@ -290,6 +290,9 @@ For example, { component: () => InnerComponent } instead of { component: InnerCo
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
         `"Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is \\"data-text-color\\" on component \\"styled.div\\"."`
       );
+      expect(console.warn.mock.calls[0][1]).toEqual(
+        expect.stringMatching(/^\s+Error\s+at/)
+      );
     });
   });
 });


### PR DESCRIPTION
Addresses #2481 

I was thinking of `warn` utility that handles all warnings and attach stack trace, but I'm not sure if this will be used for all warnings 