### PR TITLE
Import React Native components using asterisk syntax to support case …

### DIFF
--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -1,7 +1,8 @@
 // @flow
 
 /* eslint-disable import/no-unresolved */
-import reactNative, { StyleSheet } from 'react-native';
+import * as reactNative from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import _InlineStyle from '../models/InlineStyle';
 import _StyledNativeComponent from '../models/StyledNativeComponent';


### PR DESCRIPTION
…where React Native has no default export [https://www.notion.so/armancharan/React-Native-Styled-Components-Error-ec66cbc1980e424da3987bd60eb103a9]