### PR TITLE
Get rid of the ThemeProvider single child context restriction

### DIFF
--- a/packages/styled-components/src/models/ThemeProvider.js
+++ b/packages/styled-components/src/models/ThemeProvider.js
@@ -40,7 +40,7 @@ export default class ThemeProvider extends Component<Props> {
 
     return (
       <ThemeContext.Provider value={context}>
-        {React.Children.only(this.props.children)}
+        {this.props.children}
       </ThemeContext.Provider>
     );
   }


### PR DESCRIPTION
We can get rid of that restriction because ThemeProvider uses stable React Context API and children cannot be a top-level element.
Fixes #1325.
The documentation will be updated too. 