### PR TITLE
Feature: toggling vendor styles on and off

### DIFF
--- a/packages/styled-components/src/utils/stringifyRules.js
+++ b/packages/styled-components/src/utils/stringifyRules.js
@@ -19,7 +19,7 @@ const stylis = new Stylis({
   global: false,
   cascade: true,
   keyframe: false,
-  prefix: true,
+  prefix: process.env.STYLIS_SHOULD_PREFIX === undefined,
   compress: false,
   semicolon: false, // NOTE: This means "autocomplete missing semicolons"
 });

--- a/packages/styled-components/src/utils/test/stringifyRules.test.js
+++ b/packages/styled-components/src/utils/test/stringifyRules.test.js
@@ -1,0 +1,41 @@
+// @flow
+
+/**
+ * @todo could do the same for `compress`
+ */
+describe('stringifyRules', () => {
+  afterAll(() => {
+    delete process.env.STYLIS_SHOULD_PREFIX
+  })
+  describe('prefixes', () => {
+    it('should stringify with prefixes by default', () => {
+      jest.resetModules()
+      const stringifyRules = require('../stringifyRules').default
+
+      const [stringifiedSelect] = stringifyRules([`user-select: none;`], '');
+      expect(stringifiedSelect).toContain('-webkit-user-select');
+      expect(stringifiedSelect).toContain('-moz-user-select');
+      expect(stringifiedSelect).toContain('user-select:none;');
+
+      const [stringifiedDisplayFlex] = stringifyRules([`display: flex;`], '');
+      expect(stringifiedDisplayFlex).toContain('-webkit-box');
+      expect(stringifiedDisplayFlex).toContain('-webkit-flex');
+      expect(stringifiedDisplayFlex).toContain('-ms-flexbox');
+      expect(stringifiedDisplayFlex).toContain('display:flex;');
+    });
+
+    it('should stringify without prefixes if the env is set', () => {
+      jest.resetModules()
+      process.env.STYLIS_SHOULD_PREFIX = 'true'
+      const stringifyRules = require('../stringifyRules').default
+
+      const [stringifiedSelect] = stringifyRules([`user-select: none;`], '');
+      expect(stringifiedSelect).not.toContain('-moz-user-select');
+      expect(stringifiedSelect).toEqual('{user-select:none;}');
+
+      const [stringifiedDisplayFlex] = stringifyRules([`display: flex;`], '');
+      expect(stringifiedDisplayFlex).not.toContain('-webkit-box');
+      expect(stringifiedDisplayFlex).toEqual('{display:flex;}');
+    });
+  });
+});


### PR DESCRIPTION
- https://github.com/styled-components/styled-components/issues/719 (_toggling vendor prefixing on/off_)
- https://github.com/styled-components/styled-components/issues/1934 (_5.0 Roadmap_)

- This is implemented using `process.env`, though we could implement it many other ways, since stylis is instantiated immediately, this is the most straight forward & minimal way to achieve the feature, and will have no performance impact if a bundler defines the env & dead code elimination takes place. Please suggest if you have a preferred approach to achieving an implementation of this feature. It could also be moved to [constants](https://github.com/styled-components/styled-components/blob/canary/packages/styled-components/src/constants.js) file.

- A test suite for `stringifyRules` is created
- Two test cases are added, both of them use `jest.resetModules()` to ensure the `stringifyRules` file is evaluated with the updated process.env, only for this test case
1. To check the default functionality (having prefixes)
2. With the `STYLIS_SHOULD_PREFIX` env set, expect that there are no prefixes
- teardown/afterAll ensures the process.env is reset