### PR TITLE
fix component selectors + css prop usage

### DIFF
--- a/packages/styled-components/src/models/ComponentStyle.js
+++ b/packages/styled-components/src/models/ComponentStyle.js
@@ -49,7 +49,7 @@ export default class ComponentStyle {
       }
 
       const cssStatic = flatten(this.rules, executionContext, styleSheet).join('');
-      const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
+      const name = generateName(phash(this.baseHash, cssStatic.length) >>> 0);
 
       if (!styleSheet.hasNameForId(componentId, name)) {
         const cssStaticFormatted = styleSheet.options.stringifier(

--- a/packages/styled-components/src/models/ComponentStyle.js
+++ b/packages/styled-components/src/models/ComponentStyle.js
@@ -44,7 +44,10 @@ export default class ComponentStyle {
     const { componentId } = this;
 
     if (this.isStatic) {
-      if (this.staticRulesId) return this.staticRulesId;
+      if (this.staticRulesId && styleSheet.hasNameForId(componentId, this.staticRulesId)) {
+        return this.staticRulesId;
+      }
+
       const cssStatic = flatten(this.rules, executionContext, styleSheet).join('');
       const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
 
@@ -57,8 +60,9 @@ export default class ComponentStyle {
         );
 
         styleSheet.insertRules(componentId, name, cssStaticFormatted);
-        this.staticRulesId = name;
       }
+
+      this.staticRulesId = name;
 
       return name;
     } else {

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -69,6 +69,7 @@ interface StyledComponentWrapperProperties {
   attrs: Attrs;
   componentStyle: ComponentStyle;
   displayName: string;
+  foldedComponentIds: Array<string>;
   target: Target;
   styledComponentId: string;
   warnTooManyClasses: $Call<typeof createWarnTooManyClasses, string>;
@@ -113,6 +114,7 @@ function useStyledComponentImpl<Config: {}, Instance>(
     componentStyle,
     // $FlowFixMe
     defaultProps,
+    foldedComponentIds,
     styledComponentId,
     target,
   } = forwardedComponent;
@@ -173,6 +175,7 @@ function useStyledComponentImpl<Config: {}, Instance>(
 
   propsForElement.className = Array.prototype
     .concat(
+      foldedComponentIds,
       styledComponentId,
       generatedClassName !== styledComponentId ? generatedClassName : null,
       props.className,
@@ -239,6 +242,11 @@ export default function createStyledComponent(
   WrappedStyledComponent.componentStyle = componentStyle;
   WrappedStyledComponent.displayName = displayName;
 
+  WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
+    ? // $FlowFixMe
+      Array.prototype.concat(target.foldedComponentIds, target.styledComponentId)
+    : EMPTY_ARRAY;
+
   WrappedStyledComponent.styledComponentId = styledComponentId;
 
   // fold the underlying StyledComponent target up since we folded the styles
@@ -293,6 +301,7 @@ export default function createStyledComponent(
       attrs: true,
       componentStyle: true,
       displayName: true,
+      foldedComponentIds: true,
       self: true,
       styledComponentId: true,
       target: true,

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -242,6 +242,8 @@ export default function createStyledComponent(
   WrappedStyledComponent.componentStyle = componentStyle;
   WrappedStyledComponent.displayName = displayName;
 
+  // this static is used to preserve the cascade of static classes for component selector
+  // purposes; this is especially important with usage of the css prop
   WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
     ? // $FlowFixMe
       Array.prototype.concat(target.foldedComponentIds, target.styledComponentId)

--- a/packages/styled-components/src/test/__snapshots__/attrs.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/attrs.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`attrs does not pass non html tags to HTML element 1`] = `
 <div
-  className="sc-b c"
+  className="sc-a sc-b c"
 />
 `;
 
@@ -16,7 +16,7 @@ exports[`attrs merge attrs 1`] = `
 
 exports[`attrs merge attrs when inheriting SC 1`] = `
 <button
-  className="sc-b c"
+  className="sc-a sc-b c"
   tabIndex={0}
   type="submit"
 />

--- a/packages/styled-components/src/test/__snapshots__/expanded-api.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/expanded-api.test.js.snap
@@ -18,6 +18,32 @@ exports[`expanded api "as" prop prefers prop over attrs 1`] = `
 />
 `;
 
+exports[`expanded api "as" prop transfers all styles that have been applied 1`] = `"styled.div"`;
+
+exports[`expanded api "as" prop transfers all styles that have been applied 2`] = `"Styled(styled.div)"`;
+
+exports[`expanded api "as" prop transfers all styles that have been applied 3`] = `"Styled(Styled(styled.div))"`;
+
+exports[`expanded api "as" prop transfers all styles that have been applied 4`] = `
+<div
+  className="sc-a d"
+/>
+`;
+
+exports[`expanded api "as" prop transfers all styles that have been applied 5`] = `
+<div
+  className="sc-a sc-b e"
+/>
+`;
+
+exports[`expanded api "as" prop transfers all styles that have been applied 6`] = `
+<span
+  className="sc-a sc-b sc-c f"
+/>
+`;
+
+exports[`expanded api "as" prop transfers all styles that have been applied 7`] = `".d{background:blue;color:red;}.e{background:blue;color:red;color:green;}.f{background:blue;color:red;color:green;text-align:center;}"`;
+
 exports[`expanded api "as" prop works with custom components 1`] = `
 <figure
   className="sc-a b"

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ssr production mode should not create dynamic classes for fully-static components 1`] = `"<h1 class=\\"sc-a\\">Hello SSR!</h1>"`;
-
-exports[`ssr production mode should not create dynamic classes for fully-static components 2`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.sc-a{color:red;}
-data-styled.g1[id=\\"sc-a\\"]{content:\\"sc-a,\\"}
-</style>"
-`;
-
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 2`] = `

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -94,7 +94,7 @@ describe('constants', () => {
 
     it('should be true in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to true', () => {
       window.SC_DISABLE_SPEEDY = true;
-      renderAndExpect(true, '.sc-a { color:blue; }');
+      renderAndExpect(true, '.b { color:blue; }');
     });
 
     it('should be true in test NODE_ENV', () => {
@@ -109,14 +109,14 @@ describe('constants', () => {
 
     it('should work with SC_DISABLE_SPEEDY environment variable', () => {
       process.env.SC_DISABLE_SPEEDY = true;
-      renderAndExpect(true, '.sc-a { color:blue; }');
+      renderAndExpect(true, '.b { color:blue; }');
 
       delete process.env.SC_DISABLE_SPEEDY;
     });
 
     it('should work with REACT_APP_SC_DISABLE_SPEEDY environment variable', () => {
       process.env.REACT_APP_SC_DISABLE_SPEEDY = true;
-      renderAndExpect(true, '.sc-a { color:blue; }');
+      renderAndExpect(true, '.b { color:blue; }');
 
       delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
     });

--- a/packages/styled-components/src/test/expanded-api.test.js
+++ b/packages/styled-components/src/test/expanded-api.test.js
@@ -152,8 +152,6 @@ describe('expanded api', () => {
         color: red;
       `;
 
-      Comp.displayName = 'SomethingFun';
-
       const Comp2 = styled(Comp)`
         color: green;
       `;
@@ -162,31 +160,14 @@ describe('expanded api', () => {
         text-align: center;
       `;
 
-      expect(Comp.displayName).toMatchInlineSnapshot(`"SomethingFun"`);
-      expect(Comp2.displayName).toMatchInlineSnapshot(`"Styled(SomethingFun)"`);
-      expect(Comp3.displayName).toMatchInlineSnapshot(`"Styled(Styled(SomethingFun))"`);
+      expect(Comp.displayName).toMatchSnapshot();
+      expect(Comp2.displayName).toMatchSnapshot();
+      expect(Comp3.displayName).toMatchSnapshot();
+      expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
+      expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchSnapshot();
+      expect(TestRenderer.create(<Comp3 as="span" />).toJSON()).toMatchSnapshot();
 
-      expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
-                        <div
-                          className="sc-a d"
-                        />
-                  `);
-
-      expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchInlineSnapshot(`
-                        <div
-                          className="sc-b e"
-                        />
-                  `);
-
-      expect(TestRenderer.create(<Comp3 as="span" />).toJSON()).toMatchInlineSnapshot(`
-                        <span
-                          className="sc-c f"
-                        />
-                  `);
-
-      expect(getCSS(document)).toMatchInlineSnapshot(
-        `".d{background:blue;color:red;}.e{background:blue;color:red;color:green;}.f{background:blue;color:red;color:green;text-align:center;}"`
-      );
+      expect(getCSS(document)).toMatchSnapshot();
     });
   });
 });

--- a/packages/styled-components/src/test/ssr.test.js
+++ b/packages/styled-components/src/test/ssr.test.js
@@ -470,23 +470,4 @@ describe('ssr', () => {
       stream.on('error', reject);
     });
   });
