### PR TITLE
[rfc] use @emotion/stylis

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -65,12 +65,12 @@
     "@babel/helper-module-imports": "^7.0.0",
     "@babel/traverse": "^7.4.5",
     "@emotion/is-prop-valid": "^0.8.1",
+    "@emotion/stylis": "^0.8.3",
     "@emotion/unitless": "^0.7.0",
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^2.2.2",
     "merge-anything": "^2.2.5",
     "shallowequal": "^1.1.0",
-    "stylis": "^3.5.0",
     "stylis-rule-sheet": "^0.0.10",
     "supports-color": "^5.5.0"
   },

--- a/packages/styled-components/src/models/StyleSheetManager.js
+++ b/packages/styled-components/src/models/StyleSheetManager.js
@@ -8,7 +8,6 @@ type Props = {
   children?: Node,
   disableCSSOMInjection?: boolean,
   sheet?: StyleSheet,
-  stylisOptions?: Object,
   stylisPlugins?: Array<Function>,
   target?: HTMLElement,
 };
@@ -27,19 +26,11 @@ export default function StyleSheetManager(props: Props) {
    * reference equality for the useMemo dependencies array and devs will
    * likely not store the reference themselves to avoid this issue
    */
-  const [{ stylisOptions, stylisPlugins }] = useState({
-    stylisOptions: props.stylisOptions,
+  const [{ stylisPlugins }] = useState({
     stylisPlugins: props.stylisPlugins,
   });
 
   if (process.env.NODE_ENV !== 'production') {
-    if (!shallowequal(stylisOptions, props.stylisOptions)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'stylisOptions are frozen on initial mount of StyleSheetManager. Changing this prop dynamically will have no effect.'
-      );
-    }
-
     if (!shallowequal(stylisPlugins, props.stylisPlugins)) {
       // eslint-disable-next-line no-console
       console.warn(
@@ -48,31 +39,28 @@ export default function StyleSheetManager(props: Props) {
     }
   }
 
-  const styleSheet = useMemo(
-    () => {
-      let sheet = masterSheet;
+  const styleSheet = useMemo(() => {
+    let sheet = masterSheet;
 
-      if (props.sheet) {
-        // eslint-disable-next-line prefer-destructuring
-        sheet = props.sheet;
-      } else if (props.target) {
-        sheet = sheet.reconstructWithOptions({ target: props.target });
-      }
+    if (props.sheet) {
+      // eslint-disable-next-line prefer-destructuring
+      sheet = props.sheet;
+    } else if (props.target) {
+      sheet = sheet.reconstructWithOptions({ target: props.target });
+    }
 
-      if (props.disableCSSOMInjection) {
-        sheet = sheet.reconstructWithOptions({ useCSSOMInjection: false });
-      }
+    if (props.disableCSSOMInjection) {
+      sheet = sheet.reconstructWithOptions({ useCSSOMInjection: false });
+    }
 
-      if (stylisOptions || stylisPlugins) {
-        sheet = sheet.reconstructWithOptions({
-          stringifier: createStylisInstance(stylisOptions, stylisPlugins),
-        });
-      }
+    if (stylisPlugins) {
+      sheet = sheet.reconstructWithOptions({
+        stringifier: createStylisInstance(stylisPlugins),
+      });
+    }
 
-      return sheet;
-    },
-    [props.disableCSSOMInjection, props.sheet, stylisOptions, stylisPlugins, props.target]
-  );
+    return sheet;
+  }, [props.disableCSSOMInjection, props.sheet, stylisPlugins, props.target]);
 
   return (
     <StyleSheetContext.Provider value={styleSheet}>

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.js
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.js
@@ -232,6 +232,48 @@ describe('StyleSheetManager', () => {
     expect(indexOfBlueStyle).toBeGreaterThan(indexOfRedStyle);
   });
 
+  it('passing disableVendorPrefixes to StyleSheetManager works', () => {
+    const Test = styled.div`
+      display: flex;
+    `;
+
+    TestRenderer.create(
+      <StyleSheetManager disableVendorPrefixes>
+        <Test>Foo</Test>
+      </StyleSheetManager>
+    );
+
+    expect(document.head.innerHTML).toMatchInlineSnapshot(
+      `"<style data-styled=\\"active\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.sc-a{display:flex;}</style>"`
+    );
+  });
+
+  it('StyleSheetManager warns if you try to dynamically change disableVendorPrefixes', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const Test = styled.div`
+      display: flex;
+    `;
+
+    const wrapper = TestRenderer.create(
+      <StyleSheetManager disableVendorPrefixes>
+        <Test>Foo</Test>
+      </StyleSheetManager>
+    );
+
+    expect(console.warn).not.toHaveBeenCalled();
+
+    wrapper.update(
+      <StyleSheetManager disableVendorPrefixes={false}>
+        <Test>Foo</Test>
+      </StyleSheetManager>
+    );
+
+    expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"disableVendorPrefixes is frozen on initial mount of StyleSheetManager. Changing this prop dynamically will have no effect."`
+    );
+  });
+
   it('passing stylis plugins via StyleSheetManager works', () => {
     const Test = styled.div`
       padding-left: 5px;

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.js
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.js
@@ -232,48 +232,6 @@ describe('StyleSheetManager', () => {
     expect(indexOfBlueStyle).toBeGreaterThan(indexOfRedStyle);
   });
 
-  it('passing stylis options via StyleSheetManager works', () => {
-    const Test = styled.div`
-      display: flex;
-    `;
-
-    TestRenderer.create(
-      <StyleSheetManager stylisOptions={{ prefix: false }}>
-        <Test>Foo</Test>
-      </StyleSheetManager>
-    );
-
-    expect(document.head.innerHTML).toMatchInlineSnapshot(
-      `"<style data-styled=\\"active\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.sc-a{display:flex;}</style>"`
-    );
-  });
-
-  it('StyleSheetManager warns if you try to dynamically change the stylis options', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const Test = styled.div`
-      display: flex;
-    `;
-
-    const wrapper = TestRenderer.create(
-      <StyleSheetManager stylisOptions={{ prefix: false }}>
-        <Test>Foo</Test>
-      </StyleSheetManager>
-    );
-
-    expect(console.warn).not.toHaveBeenCalled();
-
-    wrapper.update(
-      <StyleSheetManager stylisOptions={{ prefix: true }}>
-        <Test>Foo</Test>
-      </StyleSheetManager>
-    );
-
-    expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"stylisOptions are frozen on initial mount of StyleSheetManager. Changing this prop dynamically will have no effect."`
-    );
-  });
-
   it('passing stylis plugins via StyleSheetManager works', () => {
     const Test = styled.div`
       padding-left: 5px;

--- a/packages/styled-components/src/utils/stylis.js
+++ b/packages/styled-components/src/utils/stylis.js
@@ -1,6 +1,6 @@
 import Stylis from '@emotion/stylis';
 import _insertRulePlugin from 'stylis-rule-sheet';
-import { EMPTY_ARRAY } from './empties';
+import { EMPTY_ARRAY, EMPTY_OBJECT } from './empties';
 
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
 
@@ -11,8 +11,16 @@ export type Stringifier = (
   componentId: string
 ) => Array<string>;
 
-export default function createStylisInstance(plugins: Array<Function> = EMPTY_ARRAY) {
-  const stylis = new Stylis();
+type StylisInstanceConstructorArgs = {
+  options?: Object,
+  plugins?: Array<Function>,
+};
+
+export default function createStylisInstance({
+  options = EMPTY_OBJECT,
+  plugins = EMPTY_ARRAY,
+}: StylisInstanceConstructorArgs = EMPTY_OBJECT) {
+  const stylis = new Stylis(options);
 
   // Wrap `insertRulePlugin to build a list of rules,
   // and then make our own plugin to return the rules. This

--- a/packages/styled-components/src/utils/stylis.js
+++ b/packages/styled-components/src/utils/stylis.js
@@ -1,6 +1,6 @@
-import Stylis from 'stylis/stylis.min';
+import Stylis from '@emotion/stylis';
 import _insertRulePlugin from 'stylis-rule-sheet';
-import { EMPTY_ARRAY, EMPTY_OBJECT } from './empties';
+import { EMPTY_ARRAY } from './empties';
 
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
 
@@ -11,21 +11,8 @@ export type Stringifier = (
   componentId: string
 ) => Array<string>;
 
-export default function createStylisInstance(
-  options: Object = EMPTY_OBJECT,
-  plugins: Array<Function> = EMPTY_ARRAY
-) {
-  const stylis = new Stylis({
-    global: false,
-    cascade: true,
-    keyframe: false,
-    prefix: true,
-    compress: false,
-    semicolon: false, // NOTE: This means "autocomplete missing semicolons"
-
-    // user-given overrides
-    ...options,
-  });
+export default function createStylisInstance(plugins: Array<Function> = EMPTY_ARRAY) {
+  const stylis = new Stylis();
 
   // Wrap `insertRulePlugin to build a list of rules,
   // and then make our own plugin to return the rules. This

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,7 +1014,7 @@
     "@emotion/styled-base" "^10.0.12"
     babel-plugin-emotion "^10.0.9"
 
-"@emotion/stylis@0.8.3":
+"@emotion/stylis@0.8.3", "@emotion/stylis@^0.8.3":
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.3.tgz#3ca7e9bcb31b3cb4afbaeb66156d86ee85e23246"
   integrity sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q==
@@ -10494,7 +10494,7 @@ stylis-rule-sheet@0.0.10, stylis-rule-sheet@^0.0.10:
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
-stylis@3.5.4, stylis@^3.5.0:
+stylis@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==


### PR DESCRIPTION
Drops the bundle size by a fair amount (12.1kB vs 13.62kB)... the downside is you
[can't customize stylis options anymore](https://www.npmjs.com/package/@emotion/stylis) but still can supply plugins.

I think it's an acceptable compromise for the bundle size win?