### PR TITLE
Fix #2367 in a cleaner way, but with more refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Fix `theme` prop for styled native components, also fixes `theme` in
+  `defaultProps` for them.
+
 ## [v4.2.1] - 2019-05-30
 
 - Remove className usage checker dev utility due to excessive false-positive noise in certain runtime environments like next.js and the related warning suppression prop (see [#2563](https://github.com/styled-components/styled-components/issues/2563)).

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -115,14 +115,9 @@ class StyledComponent extends Component<*> {
     let generatedClassName;
     if (componentStyle.isStatic) {
       generatedClassName = this.generateAndInjectStyles(EMPTY_OBJECT, this.props);
-    } else if (theme !== undefined) {
-      generatedClassName = this.generateAndInjectStyles(
-        determineTheme(this.props, theme, defaultProps),
-        this.props
-      );
     } else {
       generatedClassName = this.generateAndInjectStyles(
-        this.props.theme || EMPTY_OBJECT,
+        determineTheme(this.props, theme, defaultProps) || EMPTY_OBJECT,
         this.props
       );
     }

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -74,13 +74,10 @@ class StyledNativeComponent extends Component<*, *> {
 
           const { defaultProps, displayName, target } = forwardedComponent;
 
-          let generatedStyles;
-          if (theme !== undefined) {
-            const themeProp = determineTheme(this.props, theme, defaultProps);
-            generatedStyles = this.generateAndInjectStyles(themeProp, this.props);
-          } else {
-            generatedStyles = this.generateAndInjectStyles(theme || EMPTY_OBJECT, this.props);
-          }
+          const generatedStyles = this.generateAndInjectStyles(
+            determineTheme(this.props, theme, defaultProps) || EMPTY_OBJECT,
+            this.props,
+          );
 
           const propsForElement = {
             ...this.attrs,

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -295,6 +295,37 @@ describe('native', () => {
         style: [{}],
       });
     });
+
+    it('theme prop works', () => {
+      const Comp = styled.Text`
+        color: ${({theme}) => theme.myColor};
+      `;
+
+      const wrapper = TestRenderer.create(
+        <Comp theme={{myColor: 'red'}}>Something else</Comp>
+      );
+      const text = wrapper.root.findByType('Text');
+
+      expect(text.props.style).toMatchObject(
+        [{"color": "red"}],
+      );
+    });
+
+    it('theme in defaultProps works', () => {
+      const Comp = styled.Text`
+        color: ${({theme}) => theme.myColor};
+      `;
+      Comp.defaultProps = {theme: {myColor: 'red'}}
+
+      const wrapper = TestRenderer.create(
+        <Comp>Something else</Comp>
+      );
+      const text = wrapper.root.findByType('Text');
+
+      expect(text.props.style).toMatchObject(
+        [{"color": "red"}],
+      );
+    });
   });
 
   describe('expanded API', () => {


### PR DESCRIPTION
Modifies determineTheme usage, such that `theme === undefined` is also handled correctly.
This is another PR that fixes #2367, but does more refactoring as suggested in #2558.
I created this as a separate PR, so you can still easily merge #2558 if that is preferred in the end.