### PR TITLE
Fix IE11 quirk in canary when accessing cssText

### DIFF
--- a/packages/styled-components/src/sheet/Rehydration.js
+++ b/packages/styled-components/src/sheet/Rehydration.js
@@ -58,7 +58,10 @@ const rehydrateSheetFromTag = (sheet: Sheet, style: HTMLStyleElement) => {
   for (let i = 0, l = cssRules.length; i < l; i++) {
     const cssRule = (cssRules[i]: any);
 
-    if (cssRule.type !== PLAIN_RULE_TYPE) {
+    if (typeof cssRule.cssText !== 'string') {
+      // Avoid IE11 quirk where cssText is inaccessible on some invalid rules
+      continue;
+    } else if (cssRule.type !== PLAIN_RULE_TYPE) {
       rules.push(cssRule.cssText);
     } else {
       const marker = cssRule.selectorText.match(MARKER_RE);

--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -58,8 +58,10 @@ export class SpeedyTag implements Tag {
   }
 
   getRule(index: number): string {
-    if (index < this.length) {
-      return this.sheet.cssRules[index].cssText;
+    const rule = this.sheet.cssRules[index];
+    // Avoid IE11 quirk where cssText is inaccessible on some invalid rules
+    if (rule !== undefined && typeof rule.cssText === 'string') {
+      return rule.cssText;
     } else {
       return '';
     }


### PR DESCRIPTION
When inserting our CSS text, some CSS will always be invalid for the browser it loads in. So in IE11 some rules, like `-webkit` keyframes will become invalid.

Usually the spec dictates that in such a case the browser should ignore this rule and subsequently exclude it from the style element's `CSSStyleSheet`. In IE11 however there are some cases where it's not excluded.

When such an invalid rule is accessed it behaves incorrectly and when we try to access `cssText` in `Rehydration` it will throw a `Member Not Found` error. This can be prevented by checking the `typeof cssText` first.

Note: This doesn't need to be fixed on `sheet/Tag` but I felt it was safer to add it anyway.