### PR TITLE
Remove deprecated attrs suggestion from too many classes warning

### DIFF
--- a/packages/styled-components/src/utils/createWarnTooManyClasses.js
+++ b/packages/styled-components/src/utils/createWarnTooManyClasses.js
@@ -16,11 +16,11 @@ export default (displayName: string) => {
           `Over ${LIMIT} classes were generated for component ${displayName}. \n` +
             'Consider using the attrs method, together with a style object for frequently changed styles.\n' +
             'Example:\n' +
-            '  const Component = styled.div.attrs({\n' +
-            '    style: ({ background }) => ({\n' +
-            '      background,\n' +
-            '    }),\n' +
-            '  })`width: 100%;`\n\n' +
+            '  const Component = styled.div.attrs(props => ({\n' +
+            '    style: {\n' +
+            '      background: props.background,\n' +
+            '    },\n' +
+            '  }))`width: 100%;`\n\n' +
             '  <Component />'
         );
         warningSeen = true;


### PR DESCRIPTION
The following warning is triggered when there are too many style updates on a component:

```
Over 200 classes were generated for component ModifiedComponent. 
Consider using the attrs method, together with a style object for frequently changed styles.
Example:
  const Component = styled.div.attrs({
    style: ({ background }) => ({
      background,
    }),
  })`width: 100%;`

  <Component />
```

Unfortunately, updating the implementation of `ModifiedComponent` to match the suggestion brings up a new warning about the deprecated use of `attrs`:

```
Functions as object-form attrs({}) keys are now deprecated and will be removed in a future version of styled-components. Switch to the new attrs(props => ({})) syntax instead for easier and more powerful composition. The attrs key in question is "style" on component "ModifiedComponent"
```

I've updated the original warning to read as follows:

```
Over 200 classes were generated for component ModifiedComponent. 
Consider using the attrs method, together with a style object for frequently changed styles.
Example:
  const Component = styled.div.attrs(props => ({
    style: {
      background: props.background,
    },
  }))`width: 100%;`

  <Component />
```