### PR TITLE
Use ownerDocument instead of global document (canary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 ## Unreleased
 
 - Remove deprecated functionality (object-form `.attrs({})`)
+- Fix to use `ownerDocument` instead of global `document`, by [@yamachig](https://github.com/yamachig) (see [#2721](https://github.com/styled-components/styled-components/pull/2721))
 
 ## [v4.3.2] - 2019-06-19
 

--- a/packages/styled-components/src/sheet/Rehydration.js
+++ b/packages/styled-components/src/sheet/Rehydration.js
@@ -88,7 +88,9 @@ const rehydrateSheetFromTag = (sheet: Sheet, style: HTMLStyleElement) => {
 };
 
 export const rehydrateSheet = (sheet: Sheet) => {
-  const nodes = document.querySelectorAll(SELECTOR);
+  let targetDocument = document;
+  if(sheet.options.target) targetDocument = sheet.options.target.ownerDocument;
+  const nodes = targetDocument.querySelectorAll(SELECTOR);
 
   for (let i = 0, l = nodes.length; i < l; i++) {
     const node = ((nodes[i]: any): HTMLStyleElement);

--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -26,7 +26,7 @@ export class CSSOMTag implements Tag {
     const element = (this.element = makeStyleTag(target));
 
     // Avoid Edge bug where empty style elements don't create sheets
-    element.appendChild(document.createTextNode(''));
+    element.appendChild(element.ownerDocument.createTextNode(''));
 
     this.sheet = getSheet(element);
     this.length = 0;
@@ -74,7 +74,7 @@ export class TextTag implements Tag {
 
   insertRule(index: number, rule: string): boolean {
     if (index <= this.length && index >= 0) {
-      const node = document.createTextNode(rule);
+      const node = this.element.ownerDocument.createTextNode(rule);
       const refNode = this.nodes[index];
       this.element.insertBefore(node, refNode || null);
       this.length++;

--- a/packages/styled-components/src/sheet/dom.js
+++ b/packages/styled-components/src/sheet/dom.js
@@ -21,9 +21,11 @@ const findLastStyleTag = (target: HTMLElement): void | HTMLStyleElement => {
 
 /** Create a style element inside `target` or <head> after the last */
 export const makeStyleTag = (target?: HTMLElement): HTMLStyleElement => {
-  const head = ((document.head: any): HTMLElement);
+  let targetDocument = document;
+  if(target) targetDocument = target.ownerDocument;
+  const head = ((targetDocument.head: any): HTMLElement);
   const parent = target || head;
-  const style = document.createElement('style');
+  const style = targetDocument.createElement('style');
   const prevStyle = findLastStyleTag(parent);
   const nextSibling = prevStyle !== undefined ? prevStyle.nextSibling : null;
 


### PR DESCRIPTION
Same PR as #2721 against canary.
(Replaced the global document variables with ownerDocument so that the code works correctly on Edge.)