### PR TITLE
Fix displayName for ForwardRef and StyledComponent element

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -253,7 +253,7 @@ export default function createStyledComponent(target: Target, options: Object, r
   // Can not reuse the only one StyledComponent as ParentComponent
   // because we need assign different `displayName` value to it
   class ParentStyledComponent extends StyledComponent<*> {
-    static displayName = displayName;
+    static displayName = `StyledComponent(${displayName})`;
   }
 
   const { ParentComponent = ParentStyledComponent } = options;


### PR DESCRIPTION
## Fix missing displayName for styled-component v4.xx

### Changes

- Set displayName for `StyledComponent` class
- Set displayName for `ForwardRef` element

### description
- The `displayName` missing issue is caused by `v4` version which didn't set `displayName` properly
- This path is to fix the missing `displayName` issue for the snapshots from Enzyme.
- The cases for `<StyledComponent />` and `<ForwardRef />` in `shallow` rendering or `debug()`.
- Relevant Issues and PR: https://github.com/styled-components/styled-components/issues/2492, https://github.com/styled-components/styled-components/pull/2508 , https://github.com/styled-components/styled-components/issues/2507 , https://github.com/airbnb/enzyme/issues/1810,

--- 

### Code samples

**React Component <T />**

-  Used styled-component for rendering

```js
@flow

...

const FlexView = styled.div.attrs({
    className: 'FlexView',
})`

     ...css styles

`;


const Row: typeof FlexView = styled(FlexView)`
    box-sizing: border-box;
    padding: 0 16px;

    &:hover {
        background-color: ${colors.background.gray3};
    }

...

class T extends React.Component<{...}> {

    ...other methods

   rowRenderer = ({
        index,
        key,
        style,
    }: {
        index: number,
        key: number,
        style: Object,
    }) => {
        const { group } = this.props;

       ...

        return (
            <Row key={key} style={style}>
                <FlexView grow shrink>
                    <div />
                </FlexView>
            </Row>
        );
    };

  ...
};
```

### Test cases for Component `T` - `rowRenderer`

- rendered by `enzyme` and `enzyme-to-json`

```js
      const appList = shallow(
            <T group={group} ...otherProps />
        );
    
        const loader = appList.find('InfiniteLoader');
        const list = shallow(loader.prop('children')({})).find('List');
        // call the `rowRender` method to get the rendered content
        const row = list.prop('rowRenderer')({ index: 0, key: 'foo', style: {} });
        // here the snapshots got major changes between styled-component v3.xx and v4.xx
        expect(row).toMatchSnapshot('snapshot-row');

```

### Expected result for snapshot-row

- This works well for styled-component v3.xx, we got the correct `displayName` on tags in shapshots

```js

<AppList__Row
  style={Object {}}
>
  <FlexView
    grow={true}
    shrink={true}
  >
    <div />
  </FlexView>
</AppList__Row>
```

### The wrong result for snapshot-row for styled-component v4.xx

In this snapshots, the `displayName` is missing

```js
<StyledComponent
  ...
  forwardedComponent={..}
  forwardedRef={null}
  ...
>
  <ForwardRef
    grow={true}
    shrink={true}
  >
    <div />
  </ForwardRef>
</StyledComponent>
```

### Fixing result of this PR

- Set proper displayName for `ForwardRef` and `StyledComponent`
- Got the expected snapshots as below

For default snapshots, like `expect(row).toMatchSnapshot('loaded app row');`
```js

<ForwardRef(AppList__Row)
  style={Object {}}
>
  <ForwardRef(FlexView)
    grow={true}
    shrink={true}
  >
    <div />
  </ForwardRef(FlexView)>
</ForwardRef(AppList__Row)>
```

For enzyme shallow, like `expect(shallow(row)).toMatchSnapshot('loaded app row');` or `console.log(shallow(row).debug())`

```js
<StyledComponent(AppList__Row) style={{...}} forwardedComponent={{...}} forwardedRef={{...}}>
      <FlexView grow={true} shrink={true}>
        <div />
      </FlexView>
</StyledComponent(AppList__Row)>
```

