### PR TITLE
fix bug where style tag has been removed from the DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Ensure style tag is present in the head when calling insertRules on the browser tag. (see [#2498](https://github.com/styled-components/styled-components/pull/2498))
+
 ## [v4.2.0] - 2019-03-23
 
 - Reduced GC pressure when using component selector styles. (see [#2424](https://github.com/styled-components/styled-components/issues/2424)).

--- a/packages/styled-components/src/models/StyleTags.js
+++ b/packages/styled-components/src/models/StyleTags.js
@@ -255,6 +255,13 @@ const makeBrowserTag = (el: HTMLStyleElement, getImportRuleTag: ?() => Tag<any>)
     const importRules = [];
     const cssRulesSize = cssRules.length;
 
+    if (IS_BROWSER && !el.parentElement) {
+      const { head } = document;
+      if (head) {
+        head.appendChild(el);
+      }
+    }
+
     for (let i = 0; i < cssRulesSize; i += 1) {
       const rule = cssRules[i];
       let mayHaveImport = extractImport;


### PR DESCRIPTION
Due to how [rehydrate](https://github.com/styled-components/styled-components/blob/c3eedbeb79621acd668e15ed2d63107528ed81c3/packages/styled-components/src/models/StyleTags.js#L410) works, there is a scenario where the `Tag.styleTag` will be an element that has been removed from the DOM causing styles not to be rendered. 

This is happening for us because there is another javascript bundle being loaded on our page after our style tag has been created with the same version of styled-components. 

This ensures the style tag be added back to the DOM before trying to insertRules to it. There may be a better approach here but this is the simplest fix as far as I can tell.

 I did not see existing tests for `insertRules` or I would have added one.