### PR TITLE
Stop creating invalid CSS when using @-ms-viewport along with createGlobalStyle

### DIFF
--- a/packages/styled-components/src/utils/test/stringifyRules.test.js
+++ b/packages/styled-components/src/utils/test/stringifyRules.test.js
@@ -1,0 +1,7 @@
+import stringifyRules from '../stringifyRules';
+
+it('stringifys @-ms-viewport correctly', () => {
+  const result = stringifyRules(['@-ms-viewport { width: device-width; }'], '');
+
+  expect(result).toEqual(['@-ms-viewport{width: device-width;}']);
+});


### PR DESCRIPTION
Currently when using:

```
createGlobalCss`
@-ms-viewport { width: device-width; }
`
```

The following CSS gets injected:

```
@-ms-viewport{{ width: device-width;}}
```

This is invalid CSS and causes JSDOM to print a long error message.

This is due to a bug in stylis (https://github.com/thysultan/stylis.js/pull/148) and this PR only contains a failing test and can be fixed by updating the stylis package once it's fixed there.