### PR TITLE
update DISABLE_SPEEDY to use webpack environment variable 

### DIFF
--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -10,7 +10,7 @@ export const SC_STREAM_ATTR = 'data-styled-streamed';
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
 export const DISABLE_SPEEDY =
-  (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
+  typeof SC_DISABLE_SPEEDY === 'boolean' ? SC_DISABLE_SPEEDY :
   process.env.NODE_ENV !== 'production';
 
 // Shared empty execution context when generating static styles


### PR DESCRIPTION
When the Webpack config variable `SC_DISABLE_SPEEDY` is set to false it will not be used currently, this fixes that to allow this to be disabled even in development.