### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: node_js
-dist: trusty
-sudo: required
+dist: bionic
 addons:
-  apt:
-    packages:
-      - libnss3
-      - google-chrome-beta
+  chrome: beta
 branches:
   only:
     - master
     - develop
+    - update-travis
 env:
   global:
     - GOOGLE_CHROME_BINARY="/usr/bin/google-chrome-beta"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
   only:
     - master
     - develop
-    - update-travis
 env:
   global:
     - GOOGLE_CHROME_BINARY="/usr/bin/google-chrome-beta"


### PR DESCRIPTION
Trusty has been EOLed even in Travis, and the GPG keys in it were old enough that things were failing to install.

Try to update it to the new stuff.

Looks like the `bundlesize` command is printing some errors, and there's an unfixed lint warning on master that is being ignored as it's a `warn` not `error`, but otherwise seems fine.