### PR TITLE
DISABLE_SPEEDY can be set to "false" in test environment

### DIFF
--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -11,11 +11,18 @@ export const SC_STREAM_ATTR = 'data-styled-streamed';
 
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
-export const DISABLE_SPEEDY =
-  (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
-  (typeof process !== 'undefined' &&
-    (process.env.REACT_APP_SC_DISABLE_SPEEDY || process.env.SC_DISABLE_SPEEDY)) ||
-  process.env.NODE_ENV !== 'production';
+export const DISABLE_SPEEDY = (() => {
+  if (typeof SC_DISABLE_SPEEDY === 'boolean') {
+    return SC_DISABLE_SPEEDY;
+  }
+  if (typeof process !== 'undefined' && process.env.REACT_APP_SC_DISABLE_SPEEDY !== undefined) {
+    return process.env.REACT_APP_SC_DISABLE_SPEEDY;
+  }
+  if (typeof process !== 'undefined' && process.env.SC_DISABLE_SPEEDY !== undefined) {
+    return process.env.SC_DISABLE_SPEEDY;
+  }
+  return process.env.NODE_ENV !== 'production';
+})();
 
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};


### PR DESCRIPTION
- allow to control DISABLE_SPEEDY through global variable and environment variable even in case we would like to set it to false