### PR TITLE
add forwardedAs prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove validation in Babel macro, by [@mAAdhaTTah](http://github.com/mAAdhaTTah) (see [#2427](https://github.com/styled-components/styled-components/pull/2427))
 
-- Add "forwardedAs" prop to allow deeply passing a different "as" prop value to underlying components when using `styled()` as a higher-order component
-
 ## [v4.2.0] - 2019-03-23
 
 - Reduced GC pressure when using component selector styles. (see [#2424](https://github.com/styled-components/styled-components/issues/2424)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove validation in Babel macro, by [@mAAdhaTTah](http://github.com/mAAdhaTTah) (see [#2427](https://github.com/styled-components/styled-components/pull/2427))
 
+- Add "innerAs" prop to allow deeply passing a different "as" prop value to underlying components when using `styled()` as a higher-order component
+
 ## [v4.2.0] - 2019-03-23
 
 - Reduced GC pressure when using component selector styles. (see [#2424](https://github.com/styled-components/styled-components/issues/2424)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove validation in Babel macro, by [@mAAdhaTTah](http://github.com/mAAdhaTTah) (see [#2427](https://github.com/styled-components/styled-components/pull/2427))
 
-- Add "innerAs" prop to allow deeply passing a different "as" prop value to underlying components when using `styled()` as a higher-order component
+- Add "forwardedAs" prop to allow deeply passing a different "as" prop value to underlying components when using `styled()` as a higher-order component
 
 ## [v4.2.0] - 2019-03-23
 

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -209,7 +209,7 @@ function useStyledComponentImpl<Config: {}, Instance>(
   const isTargetTag = isTag(elementToBeCreated);
 
   const computedProps: Object = attrs !== props ? { ...attrs, ...props } : props;
-  const shouldFilterProps = 'as' in computedProps || 'innerAs' in computedProps || isTargetTag;
+  const shouldFilterProps = isTargetTag || 'as' in computedProps || 'forwardedAs' in computedProps;
   const propsForElement: Object = shouldFilterProps ? {} : { ...computedProps };
 
   if (process.env.NODE_ENV !== 'production' && 'innerRef' in computedProps && isTargetTag) {
@@ -219,9 +219,9 @@ function useStyledComponentImpl<Config: {}, Instance>(
   if (shouldFilterProps) {
     // eslint-disable-next-line guard-for-in
     for (const key in computedProps) {
-      if (key === 'innerAs') {
+      if (key === 'forwardedAs') {
         propsForElement.as = computedProps[key];
-      } else if (key !== 'as' && key !== 'innerAs' && (!isTargetTag || validAttr(key))) {
+      } else if (key !== 'as' && key !== 'forwardedAs' && (!isTargetTag || validAttr(key))) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -44,7 +44,7 @@ class StyledNativeComponent extends Component<*, *> {
           // eslint-disable-next-line no-console
           console.warn(
             `Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "${key}" on component "${displayName}".`,
-            `\n ${(new Error()).stack}`
+            `\n ${new Error().stack}`
           )
       );
 
@@ -69,6 +69,7 @@ class StyledNativeComponent extends Component<*, *> {
             as: renderAs,
             forwardedComponent,
             forwardedRef,
+            innerAs,
             innerRef,
             style = [],
             ...props
@@ -91,6 +92,7 @@ class StyledNativeComponent extends Component<*, *> {
           };
 
           if (forwardedRef) propsForElement.ref = forwardedRef;
+          if (innerAs) propsForElement.as = innerAs;
 
           if (process.env.NODE_ENV !== 'production' && innerRef) {
             this.warnInnerRef(displayName);

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -68,8 +68,8 @@ class StyledNativeComponent extends Component<*, *> {
           const {
             as: renderAs,
             forwardedComponent,
+            forwardedAs,
             forwardedRef,
-            innerAs,
             innerRef,
             style = [],
             ...props
@@ -92,7 +92,7 @@ class StyledNativeComponent extends Component<*, *> {
           };
 
           if (forwardedRef) propsForElement.ref = forwardedRef;
-          if (innerAs) propsForElement.as = innerAs;
+          if (forwardedAs) propsForElement.as = forwardedAs;
 
           if (process.env.NODE_ENV !== 'production' && innerRef) {
             this.warnInnerRef(displayName);

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -120,14 +120,14 @@ describe('native', () => {
     expect(wrapper.root.findByType('View').props.style).toEqual([{ paddingTop: 5, opacity: 0.9 }]);
   });
 
-  it('should forward the "as" prop if "innerAs" is used', () => {
+  it('should forward the "as" prop if "forwardedAs" is used', () => {
     const Comp = ({ as: Component = View, ...props }) => <Component {...props} />;
 
     const Comp2 = styled(Comp)`
       background: red;
     `;
 
-    const wrapper = TestRenderer.create(<Comp2 innerAs={Text} />);
+    const wrapper = TestRenderer.create(<Comp2 forwardedAs={Text} />);
 
     expect(wrapper.root.findByType('Text')).not.toBeUndefined();
   });

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable react/prop-types */
 import 'react-native';
 import { Text, View } from 'react-native';
 import React from 'react';
@@ -117,6 +118,18 @@ describe('native', () => {
     wrapper.update(<Comp opacity={0.9} />);
 
     expect(wrapper.root.findByType('View').props.style).toEqual([{ paddingTop: 5, opacity: 0.9 }]);
+  });
+
+  it('should forward the "as" prop if "innerAs" is used', () => {
+    const Comp = ({ as: Component = View, ...props }) => <Component {...props} />;
+
+    const Comp2 = styled(Comp)`
+      background: red;
+    `;
+
+    const wrapper = TestRenderer.create(<Comp2 innerAs={Text} />);
+
+    expect(wrapper.root.findByType('Text')).not.toBeUndefined();
   });
 
   describe('attrs', () => {
@@ -390,9 +403,7 @@ For example, { component: () => InnerComponent } instead of { component: InnerCo
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
         `"Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is \\"data-text-color\\" on component \\"Styled(View)\\"."`
       );
-      expect(console.warn.mock.calls[0][1]).toEqual(
-        expect.stringMatching(/^\s+Error\s+at/)
-      );
+      expect(console.warn.mock.calls[0][1]).toEqual(expect.stringMatching(/^\s+Error\s+at/));
     });
   });
 });

--- a/packages/styled-components/src/test/props.test.js
+++ b/packages/styled-components/src/test/props.test.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable react/prop-types */
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
@@ -18,6 +19,7 @@ describe('props', () => {
     TestRenderer.create(<Comp />);
     expectCSSMatches('.b { color:black; }');
   });
+
   it('should execute interpolations and inject props', () => {
     const Comp = styled.div`
       color: ${props => props.fg || 'black'};
@@ -25,6 +27,7 @@ describe('props', () => {
     TestRenderer.create(<Comp fg="red" />);
     expectCSSMatches('.b { color:red; }');
   });
+
   it('should ignore non-0 falsy object interpolations', () => {
     const Comp = styled.div`
       ${() => ({
@@ -37,5 +40,19 @@ describe('props', () => {
     `;
     TestRenderer.create(<Comp fg="red" />);
     expectCSSMatches('.b { border-width:0; }');
+  });
+
+  it('should forward the "as" prop if "innerAs" is used', () => {
+    const Comp = ({ as: Component = 'div', ...props }) => <Component {...props} />;
+
+    const Comp2 = styled(Comp)`
+      background: red;
+    `;
+
+    expect(TestRenderer.create(<Comp2 innerAs="button" />).toJSON()).toMatchInlineSnapshot(`
+      <button
+        className="sc-a"
+      />
+    `);
   });
 });

--- a/packages/styled-components/src/test/props.test.js
+++ b/packages/styled-components/src/test/props.test.js
@@ -42,17 +42,19 @@ describe('props', () => {
     expectCSSMatches('.b { border-width:0; }');
   });
 
-  it('should forward the "as" prop if "innerAs" is used', () => {
+  it('should forward the "as" prop if "forwardedAs" is used', () => {
     const Comp = ({ as: Component = 'div', ...props }) => <Component {...props} />;
 
     const Comp2 = styled(Comp)`
       background: red;
     `;
 
-    expect(TestRenderer.create(<Comp2 innerAs="button" />).toJSON()).toMatchInlineSnapshot(`
+    expect(TestRenderer.create(<Comp2 forwardedAs="button" />).toJSON()).toMatchInlineSnapshot(`
       <button
         className="sc-a"
       />
     `);
+
+    expectCSSMatches('.sc-a { background: red; }');
   });
 });


### PR DESCRIPTION
This works around the most common issue with #439 and #2545  around integrating the `styled()` HOC with other components that also accept an "as" prop