### PR TITLE
lower the threshold for the "too many classes" warning

### DIFF
--- a/packages/styled-components/src/test/warnTooManyClasses.test.js
+++ b/packages/styled-components/src/test/warnTooManyClasses.test.js
@@ -2,54 +2,53 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
+import { LIMIT } from '../utils/createWarnTooManyClasses';
 import { resetStyled } from './utils';
 
 let styled;
 
 describe('warn too many classes', () => {
-  const nativeWarn = console.warn;
-  let warnCallCount;
   /**
    * Make sure the setup is the same for every test
    */
   beforeEach(() => {
-    (console: any).warn = () => warnCallCount++;
-    warnCallCount = 0;
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     styled = resetStyled();
-  });
-
-  afterEach(() => {
-    (console: any).warn = nativeWarn;
   });
 
   it('should warn once', () => {
     const Comp = styled.div`
       width: ${props => props.size};
     `;
-    for (let i = 0; i < 300; i++) {
+
+    for (let i = 0; i < LIMIT + 1; i++) {
       TestRenderer.create(<Comp size={i} />);
     }
-    expect(warnCallCount).toEqual(1);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
-  it('should warn if number of classes is 200', () => {
+  it(`should warn if number of classes is ${LIMIT}`, () => {
     const Comp = styled.div`
       width: ${props => props.size};
     `;
-    for (let i = 0; i < 200; i++) {
+
+    for (let i = 0; i < LIMIT; i++) {
       TestRenderer.create(<Comp size={i} />);
     }
-    expect(warnCallCount).toEqual(1);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
-  it('should not warn if number of classes is below 200', () => {
+  it(`should not warn if number of classes is below ${LIMIT}`, () => {
     const Comp = styled.div`
       width: ${props => props.size};
     `;
-    for (let i = 0; i < 199; i++) {
+
+    for (let i = 0; i < LIMIT - 1; i++) {
       TestRenderer.create(<Comp size={i} />);
     }
 
-    expect(warnCallCount).toEqual(0);
+    expect(console.warn).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/styled-components/src/utils/createWarnTooManyClasses.js
+++ b/packages/styled-components/src/utils/createWarnTooManyClasses.js
@@ -1,6 +1,6 @@
 // @flow
 
-const LIMIT = 200;
+export const LIMIT = 50;
 
 export default (displayName: string) => {
   let generatedClasses = {};
@@ -13,12 +13,12 @@ export default (displayName: string) => {
         // Unable to find latestRule in test environment.
         /* eslint-disable no-console, prefer-template */
         console.warn(
-          `Over ${LIMIT} classes were generated for component ${displayName}. \n` +
-            'Consider using the attrs method, together with a style object for frequently changed styles.\n' +
+          `Over ${LIMIT} classes were generated for component ${displayName}. This happens when some of the props you use for styling have many potential values and we need to make a new CSS class for each variant. Over time the stylesheet will grow and slow down your app.\n` +
+            'For these particular CSS rules with high dynamicity, consider using the attrs() method together with a style object.\n' +
             'Example:\n' +
-            '  const Component = styled.div.attrs(p => ({\n' +
+            '  const Component = styled.div.attrs(props => ({\n' +
             '    style: {\n' +
-            '      background: p.background,\n' +
+            '      background: props.background,\n' +
             '    },\n' +
             '  }))`width: 100%;`\n\n' +
             '  <Component />'


### PR DESCRIPTION
If your component is dynamic enough to have 20+ styling permutations
it's probably time to inline some stuff or the stylesheet will
be massive.