### PR TITLE
Improve error message for StyledComponentsError

### DIFF
--- a/packages/styled-components/src/utils/error.js
+++ b/packages/styled-components/src/utils/error.js
@@ -46,8 +46,8 @@ export default class StyledComponentsError extends Error {
   constructor(code: string | number, ...interpolations: Array<any>) {
     if (process.env.NODE_ENV === 'production') {
       super(
-        `An error occurred. See https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/errors.md#${code} for more information. ${
-          interpolations ? `Additional arguments: ${interpolations.join(', ')}` : ''
+        `An error occurred. See https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/errors.md#${code} for more information.${
+          interpolations.length > 0 ? ` Additional arguments: ${interpolations.join(', ')}` : ''
         }`
       );
     } else {

--- a/packages/styled-components/src/utils/test/__snapshots__/error.test.js.snap
+++ b/packages/styled-components/src/utils/test/__snapshots__/error.test.js.snap
@@ -9,6 +9,6 @@ exports[`development returns a rich error 1`] = `
 - Are you accidentally calling collectStyles twice?"
 `;
 
-exports[`production returns an error link 1`] = `"An error occurred. See https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/errors.md#2 for more information. Additional arguments: "`;
+exports[`production returns an error link 1`] = `"An error occurred. See https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/errors.md#2 for more information."`;
 
 exports[`production returns an error link with interpolations if given 1`] = `"An error occurred. See https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/errors.md#1 for more information. Additional arguments: foo"`;


### PR DESCRIPTION
Improve error message for `StyledComponentsError` when no additional arguments are provided.

Tiny little thing I found. The variable `interpolations` will always evaluate to true, since `[]` is a truthy value 😄 .