-
-  describe('production mode', () => {
-    beforeEach(() => {
-      process.env.NODE_ENV = 'production';
-    });
-
-    it('should not create dynamic classes for fully-static components', () => {
-      const Heading = styled.h1`
-        color: red;
-      `;
-
-      const sheet = new ServerStyleSheet();
-      const html = renderToString(sheet.collectStyles(<Heading>Hello SSR!</Heading>));
-      const css = sheet.getStyleTags();
-
-      expect(html).toMatchSnapshot();
-      expect(css).toMatchSnapshot();
-    });
-  });
 });

--- a/packages/styled-components/src/test/styles.test.js
+++ b/packages/styled-components/src/test/styles.test.js
@@ -291,19 +291,4 @@ describe('with styles', () => {
       expect(el.getAttribute('nonce')).toBe('foo');
     });
   });
-
-  describe('production mode', () => {
-    beforeEach(() => {
-      process.env.NODE_ENV = 'production';
-    });
-
-    it('should not generate a dynamic class for static rules', () => {
-      const rule = 'color: blue;';
-      const Comp = styled.div`
-        ${rule};
-      `;
-      TestRenderer.create(<Comp />);
-      expectCSSMatches('.sc-a { color:blue; }');
-    });
-  });
 });


### PR DESCRIPTION
This PR reverts the change to remove `foldedComponentIds` and reintroduces some v4 behavior to not inject styles into the static component classes.

Without these changes components targeted via component selector that have been wrapped in any way (css prop, styled() hoc, etc.) will not be found for style application which is a regression from v4.

In order to reintroduce `foldedComponentIds` we need to go back to the previous behavior in v4 of not injecting styles into the component stable ssr className so that it remains available for placeholder / targeting usage only.