### PR TITLE
Export styled as styled

### DIFF
--- a/packages/styled-components/src/index-standalone.js
+++ b/packages/styled-components/src/index-standalone.js
@@ -14,3 +14,4 @@ for (const key in secondary) {
 }
 
 export default styled;
+export { styled };

--- a/packages/styled-components/src/index.js
+++ b/packages/styled-components/src/index.js
@@ -3,3 +3,4 @@ import styled from './constructors/styled';
 
 export * from './base';
 export { styled as default };
+export { styled };


### PR DESCRIPTION
Having named export help us to have a concise way to program by using a common naming.

Since you thought about the naming of this export and for the most part, people refer to `styled-components` when we see `styled` function, most likely.

I would prefer the tool to help me with this topic.

Naming is hard and better to follow conventions that reduce the cognitive load and allow us the use of ubiquitous language when it comes to referring the same thing.

> You don't need this, just name it styled

I will agree with you 100% until you deal with Interns and Junior people or people that are not involved in the React ecosystem or JavaScript in general.

Rather than relying on discipline alone, better to encourage these practices since the tools can help a bit with such of a small amount of work, in my personal opinion.

> Having default export allow me to name it as I like it.

If you want to rename things, at least have a really simple way to lexically analyze the code when it happens; since the search results will show `styled` being renamed to something else it will easy to understand your code.