### PR TITLE
fix: add check for style tag detached and then removed - sheet in the style tag is null in this case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Backport fix where classnames are composed in the wrong order if custom class names are passed in (see [#2760](https://github.com/styled-components/styled-components/pull/2760))
 
+- Fix add check for style tag detached - sheet in the style tag is null in this case, by [@newying61](https://github.com/newying61) (see [#2707](https://github.com/styled-components/styled-components/pull/2707))
+
 ## [v4.3.2] - 2019-06-19
 
 - Fix usage of the "css" prop with the styled-components babel macro (relevant to CRA 2.x users), by [@jamesknelson](http://github.com/jamesknelson) (see [#2633](https://github.com/styled-components/styled-components/issues/2633))

--- a/packages/styled-components/src/models/StyleTags.js
+++ b/packages/styled-components/src/models/StyleTags.js
@@ -178,6 +178,8 @@ const makeSpeedyTag = (el: HTMLStyleElement, getImportRuleTag: ?() => Tag<any>):
   const removeRules = id => {
     const marker = markers[id];
     if (marker === undefined) return;
+    // $FlowFixMe
+    if (el.isConnected === false) return;
 
     const size = sizes[marker];
     const sheet = sheetForTag(el);


### PR DESCRIPTION
Hi, thanks for the great work and amazing lib.

We have a special use case of React and styled-components:
- Rendering React App inside shadow DOM
- Unmount React App when web component tag removed from DOM (in disconnectedCallback function)

When un-mounting the app, what I found is the sheet property in \<style\> tag made by makeSpeedyTag() function is null, because when disconnectedCallback getting called, the style DOM node is already removed from DOM.
Because sheet is empty, currently styled-components throws an exception in [sheetForTag](https://github.com/styled-components/styled-components/blob/master/packages/styled-components/src/utils/insertRuleHelpers.js#L23) function.

By checking the [isConnected](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) flag, we know whether the style element is detached or not.
This flag is not supported by IE11 and Edge (<76), so, it will return undefined.
undefined === false is false in JavaScript, so, should be fine for the older browsers. 

I am not sure whether styled-components should consider this issue or not.
Just raise a pull request first, if this case is too special, I'll find some other solutions.
Thanks.