### PR TITLE
added a failing test for an 'as' prop bug

### DIFF
--- a/packages/styled-components/src/test/expanded-api.test.js
+++ b/packages/styled-components/src/test/expanded-api.test.js
@@ -142,7 +142,7 @@ describe('expanded api', () => {
       expect(TestRenderer.create(<Comp as={Override} />).toJSON()).toMatchSnapshot();
     });
 
-    it.only('does not pass down non standard props to custom component', () => {
+    it('does not pass down non standard props to custom component', () => {
       const Override = props => <figure {...props} />;
       const Comp = styled.div`
         color: red;

--- a/packages/styled-components/src/test/expanded-api.test.js
+++ b/packages/styled-components/src/test/expanded-api.test.js
@@ -142,6 +142,18 @@ describe('expanded api', () => {
       expect(TestRenderer.create(<Comp as={Override} />).toJSON()).toMatchSnapshot();
     });
 
+    it.only('does not pass down non standard props to custom component', () => {
+      const Override = props => <figure {...props} />;
+      const Comp = styled.div`
+        color: red;
+      `;
+
+      const instance = TestRenderer.create(<Comp fullWidth as={Override} />).root;
+      const figureProps = instance.findByType('figure').props;
+
+      expect(figureProps.fullWidth).toBeUndefined();
+    });
+
     it('transfers all styles that have been applied', () => {
       const Comp = styled.div`
         background: blue;


### PR DESCRIPTION
This is a failing test for a bug I noticed the other day while using the 'as' prop to pass styles down to a react-router link component.  

When you use 'as' to restyle a non-html component it passes down non-standard props to the underlying dom element. Which results in the following react error:
> React does not recognize the `fullWidth` prop on a DOM element.

here is a simplified code sandbox for the issue: https://codesandbox.io/s/flamboyant-bsnns-bsnns

As I am writing this I am realizing there probably isn't much that can be done without potentially breaking custom components that pass non-standard props down multiple levels.  The only solution I can think of is adding an option to strip non-standard props from custom components to the `styled` function.

```
styled(Link, {stripNonStandardProps: true})
```

Happy to give solving this a shot if someone can point me in the right direction.