### PR TITLE
Fix theme detection in react native when no ThemeProvider is used

### DIFF
--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -79,7 +79,7 @@ class StyledNativeComponent extends Component<*, *> {
             const themeProp = determineTheme(this.props, theme, defaultProps);
             generatedStyles = this.generateAndInjectStyles(themeProp, this.props);
           } else {
-            generatedStyles = this.generateAndInjectStyles(theme || EMPTY_OBJECT, this.props);
+            generatedStyles = this.generateAndInjectStyles(this.props.theme || EMPTY_OBJECT, this.props);
           }
 
           const propsForElement = {


### PR DESCRIPTION
This fixes #2367, the previous code would result in the always being set to EMPTY_OBJECT. This brings it in line with the same code in [StyledComponent.js](https://github.com/styled-components/styled-components/blob/772280915f3ce342181d55b6b0e1f6fc5050b67f/packages/styled-components/src/models/StyledComponent.js#L130-L133). 