### PR TITLE
Make possible to initialize SC_ATTR via REACT_APP_SC_ATTR env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file. If a contri
 _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/)._
 
 ## Unreleased
-- Make possible to initialize `SC_ATTR` and `SC_DISABLE_SPEEDY` via `REACT_APP_*` .env variables for easier integration with CRA applications  (see [#2501](https://github.com/styled-components/styled-components/pull/2501))
+
+- Make it possible to initialize `SC_ATTR` and `SC_DISABLE_SPEEDY` via `REACT_APP_*` .env variables for easier integration with CRA applications (see [#2501](https://github.com/styled-components/styled-components/pull/2501))
 
 - Fix components being folded inappropriately when an interim HOC is present (see [#2586](https://github.com/styled-components/styled-components/issues/2586))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. If a contri
 _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/)._
 
 ## Unreleased
-- Make possible to initialize SC_ATTR via REACT_APP_SC_ATTR env variable (see [#2501](https://github.com/styled-components/styled-components/pull/2501))
+- Make possible to initialize `SC_ATTR` and `SC_DISABLE_SPEEDY` via `REACT_APP_*` .env variables for easier integration with CRA applications  (see [#2501](https://github.com/styled-components/styled-components/pull/2501))
 
 - Fix components being folded inappropriately when an interim HOC is present (see [#2586](https://github.com/styled-components/styled-components/issues/2586))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. If a contri
 _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/)._
 
 ## Unreleased
+- Make possible to initialize SC_ATTR via REACT_APP_SC_ATTR env variable (see [#2501](https://github.com/styled-components/styled-components/pull/2501))
 
 - Fix components being folded inappropriately when an interim HOC is present (see [#2586](https://github.com/styled-components/styled-components/issues/2586))
 

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -13,7 +13,6 @@ export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in wind
 
 export const DISABLE_SPEEDY =
   (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
-  (process.env.REACT_APP_SC_DISABLE_SPEEDY || process.env.SC_DISABLE_SPEEDY) ||
   process.env.NODE_ENV !== 'production';
 
 // Shared empty execution context when generating static styles

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -13,6 +13,8 @@ export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in wind
 
 export const DISABLE_SPEEDY =
   (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
+  (typeof process !== 'undefined' &&
+    (process.env.REACT_APP_SC_DISABLE_SPEEDY || process.env.SC_DISABLE_SPEEDY)) ||
   process.env.NODE_ENV !== 'production';
 
 // Shared empty execution context when generating static styles

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -1,7 +1,9 @@
 // @flow
 declare var SC_DISABLE_SPEEDY: ?boolean;
 
-export const SC_ATTR = (typeof process !== 'undefined' && process.env.SC_ATTR) || 'data-styled';
+export const SC_ATTR =
+  (typeof process !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
+  'data-styled';
 
 export const SC_VERSION_ATTR = 'data-styled-version';
 

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -13,6 +13,7 @@ export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in wind
 
 export const DISABLE_SPEEDY =
   (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
+  (process.env.REACT_APP_SC_DISABLE_SPEEDY || process.env.SC_DISABLE_SPEEDY) ||
   process.env.NODE_ENV !== 'production';
 
 // Shared empty execution context when generating static styles

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -74,6 +74,8 @@ describe('constants', () => {
     afterEach(() => {
       process.env.NODE_ENV = 'test';
       delete process.env.DISABLE_SPEEDY;
+      delete process.env.SC_DISABLE_SPEEDY;
+      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
     });
 
     it('should be false in production NODE_ENV when SC_DISABLE_SPEEDY is not set', () => {
@@ -92,6 +94,16 @@ describe('constants', () => {
 
     it('should be true in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to true', () => {
       window.SC_DISABLE_SPEEDY = true;
+      renderAndExpect(true, '.b { color:blue; }');
+    });
+
+    it('should be true when SC_DISABLE_SPEEDY env is set to true', () => {
+      process.env.SC_DISABLE_SPEEDY = true;
+      renderAndExpect(true, '.b { color:blue; }');
+    });
+
+    it('should be true when REACT_APP_SC_DISABLE_SPEEDY env is set to true', () => {
+      process.env.REACT_APP_SC_DISABLE_SPEEDY = true;
       renderAndExpect(true, '.b { color:blue; }');
     });
 

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -74,8 +74,6 @@ describe('constants', () => {
     afterEach(() => {
       process.env.NODE_ENV = 'test';
       delete process.env.DISABLE_SPEEDY;
-      delete process.env.SC_DISABLE_SPEEDY;
-      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
     });
 
     it('should be false in production NODE_ENV when SC_DISABLE_SPEEDY is not set', () => {
@@ -94,16 +92,6 @@ describe('constants', () => {
 
     it('should be true in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to true', () => {
       window.SC_DISABLE_SPEEDY = true;
-      renderAndExpect(true, '.b { color:blue; }');
-    });
-
-    it('should be true when SC_DISABLE_SPEEDY env is set to true', () => {
-      process.env.SC_DISABLE_SPEEDY = true;
-      renderAndExpect(true, '.b { color:blue; }');
-    });
-
-    it('should be true when REACT_APP_SC_DISABLE_SPEEDY env is set to true', () => {
-      process.env.REACT_APP_SC_DISABLE_SPEEDY = true;
       renderAndExpect(true, '.b { color:blue; }');
     });
 

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable global-require */
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
@@ -12,7 +13,7 @@ describe('constants', () => {
 
   describe('SC_ATTR', () => {
     function renderAndExpect(expectedAttr) {
-      const SC_ATTR = require('../constants').SC_ATTR;
+      const { SC_ATTR } = require('../constants');
       const styled = require('./utils').resetStyled();
 
       const Comp = styled.div`
@@ -54,7 +55,7 @@ describe('constants', () => {
 
   describe('DISABLE_SPEEDY', () => {
     function renderAndExpect(expectedDisableSpeedy, expectedCss) {
-      const DISABLE_SPEEDY = require('../constants').DISABLE_SPEEDY;
+      const { DISABLE_SPEEDY } = require('../constants');
       const styled = require('./utils').resetStyled();
 
       const Comp = styled.div`
@@ -103,6 +104,20 @@ describe('constants', () => {
     it('should be true in development NODE_ENV', () => {
       process.env.NODE_ENV = 'development';
       renderAndExpect(true, '.b { color:blue; }');
+    });
+
+    it('should work with SC_DISABLE_SPEEDY environment variable', () => {
+      process.env.SC_DISABLE_SPEEDY = true;
+      renderAndExpect(true, '.b { color:blue; }');
+
+      delete process.env.SC_DISABLE_SPEEDY;
+    });
+
+    it('should work with REACT_APP_SC_DISABLE_SPEEDY environment variable', () => {
+      process.env.REACT_APP_SC_DISABLE_SPEEDY = true;
+      renderAndExpect(true, '.b { color:blue; }');
+
+      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
     });
   });
 });

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -40,6 +40,16 @@ describe('constants', () => {
 
       delete process.env.SC_ATTR;
     });
+
+    it('should work with REACT_APP_SC_ATTR', () => {
+      const REACT_APP_CUSTOM_SC_ATTR = 'data-custom-react_app-styled-components';
+      process.env.REACT_APP_SC_ATTR = REACT_APP_CUSTOM_SC_ATTR;
+      jest.resetModules();
+
+      renderAndExpect(REACT_APP_CUSTOM_SC_ATTR);
+
+      delete process.env.REACT_APP_SC_ATTR;
+    });
   });
 
   describe('DISABLE_SPEEDY', () => {


### PR DESCRIPTION
When working with two or more different styled-components instances on a single page (or application), `SC_ATTR` environment variable could be used for distinguishing between those instances.

However, in create-react-app based applications, environment variables are filtered out by matching them with a well-known pattern (`REACT_APP_`) -> [see here](https://github.com/facebook/create-react-app/blob/bffc296a2c8967d46bed40d3120d82f2752496dc/packages/react-scripts/config/env.js#L73).

This PR enables usage of `REACT_APP_SC_ATTR` environment variable as a fallback and its easier configuration via a `.env` file.