### PR TITLE
Get rid of the ThemeProvider single child context restriction (canary)

### DIFF
--- a/packages/styled-components/src/models/ThemeProvider.js
+++ b/packages/styled-components/src/models/ThemeProvider.js
@@ -52,7 +52,7 @@ export default function ThemeProvider(props: Props) {
 
   return (
     <ThemeContext.Provider value={themeContext}>
-      {React.Children.only(props.children)}
+      {props.children}
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
This is the follow-up to https://github.com/styled-components/styled-components/pull/2706.