### PR TITLE
show the multi instance warning for all envs

### DIFF
--- a/packages/styled-components/src/base.js
+++ b/packages/styled-components/src/base.js
@@ -33,23 +33,15 @@ if (
 }
 
 /* Warning if there are several instances of styled-components */
-if (
-  process.env.NODE_ENV !== 'production' &&
-  process.env.NODE_ENV !== 'test' &&
-  typeof window !== 'undefined' &&
-  typeof navigator !== 'undefined' &&
-  typeof navigator.userAgent === 'string' &&
-  navigator.userAgent.indexOf('Node.js') === -1 &&
-  navigator.userAgent.indexOf('jsdom') === -1
-) {
+if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
   window['__styled-components-init__'] = window['__styled-components-init__'] || 0;
 
   if (window['__styled-components-init__'] === 1) {
     // eslint-disable-next-line no-console
     console.warn(
       "It looks like there are several instances of 'styled-components' initialized in this application. " +
-        'This may cause dynamic styles not rendering properly, errors happening during rehydration process ' +
-        'and makes your application bigger without a good reason.\n\n' +
+        'This may cause dynamic styles not rendering properly, errors happening during rehydration process, ' +
+        'missing theme prop, and makes your application bigger without a good reason.\n\n' +
         'See https://s-c.sh/2BAXzed for more info.'
     );
   }


### PR DESCRIPTION
Going to add a section to FAQ about deduping the library within
environments like jest. Not sure why this was so tightly restricted
before because it's a totally valid warning even for browser-like
SSR use cases.