### PR TITLE
implement forwardedAs for 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 - Fix `theme` prop for styled native components, also fixes `theme` in
   `defaultProps` for them.
 
+- Add "forwardedAs" prop to allow deeply passing a different "as" prop value to underlying components
+  when using `styled()` as a higher-order component
+
 ## [v4.2.1] - 2019-05-30
 
 - Remove className usage checker dev utility due to excessive false-positive noise in certain runtime environments like next.js and the related warning suppression prop (see [#2563](https://github.com/styled-components/styled-components/issues/2563)).

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -138,6 +138,7 @@ class StyledComponent extends Component<*> {
       if (key === 'forwardedComponent' || key === 'as') {
         continue;
       } else if (key === 'forwardedRef') propsForElement.ref = computedProps[key];
+      else if (key === 'forwardedAs') propsForElement.as = computedProps[key];
       else if (!isTargetTag || validAttr(key)) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -42,7 +42,7 @@ class StyledNativeComponent extends Component<*, *> {
           // eslint-disable-next-line no-console
           console.warn(
             `Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "${key}" on component "${displayName}".`,
-            `\n ${(new Error()).stack}`
+            `\n ${new Error().stack}`
           )
       );
 
@@ -65,6 +65,7 @@ class StyledNativeComponent extends Component<*, *> {
         {(theme?: Theme) => {
           const {
             as: renderAs,
+            forwardedAs,
             forwardedComponent,
             forwardedRef,
             innerRef,
@@ -76,7 +77,7 @@ class StyledNativeComponent extends Component<*, *> {
 
           const generatedStyles = this.generateAndInjectStyles(
             determineTheme(this.props, theme, defaultProps) || EMPTY_OBJECT,
-            this.props,
+            this.props
           );
 
           const propsForElement = {
@@ -85,6 +86,7 @@ class StyledNativeComponent extends Component<*, *> {
             style: [generatedStyles].concat(style),
           };
 
+          if (forwardedAs) propsForElement.as = forwardedAs;
           if (forwardedRef) propsForElement.ref = forwardedRef;
 
           if (process.env.NODE_ENV !== 'production' && innerRef) {

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -1,5 +1,5 @@
 // @flow
-import 'react-native';
+/* eslint-disable react/prop-types */
 import { Text, View } from 'react-native';
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
@@ -117,6 +117,18 @@ describe('native', () => {
     wrapper.update(<Comp opacity={0.9} />);
 
     expect(wrapper.root.findByType('View').props.style).toEqual([{ paddingTop: 5, opacity: 0.9 }]);
+  });
+
+  it('should pass "forwardedAs" to the underlying component as "as" if used', () => {
+    const Comp = ({ as: Component = View, ...props }) => <Component {...props} />;
+
+    const Comp2 = styled(Comp)`
+      background: red;
+    `;
+
+    const wrapper = TestRenderer.create(<Comp2 forwardedAs={Text} />);
+
+    expect(wrapper.root.findByType('Text')).not.toBeUndefined();
   });
 
   describe('attrs', () => {
@@ -298,33 +310,25 @@ describe('native', () => {
 
     it('theme prop works', () => {
       const Comp = styled.Text`
-        color: ${({theme}) => theme.myColor};
+        color: ${({ theme }) => theme.myColor};
       `;
 
-      const wrapper = TestRenderer.create(
-        <Comp theme={{myColor: 'red'}}>Something else</Comp>
-      );
+      const wrapper = TestRenderer.create(<Comp theme={{ myColor: 'red' }}>Something else</Comp>);
       const text = wrapper.root.findByType('Text');
 
-      expect(text.props.style).toMatchObject(
-        [{"color": "red"}],
-      );
+      expect(text.props.style).toMatchObject([{ color: 'red' }]);
     });
 
     it('theme in defaultProps works', () => {
       const Comp = styled.Text`
-        color: ${({theme}) => theme.myColor};
+        color: ${({ theme }) => theme.myColor};
       `;
-      Comp.defaultProps = {theme: {myColor: 'red'}}
+      Comp.defaultProps = { theme: { myColor: 'red' } };
 
-      const wrapper = TestRenderer.create(
-        <Comp>Something else</Comp>
-      );
+      const wrapper = TestRenderer.create(<Comp>Something else</Comp>);
       const text = wrapper.root.findByType('Text');
 
-      expect(text.props.style).toMatchObject(
-        [{"color": "red"}],
-      );
+      expect(text.props.style).toMatchObject([{ color: 'red' }]);
     });
   });
 
@@ -421,9 +425,7 @@ For example, { component: () => InnerComponent } instead of { component: InnerCo
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
         `"Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is \\"data-text-color\\" on component \\"Styled(View)\\"."`
       );
-      expect(console.warn.mock.calls[0][1]).toEqual(
-        expect.stringMatching(/^\s+Error\s+at/)
-      );
+      expect(console.warn.mock.calls[0][1]).toEqual(expect.stringMatching(/^\s+Error\s+at/));
     });
   });
 });

--- a/packages/styled-components/src/test/props.test.js
+++ b/packages/styled-components/src/test/props.test.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable react/prop-types */
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
@@ -18,6 +19,7 @@ describe('props', () => {
     TestRenderer.create(<Comp />);
     expectCSSMatches('.b { color:black; }');
   });
+
   it('should execute interpolations and inject props', () => {
     const Comp = styled.div`
       color: ${props => props.fg || 'black'};
@@ -25,6 +27,7 @@ describe('props', () => {
     TestRenderer.create(<Comp fg="red" />);
     expectCSSMatches('.b { color:red; }');
   });
+
   it('should ignore non-0 falsy object interpolations', () => {
     const Comp = styled.div`
       ${() => ({
@@ -37,5 +40,21 @@ describe('props', () => {
     `;
     TestRenderer.create(<Comp fg="red" />);
     expectCSSMatches('.b { border-width:0; }');
+  });
+
+  it('should pass "forwardedAs" to the underlying component as "as" if used', () => {
+    const Comp = ({ as: Component = 'div', ...props }) => <Component {...props} />;
+
+    const Comp2 = styled(Comp)`
+      background: red;
+    `;
+
+    expect(TestRenderer.create(<Comp2 forwardedAs="button" />).toJSON()).toMatchInlineSnapshot(`
+<button
+  className="sc-a b"
+/>
+`);
+
+    expectCSSMatches('.b { background: red; }');
   });
 });


### PR DESCRIPTION
same as the [canary PR](https://github.com/styled-components/styled-components/pull/2573) but this is a simple-enough change that we can ship it in a 4.x minor release