### PR TITLE
remove the concept of foldedComponentIds

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -67,7 +67,6 @@ function useResolvedAttrs<Config>(theme: any = EMPTY_OBJECT, props: Config, attr
 interface StyledComponentWrapperProperties {
   attrs: Attrs;
   componentStyle: ComponentStyle;
-  foldedComponentIds: Array<string>;
   target: Target;
   styledComponentId: string;
   warnTooManyClasses: $Call<typeof createWarnTooManyClasses, string>;
@@ -111,7 +110,6 @@ function useStyledComponentImpl<Config: {}, Instance>(
     componentStyle,
     // $FlowFixMe
     defaultProps,
-    foldedComponentIds,
     styledComponentId,
     target,
   } = forwardedComponent;
@@ -159,7 +157,6 @@ function useStyledComponentImpl<Config: {}, Instance>(
 
   propsForElement.className = Array.prototype
     .concat(
-      foldedComponentIds,
       styledComponentId,
       generatedClassName !== styledComponentId ? generatedClassName : null,
       props.className,
@@ -226,11 +223,6 @@ export default function createStyledComponent(
   WrappedStyledComponent.componentStyle = componentStyle;
   WrappedStyledComponent.displayName = displayName;
 
-  WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
-    ? // $FlowFixMe
-      Array.prototype.concat(target.foldedComponentIds, target.styledComponentId)
-    : EMPTY_ARRAY;
-
   WrappedStyledComponent.styledComponentId = styledComponentId;
 
   // fold the underlying StyledComponent target up since we folded the styles
@@ -281,7 +273,6 @@ export default function createStyledComponent(
       attrs: true,
       componentStyle: true,
       displayName: true,
-      foldedComponentIds: true,
       self: true,
       styledComponentId: true,
       target: true,

--- a/packages/styled-components/src/test/__snapshots__/attrs.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/attrs.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`attrs does not pass non html tags to HTML element 1`] = `
 <div
-  className="sc-a sc-b c"
+  className="sc-b c"
 />
 `;
 
@@ -16,7 +16,7 @@ exports[`attrs merge attrs 1`] = `
 
 exports[`attrs merge attrs when inheriting SC 1`] = `
 <button
-  className="sc-a sc-b c"
+  className="sc-b c"
   tabIndex={0}
   type="submit"
 />

--- a/packages/styled-components/src/test/__snapshots__/expanded-api.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/expanded-api.test.js.snap
@@ -18,32 +18,6 @@ exports[`expanded api "as" prop prefers prop over attrs 1`] = `
 />
 `;
 
-exports[`expanded api "as" prop transfers all styles that have been applied 1`] = `"styled.div"`;
-
-exports[`expanded api "as" prop transfers all styles that have been applied 2`] = `"Styled(styled.div)"`;
-
-exports[`expanded api "as" prop transfers all styles that have been applied 3`] = `"Styled(Styled(styled.div))"`;
-
-exports[`expanded api "as" prop transfers all styles that have been applied 4`] = `
-<div
-  className="sc-a d"
-/>
-`;
-
-exports[`expanded api "as" prop transfers all styles that have been applied 5`] = `
-<div
-  className="sc-a sc-b e"
-/>
-`;
-
-exports[`expanded api "as" prop transfers all styles that have been applied 6`] = `
-<span
-  className="sc-a sc-b sc-c f"
-/>
-`;
-
-exports[`expanded api "as" prop transfers all styles that have been applied 7`] = `".d{background:blue;color:red;}.e{background:blue;color:red;color:green;}.f{background:blue;color:red;color:green;text-align:center;}"`;
-
 exports[`expanded api "as" prop works with custom components 1`] = `
 <figure
   className="sc-a b"

--- a/packages/styled-components/src/test/expanded-api.test.js
+++ b/packages/styled-components/src/test/expanded-api.test.js
@@ -152,6 +152,8 @@ describe('expanded api', () => {
         color: red;
       `;
 
+      Comp.displayName = 'SomethingFun';
+
       const Comp2 = styled(Comp)`
         color: green;
       `;
@@ -160,14 +162,31 @@ describe('expanded api', () => {
         text-align: center;
       `;
 
-      expect(Comp.displayName).toMatchSnapshot();
-      expect(Comp2.displayName).toMatchSnapshot();
-      expect(Comp3.displayName).toMatchSnapshot();
-      expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
-      expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchSnapshot();
-      expect(TestRenderer.create(<Comp3 as="span" />).toJSON()).toMatchSnapshot();
+      expect(Comp.displayName).toMatchInlineSnapshot(`"SomethingFun"`);
+      expect(Comp2.displayName).toMatchInlineSnapshot(`"Styled(SomethingFun)"`);
+      expect(Comp3.displayName).toMatchInlineSnapshot(`"Styled(Styled(SomethingFun))"`);
 
-      expect(getCSS(document)).toMatchSnapshot();
+      expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
+                        <div
+                          className="sc-a d"
+                        />
+                  `);
+
+      expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchInlineSnapshot(`
+                        <div
+                          className="sc-b e"
+                        />
+                  `);
+
+      expect(TestRenderer.create(<Comp3 as="span" />).toJSON()).toMatchInlineSnapshot(`
+                        <span
+                          className="sc-c f"
+                        />
+                  `);
+
+      expect(getCSS(document)).toMatchInlineSnapshot(
+        `".d{background:blue;color:red;}.e{background:blue;color:red;color:green;}.f{background:blue;color:red;color:green;text-align:center;}"`
+      );
     });
   });
 });


### PR DESCRIPTION
since we literally concat the styles together and make an entirely
new component, we don't have to care about what the layers were
that came before and in v5 it actually causes issues to keep that
information around because the base layer could be mounted later
than the overridden component and cause specificity issues