### PR TITLE
[POC] Implement rule hoisting for import/font-face rules

### DIFF
--- a/packages/styled-components/src/models/test/StyleSheetManager.test.js
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.js
@@ -337,7 +337,7 @@ describe('StyleSheetManager', () => {
       </StyleSheetManager>
     );
 
-    expect(outerSheet.getTag().tag.getRule(0)).toMatchInlineSnapshot(`".c {padding-left: 5px;}"`);
+    expect(outerSheet.getTag().normalTag.tag.getRule(0)).toMatchInlineSnapshot(`".c {padding-left: 5px;}"`);
 
     expect(document.head.innerHTML).toMatchInlineSnapshot(
       `"<style data-styled=\\"active\\" data-styled-version=\\"JEST_MOCK_VERSION\\"></style><style data-styled=\\"active\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.d{background:red;}</style>"`

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -3,14 +3,18 @@
 
 import type { GroupedTag, Tag } from './types';
 
-/** Create a GroupedTag with an underlying Tag implementation */
-export const makeGroupedTag = (tag: Tag): GroupedTag => {
-  return new DefaultGroupedTag(tag);
-};
-
 const BASE_SIZE = 1 << 8;
 
-class DefaultGroupedTag implements GroupedTag {
+const indexOfGroup = (groupSizes: Uint32Array, group: number): number => {
+  let index = 0;
+  for (let i = 0; i < group; i++) {
+    index += groupSizes[i];
+  }
+
+  return index;
+};
+
+export class DefaultGroupedTag implements GroupedTag {
   groupSizes: Uint32Array;
 
   length: number;
@@ -21,15 +25,6 @@ class DefaultGroupedTag implements GroupedTag {
     this.groupSizes = new Uint32Array(BASE_SIZE);
     this.length = BASE_SIZE;
     this.tag = tag;
-  }
-
-  indexOfGroup(group: number): number {
-    let index = 0;
-    for (let i = 0; i < group; i++) {
-      index += this.groupSizes[i];
-    }
-
-    return index;
   }
 
   insertRules(group: number, rules: string[]): void {
@@ -47,7 +42,7 @@ class DefaultGroupedTag implements GroupedTag {
       }
     }
 
-    const startIndex = this.indexOfGroup(group + 1);
+    const startIndex = indexOfGroup(this.groupSizes, group + 1);
     for (let i = 0, l = rules.length; i < l; i++) {
       if (this.tag.insertRule(startIndex + i, rules[i])) {
         this.groupSizes[group]++;
@@ -58,7 +53,7 @@ class DefaultGroupedTag implements GroupedTag {
   clearGroup(group: number): void {
     if (group < this.length) {
       const length = this.groupSizes[group];
-      const startIndex = this.indexOfGroup(group);
+      const startIndex = indexOfGroup(this.groupSizes, group);
       const endIndex = startIndex + length;
 
       this.groupSizes[group] = 0;
@@ -76,7 +71,7 @@ class DefaultGroupedTag implements GroupedTag {
     }
 
     const length = this.groupSizes[group];
-    const startIndex = this.indexOfGroup(group);
+    const startIndex = indexOfGroup(this.groupSizes, group);
     const endIndex = startIndex + length;
 
     for (let i = startIndex; i < endIndex; i++) {

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -8,13 +8,13 @@ const BASE_SIZE = 1 << 8;
 export class DefaultGroupedTag implements GroupedTag {
   groupSizes: Uint32Array;
 
-  length: number;
+  groups: number;
 
   tag: Tag;
 
   constructor(tag: Tag) {
     this.groupSizes = new Uint32Array(BASE_SIZE);
-    this.length = BASE_SIZE;
+    this.groups = BASE_SIZE;
     this.tag = tag;
   }
 
@@ -35,7 +35,7 @@ export class DefaultGroupedTag implements GroupedTag {
 
       this.groupSizes = new Uint32Array(newSize);
       this.groupSizes.set(oldBuffer);
-      this.length = newSize;
+      this.groups = newSize;
 
       for (let i = oldSize; i < newSize; i++) {
         this.groupSizes[i] = 0;
@@ -51,10 +51,10 @@ export class DefaultGroupedTag implements GroupedTag {
   }
 
   clearGroup(group: number): void {
-    if (group < this.length) {
-      const length = this.groupSizes[group];
+    if (group < this.groups) {
+      const groupSize = this.groupSizes[group];
       const startIndex = this.indexOfGroup(group);
-      const endIndex = startIndex + length;
+      const endIndex = startIndex + groupSize;
 
       this.groupSizes[group] = 0;
 
@@ -66,13 +66,13 @@ export class DefaultGroupedTag implements GroupedTag {
 
   getGroup(group: number): string {
     let css = '';
-    if (group >= this.length || this.groupSizes[group] === 0) {
+    if (group >= this.groups || this.groupSizes[group] === 0) {
       return css;
     }
 
-    const length = this.groupSizes[group];
+    const groupSize = this.groupSizes[group];
     const startIndex = this.indexOfGroup(group);
-    const endIndex = startIndex + length;
+    const endIndex = startIndex + groupSize;
 
     for (let i = startIndex; i < endIndex; i++) {
       css += `${this.tag.getRule(i)}\n`;

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -5,15 +5,6 @@ import type { GroupedTag, Tag } from './types';
 
 const BASE_SIZE = 1 << 8;
 
-const indexOfGroup = (groupSizes: Uint32Array, group: number): number => {
-  let index = 0;
-  for (let i = 0; i < group; i++) {
-    index += groupSizes[i];
-  }
-
-  return index;
-};
-
 export class DefaultGroupedTag implements GroupedTag {
   groupSizes: Uint32Array;
 
@@ -25,6 +16,15 @@ export class DefaultGroupedTag implements GroupedTag {
     this.groupSizes = new Uint32Array(BASE_SIZE);
     this.length = BASE_SIZE;
     this.tag = tag;
+  }
+
+  indexOfGroup(group: number): number {
+    let index = 0;
+    for (let i = 0; i < group; i++) {
+      index += this.groupSizes[i];
+    }
+
+    return index;
   }
 
   insertRules(group: number, rules: string[]): void {
@@ -42,7 +42,7 @@ export class DefaultGroupedTag implements GroupedTag {
       }
     }
 
-    const startIndex = indexOfGroup(this.groupSizes, group + 1);
+    const startIndex = this.indexOfGroup(group + 1);
     for (let i = 0, l = rules.length; i < l; i++) {
       if (this.tag.insertRule(startIndex + i, rules[i])) {
         this.groupSizes[group]++;
@@ -53,7 +53,7 @@ export class DefaultGroupedTag implements GroupedTag {
   clearGroup(group: number): void {
     if (group < this.length) {
       const length = this.groupSizes[group];
-      const startIndex = indexOfGroup(this.groupSizes, group);
+      const startIndex = this.indexOfGroup(group);
       const endIndex = startIndex + length;
 
       this.groupSizes[group] = 0;
@@ -71,7 +71,7 @@ export class DefaultGroupedTag implements GroupedTag {
     }
 
     const length = this.groupSizes[group];
-    const startIndex = indexOfGroup(this.groupSizes, group);
+    const startIndex = this.indexOfGroup(group);
     const endIndex = startIndex + length;
 
     for (let i = startIndex; i < endIndex; i++) {

--- a/packages/styled-components/src/sheet/HoistedTag.js
+++ b/packages/styled-components/src/sheet/HoistedTag.js
@@ -4,19 +4,19 @@ import type { HoistedTag, GroupedTag, Tag } from './types';
 import { DefaultGroupedTag } from './GroupedTag';
 import { WindowedTag } from './WindowedTag';
 
-const hoistedRuleRe = /\s*@(font-face|import)/;
+const hoistedRuleRe = /\s*@import/;
 
 export class DefaultHoistedTag implements HoistedTag {
   hoistedTag: GroupedTag;
 
   normalTag: GroupedTag;
 
-  length: number;
+  groups: number;
 
   constructor(tag: Tag) {
     this.hoistedTag = new DefaultGroupedTag(new WindowedTag(tag));
     this.normalTag = new DefaultGroupedTag(new WindowedTag(tag));
-    this.length = 0;
+    this.groups = 0;
   }
 
   insertRules(group: number, rules: string[]): void {
@@ -34,17 +34,18 @@ export class DefaultHoistedTag implements HoistedTag {
 
     this.normalTag.insertRules(group, normalRules);
     this.hoistedTag.insertRules(group, hoistedRules);
-    this.length = this.normalTag.length;
+    // We just use the normalTag groups
+    // since the normalTag and hoistedTag have the same groups
+    this.groups = this.normalTag.groups;
   }
 
   clearGroup(group: number) {
     this.normalTag.clearGroup(group);
     this.hoistedTag.clearGroup(group);
-    this.length = this.normalTag.length;
+    this.groups = this.normalTag.groups;
   }
 
-  // TODO: Needs to be replaced to keep hoisted ordering
-  getGroup(group: number) {
-    return this.hoistedTag.getGroup(group) + this.normalTag.getGroup(group);
+  getHoistedAndNormalGroups(group: number) {
+    return { hoisted: this.hoistedTag.getGroup(group), normal: this.normalTag.getGroup(group) };
   }
 }

--- a/packages/styled-components/src/sheet/HoistedTag.js
+++ b/packages/styled-components/src/sheet/HoistedTag.js
@@ -1,0 +1,50 @@
+// @flow
+
+import type { HoistedTag, GroupedTag, Tag } from './types';
+import { DefaultGroupedTag } from './GroupedTag';
+import { WindowedTag } from './WindowedTag';
+
+const hoistedRuleRe = /\s*@(font-face|import)/;
+
+export class DefaultHoistedTag implements HoistedTag {
+  hoistedTag: GroupedTag;
+
+  normalTag: GroupedTag;
+
+  length: number;
+
+  constructor(tag: Tag) {
+    this.hoistedTag = new DefaultGroupedTag(new WindowedTag(tag));
+    this.normalTag = new DefaultGroupedTag(new WindowedTag(tag));
+    this.length = 0;
+  }
+
+  insertRules(group: number, rules: string[]): void {
+    const hoistedRules = [];
+    const normalRules = [];
+
+    for (let i = 0, l = rules.length; i < l; i++) {
+      const rule = rules[i];
+      if (hoistedRuleRe.test(rule)) {
+        hoistedRules.push(rule);
+      } else {
+        normalRules.push(rule);
+      }
+    }
+
+    this.normalTag.insertRules(group, normalRules);
+    this.hoistedTag.insertRules(group, hoistedRules);
+    this.length = this.normalTag.length;
+  }
+
+  clearGroup(group: number) {
+    this.normalTag.clearGroup(group);
+    this.hoistedTag.clearGroup(group);
+    this.length = this.normalTag.length;
+  }
+
+  // TODO: Needs to be replaced to keep hoisted ordering
+  getGroup(group: number) {
+    return this.hoistedTag.getGroup(group) + this.normalTag.getGroup(group);
+  }
+}

--- a/packages/styled-components/src/sheet/Sheet.js
+++ b/packages/styled-components/src/sheet/Sheet.js
@@ -1,9 +1,9 @@
 // @flow
 import { DISABLE_SPEEDY, IS_BROWSER } from '../constants';
 import createStylisInstance from '../utils/stylis';
-import type { GroupedTag, Sheet, SheetOptions } from './types';
+import type { HoistedTag, Sheet, SheetOptions } from './types';
 import { makeTag } from './Tag';
-import { makeGroupedTag } from './GroupedTag';
+import { DefaultHoistedTag } from './HoistedTag';
 import { getGroupForId } from './GroupIDAllocator';
 import { outputSheet, rehydrateSheet } from './Rehydration';
 
@@ -27,7 +27,7 @@ export default class StyleSheet implements Sheet {
 
   options: SheetOptions;
 
-  tag: void | GroupedTag;
+  tag: void | HoistedTag;
 
   /** Register a group ID to give it an index */
   static registerId(id: string): number {
@@ -54,9 +54,9 @@ export default class StyleSheet implements Sheet {
     return new StyleSheet({ ...this.options, ...options });
   }
 
-  /** Lazily initialises a GroupedTag for when it's actually needed */
-  getTag(): GroupedTag {
-    return this.tag || (this.tag = makeGroupedTag(makeTag(this.options)));
+  /** Lazily initialises a HoistingGroupedTag for when it's actually needed */
+  getTag(): HoistedTag {
+    return this.tag || (this.tag = new DefaultHoistedTag(makeTag(this.options)));
   }
 
   /** Check whether a name is known for caching */

--- a/packages/styled-components/src/sheet/WindowedTag.js
+++ b/packages/styled-components/src/sheet/WindowedTag.js
@@ -1,0 +1,54 @@
+// @flow
+/* eslint-disable no-use-before-define */
+
+import type { Tag } from './types';
+
+const getOffset = (prev: void | WindowedTag): number => {
+  let offset = 0;
+  for (let x = prev; x !== undefined; x = x.prev) {
+    offset += x.length;
+  }
+
+  return offset;
+};
+
+export class WindowedTag implements Tag {
+  prev: void | WindowedTag;
+
+  tag: Tag;
+
+  length: number;
+
+  constructor(tag: Tag) {
+    this.tag = tag;
+    this.length = 0;
+
+    if ((tag: any).window !== undefined) {
+      this.prev = (tag: any).window;
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    (tag: any).window = this;
+  }
+
+  insertRule(index: number, rule: string): boolean {
+    const offset = getOffset(this.prev);
+    if (this.tag.insertRule(offset + index, rule)) {
+      this.length++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  deleteRule(index: number): void {
+    const offset = getOffset(this.prev);
+    this.tag.deleteRule(offset + index);
+    this.length--;
+  }
+
+  getRule(index: number): string {
+    const offset = getOffset(this.prev);
+    return this.tag.getRule(index + offset);
+  }
+}

--- a/packages/styled-components/src/sheet/test/GroupedTag.test.js
+++ b/packages/styled-components/src/sheet/test/GroupedTag.test.js
@@ -2,78 +2,82 @@
 
 import { VirtualTag } from '../Tag';
 import { DefaultGroupedTag } from '../GroupedTag';
+import { WindowedTag } from '../WindowedTag';
 
-let tag;
-let groupedTag;
+const describeGroupedTag = makeTagAndGroupedTag => {
+  let groupedTag, tag;
+  beforeEach(() => {
+    ({ groupedTag, tag } = makeTagAndGroupedTag());
+  });
 
-beforeEach(() => {
-  tag = new VirtualTag();
-  groupedTag = new DefaultGroupedTag(tag);
+  it('inserts and retrieves rules by groups correctly', () => {
+    groupedTag.insertRules(2, ['.g2-a {}', '.g2-b {}']);
+
+    // Insert out of order into the right group
+    groupedTag.insertRules(1, ['.g1-a {}', '.g1-b {}']);
+
+    groupedTag.insertRules(2, ['.g2-c {}', '.g2-d {}']);
+
+    expect(groupedTag.groups).toBeGreaterThan(2);
+    expect(tag.length).toBe(6);
+
+    // Expect groups to contain inserted rules
+    expect(groupedTag.getGroup(0)).toBe('');
+    expect(groupedTag.getGroup(1)).toBe('.g1-a {}\n.g1-b {}\n');
+    expect(groupedTag.getGroup(2)).toBe('.g2-a {}\n.g2-b {}\n' + '.g2-c {}\n.g2-d {}\n');
+
+    // Check some rules in the tag as well
+    expect(tag.getRule(3)).toBe('.g2-b {}');
+    expect(tag.getRule(0)).toBe('.g1-a {}');
+
+    // And the indices for sizes: [0, 2, 4, 0, ...]
+    expect(groupedTag.indexOfGroup(0)).toBe(0);
+    expect(groupedTag.indexOfGroup(1)).toBe(0);
+    expect(groupedTag.indexOfGroup(2)).toBe(2);
+    expect(groupedTag.indexOfGroup(3)).toBe(6);
+    expect(groupedTag.indexOfGroup(4)).toBe(6);
+  });
+
+  it('inserts and deletes groups correctly', () => {
+    groupedTag.insertRules(1, ['.g1-a {}']);
+    expect(tag.length).toBe(1);
+    expect(groupedTag.getGroup(1)).not.toBe('');
+    groupedTag.clearGroup(1);
+    expect(tag.length).toBe(0);
+    expect(groupedTag.getGroup(1)).toBe('');
+
+    // Noop test for non-existent group
+    groupedTag.clearGroup(0);
+    expect(tag.length).toBe(0);
+  });
+
+  it('does supports large group numbers', () => {
+    const baseSize = groupedTag.groups;
+    const group = 1 << 10;
+    groupedTag.insertRules(group, ['.test {}']);
+
+    // We expect the internal buffer to have grown beyond its initial size
+    expect(groupedTag.groups).toBeGreaterThan(baseSize);
+
+    expect(groupedTag.groups).toBeGreaterThan(group);
+    expect(tag.length).toBe(1);
+    expect(groupedTag.indexOfGroup(group)).toBe(0);
+    expect(groupedTag.getGroup(group)).toBe('.test {}\n');
+  });
+};
+
+describe('GroupedTag with a VirtualTag', () => {
+  describeGroupedTag(() => {
+    const tag = new VirtualTag();
+    const groupedTag = new DefaultGroupedTag(tag);
+    return { tag, groupedTag };
+  });
 });
 
-it('inserts and retrieves rules by groups correctly', () => {
-  groupedTag.insertRules(2, [
-    '.g2-a {}',
-    '.g2-b {}'
-  ]);
-
-  // Insert out of order into the right group
-  groupedTag.insertRules(1, [
-    '.g1-a {}',
-    '.g1-b {}'
-  ]);
-
-  groupedTag.insertRules(2, [
-    '.g2-c {}',
-    '.g2-d {}'
-  ]);
-
-  expect(groupedTag.length).toBeGreaterThan(2);
-  expect(tag.length).toBe(6);
-
-  // Expect groups to contain inserted rules
-  expect(groupedTag.getGroup(0)).toBe('');
-  expect(groupedTag.getGroup(1)).toBe('.g1-a {}\n.g1-b {}\n');
-  expect(groupedTag.getGroup(2)).toBe(
-    '.g2-a {}\n.g2-b {}\n' +
-    '.g2-c {}\n.g2-d {}\n'
-  );
-
-  // Check some rules in the tag as well
-  expect(tag.getRule(3)).toBe('.g2-b {}');
-  expect(tag.getRule(0)).toBe('.g1-a {}');
-
-  // And the indices for sizes: [0, 2, 4, 0, ...]
-  expect(groupedTag.indexOfGroup(0)).toBe(0);
-  expect(groupedTag.indexOfGroup(1)).toBe(0);
-  expect(groupedTag.indexOfGroup(2)).toBe(2);
-  expect(groupedTag.indexOfGroup(3)).toBe(6);
-  expect(groupedTag.indexOfGroup(4)).toBe(6);
-});
-
-it('inserts and deletes groups correctly', () => {
-  groupedTag.insertRules(1, ['.g1-a {}']);
-  expect(tag.length).toBe(1);
-  expect(groupedTag.getGroup(1)).not.toBe('');
-  groupedTag.clearGroup(1);
-  expect(tag.length).toBe(0);
-  expect(groupedTag.getGroup(1)).toBe('');
-
-  // Noop test for non-existent group
-  groupedTag.clearGroup(0);
-  expect(tag.length).toBe(0);
-});
-
-it('does supports large group numbers', () => {
-  const baseSize = groupedTag.length;
-  const group = 1 << 10;
-  groupedTag.insertRules(group, ['.test {}']);
-
-  // We expect the internal buffer to have grown beyond its initial size
-  expect(groupedTag.length).toBeGreaterThan(baseSize);
-
-  expect(groupedTag.length).toBeGreaterThan(group);
-  expect(tag.length).toBe(1);
-  expect(groupedTag.indexOfGroup(group)).toBe(0);
-  expect(groupedTag.getGroup(group)).toBe('.test {}\n');
+describe('GroupedTag with a Windowed VirtualTag', () => {
+  describeGroupedTag(() => {
+    const tag = new WindowedTag(new VirtualTag());
+    const groupedTag = new DefaultGroupedTag(tag);
+    return { tag, groupedTag };
+  });
 });

--- a/packages/styled-components/src/sheet/test/GroupedTag.test.js
+++ b/packages/styled-components/src/sheet/test/GroupedTag.test.js
@@ -1,14 +1,14 @@
 // @flow
 
 import { VirtualTag } from '../Tag';
-import { makeGroupedTag } from '../GroupedTag';
+import { DefaultGroupedTag } from '../GroupedTag';
 
 let tag;
 let groupedTag;
 
 beforeEach(() => {
   tag = new VirtualTag();
-  groupedTag = makeGroupedTag(tag);
+  groupedTag = new DefaultGroupedTag(tag);
 });
 
 it('inserts and retrieves rules by groups correctly', () => {

--- a/packages/styled-components/src/sheet/test/HoistedTag.test.js
+++ b/packages/styled-components/src/sheet/test/HoistedTag.test.js
@@ -1,0 +1,176 @@
+// @flow
+
+import { VirtualTag } from '../Tag';
+import { DefaultHoistedTag } from '../HoistedTag';
+
+describe('DefaultHoistedTag', () => {
+  let hoistingTag, tag;
+  beforeEach(() => {
+    tag = new VirtualTag();
+    hoistingTag = new DefaultHoistedTag(tag);
+  });
+  // Start GroupedTag tests for when there's no hoisted rules
+  it('inserts and retrieves normal rules by groups correctly', () => {
+    hoistingTag.insertRules(2, ['.g2-a {}', '.g2-b {}']);
+
+    // Insert out of order into the right group
+    hoistingTag.insertRules(1, ['.g1-a {}', '.g1-b {}']);
+
+    hoistingTag.insertRules(2, ['.g2-c {}', '.g2-d {}']);
+
+    expect(hoistingTag.groups).toBeGreaterThan(2);
+    expect(tag.length).toBe(6);
+
+    // Expect groups to contain inserted rules
+    expect(hoistingTag.getHoistedAndNormalGroups(0)).toEqual({ hoisted: '', normal: '' });
+    expect(hoistingTag.getHoistedAndNormalGroups(1)).toEqual({
+      hoisted: '',
+      normal: '.g1-a {}\n.g1-b {}\n',
+    });
+    expect(hoistingTag.getHoistedAndNormalGroups(2)).toEqual({
+      hoisted: '',
+      normal: '.g2-a {}\n.g2-b {}\n' + '.g2-c {}\n.g2-d {}\n',
+    });
+
+    // Check some rules in the tag as well
+    expect(tag.getRule(3)).toBe('.g2-b {}');
+    expect(tag.getRule(0)).toBe('.g1-a {}');
+
+    // And the indices for sizes: [0, 2, 4, 0, ...]
+    expect(hoistingTag.normalTag.indexOfGroup(0)).toBe(0);
+    expect(hoistingTag.normalTag.indexOfGroup(1)).toBe(0);
+    expect(hoistingTag.normalTag.indexOfGroup(2)).toBe(2);
+    expect(hoistingTag.normalTag.indexOfGroup(3)).toBe(6);
+    expect(hoistingTag.normalTag.indexOfGroup(4)).toBe(6);
+
+    // Check to make sure the hoistedTag is empty
+    expect(hoistingTag.hoistedTag.getGroup(0)).toBe('');
+    // Dig to the WindowedTag in order to avoid the array allocated by GroupedTag
+    expect(hoistingTag.hoistedTag.tag.length).toBe(0);
+  });
+
+  it('inserts and deletes groups with normal rules correctly', () => {
+    hoistingTag.insertRules(1, ['.g1-a {}']);
+    expect(tag.length).toBe(1);
+    expect(hoistingTag.getHoistedAndNormalGroups(1).normal).not.toBe('');
+    hoistingTag.clearGroup(1);
+    expect(tag.length).toBe(0);
+    expect(hoistingTag.getHoistedAndNormalGroups(1).normal).toBe('');
+
+    // Noop test for non-existent group
+    hoistingTag.clearGroup(0);
+    expect(tag.length).toBe(0);
+  });
+
+  it('supports large group numbers', () => {
+    const baseSize = hoistingTag.groups;
+    const group = 1 << 10;
+    hoistingTag.insertRules(group, ['.test {}']);
+
+    // We expect the internal buffer to have grown beyond its initial size
+    expect(hoistingTag.groups).toBeGreaterThan(baseSize);
+
+    expect(hoistingTag.groups).toBeGreaterThan(group);
+    expect(tag.length).toBe(1);
+    expect(hoistingTag.normalTag.indexOfGroup(group)).toBe(0);
+    expect(hoistingTag.getHoistedAndNormalGroups(group).normal).toBe('.test {}\n');
+  });
+
+  // End GroupedTag tests, Start tests for hoisting @import rules
+  it('should hoist @import rules to be first in a group', () => {
+    // Insert some normal style rules
+    hoistingTag.insertRules(2, ['.g2-a {}', '.g2-b {}']);
+
+    // Insert an @import and an @font-face rule to the same group
+    hoistingTag.insertRules(2, [
+      '@import url("");',
+      '@font-face { font-family: "test", src: url("")}',
+    ]);
+
+    expect(hoistingTag.groups).toBeGreaterThan(2);
+    expect(tag.length).toBe(4);
+
+    // Expect groups to contain inserted rules
+    expect(hoistingTag.getHoistedAndNormalGroups(0)).toEqual({ hoisted: '', normal: '' });
+    expect(hoistingTag.getHoistedAndNormalGroups(1)).toEqual({ hoisted: '', normal: '' });
+    expect(hoistingTag.getHoistedAndNormalGroups(2)).toEqual({
+      hoisted: '@import url("");\n',
+      normal: '.g2-a {}\n.g2-b {}\n@font-face { font-family: "test", src: url("")}\n',
+    });
+
+    // Check some rules in the tag as well
+    expect(tag.getRule(2)).toBe('.g2-b {}');
+    expect(tag.getRule(0)).toBe('@import url("");');
+
+    // We added 3 rules to group 2, so check the indicies
+    expect(hoistingTag.normalTag.indexOfGroup(0)).toBe(0);
+    expect(hoistingTag.normalTag.indexOfGroup(1)).toBe(0);
+    expect(hoistingTag.normalTag.indexOfGroup(2)).toBe(0);
+    expect(hoistingTag.normalTag.indexOfGroup(3)).toBe(3);
+
+    // Check to make sure the hoistedTag has the @import rules
+    expect(hoistingTag.hoistedTag.getGroup(0)).toBe('');
+    expect(hoistingTag.hoistedTag.getGroup(2)).toBe('@import url("");\n');
+    expect(hoistingTag.hoistedTag.groups).toBeGreaterThan(2);
+  });
+
+  it('should hoist @import rules when interleaved in multiple groups', () => {
+    // Insert some normal style rules
+    hoistingTag.insertRules(2, ['.g2-a {}', '.g2-b {}']);
+    hoistingTag.insertRules(1, ['.g1-a {}', '.g1-b {}']);
+    hoistingTag.insertRules(0, ['.g0-a {}', '.g0-b {}']);
+
+    // Insert an @import and an @font-face rule to the each group, only the @import needs hoisting
+    hoistingTag.insertRules(2, [
+      '@import url("2");',
+      '@font-face { font-family: "test", src: url("2")}',
+    ]);
+    hoistingTag.insertRules(1, [
+      '@import url("1");',
+      '@font-face { font-family: "test", src: url("1")}',
+    ]);
+    hoistingTag.insertRules(0, [
+      '@import url("0");',
+      '@font-face { font-family: "test", src: url("0")}',
+    ]);
+
+    expect(hoistingTag.normalTag.tag.length).toBe(9); // Check the normal window
+    expect(hoistingTag.hoistedTag.tag.length).toBe(3); // Check the hoisted window
+    expect(tag.length).toBe(12);
+
+    // Expect groups to contain inserted hoisted & normal rules
+    expect(hoistingTag.getHoistedAndNormalGroups(0)).toEqual({
+      hoisted: '@import url("0");\n',
+      normal: '.g0-a {}\n.g0-b {}\n@font-face { font-family: "test", src: url("0")}\n',
+    });
+    expect(hoistingTag.getHoistedAndNormalGroups(1)).toEqual({
+      hoisted: '@import url("1");\n',
+      normal: '.g1-a {}\n.g1-b {}\n@font-face { font-family: "test", src: url("1")}\n',
+    });
+    expect(hoistingTag.getHoistedAndNormalGroups(2)).toEqual({
+      hoisted: '@import url("2");\n',
+      normal: '.g2-a {}\n.g2-b {}\n@font-face { font-family: "test", src: url("2")}\n',
+    });
+
+    // Expect tag to have hoisted rules in right order then normal rules
+
+    expect(tag.getRule(0)).toBe('@import url("0");');
+    expect(tag.getRule(1)).toBe('@import url("1");');
+    expect(tag.getRule(2)).toBe('@import url("2");');
+    expect(tag.getRule(3)).toBe('.g0-a {}');
+    expect(tag.getRule(5)).toBe('@font-face { font-family: "test", src: url("0")}');
+    expect(tag.getRule(6)).toBe('.g1-a {}');
+    expect(tag.getRule(8)).toBe('@font-face { font-family: "test", src: url("1")}');
+    expect(tag.getRule(9)).toBe('.g2-a {}');
+    expect(tag.getRule(11)).toBe('@font-face { font-family: "test", src: url("2")}');
+    expect(hoistingTag.normalTag.indexOfGroup(0)).toBe(0);
+    expect(hoistingTag.normalTag.indexOfGroup(1)).toBe(3);
+    expect(hoistingTag.normalTag.indexOfGroup(2)).toBe(6);
+    expect(hoistingTag.normalTag.indexOfGroup(3)).toBe(9);
+
+    // Check to make sure the hoistedTag has the @import and @font-face rules
+    expect(hoistingTag.hoistedTag.getGroup(0)).toBe('@import url("0");\n');
+    expect(hoistingTag.hoistedTag.getGroup(1)).toBe('@import url("1");\n');
+    expect(hoistingTag.hoistedTag.getGroup(2)).toBe('@import url("2");\n');
+  });
+});

--- a/packages/styled-components/src/sheet/test/Rehydration.test.js
+++ b/packages/styled-components/src/sheet/test/Rehydration.test.js
@@ -68,7 +68,7 @@ describe('rehydrateSheet', () => {
     expect(sheet.hasNameForId('empty', 'empty')).toBe(false);
     expect(sheet.hasNameForId('idB', 'nameB')).toBe(true);
     // Populates the underlying tag
-    expect(sheet.getTag().tag.length).toBe(2);
+    expect(sheet.getTag().normalTag.tag.length).toBe(2);
     expect(sheet.getTag().getGroup(11)).toBe('.a {}\n');
     expect(sheet.getTag().getGroup(22)).toBe('.b {}\n');
     expect(sheet.getTag().getGroup(33)).toBe('');
@@ -91,7 +91,7 @@ describe('rehydrateSheet', () => {
     rehydrateSheet(sheet);
     expect(GroupIDAllocator.getIdForGroup(11)).toBe(undefined);
     expect(sheet.hasNameForId('idA', 'nameA')).toBe(false);
-    expect(sheet.getTag().tag.length).toBe(0);
+    expect(sheet.getTag().normalTag.tag.length).toBe(0);
     expect(styleHead.parentElement).toBe(document.head);
   });
 });

--- a/packages/styled-components/src/sheet/test/Sheet.test.js
+++ b/packages/styled-components/src/sheet/test/Sheet.test.js
@@ -7,7 +7,7 @@ let tag;
 
 beforeEach(() => {
   sheet = new StyleSheet({ isServer: true });
-  tag = sheet.getTag().tag;
+  tag = sheet.getTag().normalTag.tag;
 });
 
 it('inserts rules correctly', () => {

--- a/packages/styled-components/src/sheet/test/Tag.test.js
+++ b/packages/styled-components/src/sheet/test/Tag.test.js
@@ -1,10 +1,11 @@
 // @flow
 
 import { type Tag, CSSOMTag, TextTag, VirtualTag } from '../Tag';
+import { WindowedTag } from '../WindowedTag';
 
-const describeTag = (TagClass: Class<Tag>) => {
+const describeTag = (TagClass: Class<Tag>, TagToWindow: Class<Tag>) => {
   it('inserts and retrieves rules at indices', () => {
-    const tag = new TagClass();
+    const tag = TagToWindow ? new TagClass(new TagToWindow()) : new TagClass();
     expect(tag.insertRule(0, '.b {}')).toBe(true);
     expect(tag.insertRule(0, '.a {}')).toBe(true);
     expect(tag.insertRule(2, '.c {}')).toBe(true);
@@ -17,7 +18,7 @@ const describeTag = (TagClass: Class<Tag>) => {
   });
 
   it('deletes rules that have been inserted', () => {
-    const tag = new TagClass();
+    const tag = TagToWindow ? new TagClass(new TagToWindow()) : new TagClass();
     expect(tag.insertRule(0, '.b {}')).toBe(true);
     expect(tag.length).toBe(1);
     tag.deleteRule(0);
@@ -43,4 +44,10 @@ describe('TextTag', () => {
 
 describe('VirtualTag', () => {
   describeTag(VirtualTag);
+});
+
+describe('WindowedTag acts like a tag', () => {
+  describeTag(WindowedTag, CSSOMTag);
+  describeTag(WindowedTag, TextTag);
+  describeTag(WindowedTag, VirtualTag);
 });

--- a/packages/styled-components/src/sheet/test/WindowedTag.test.js
+++ b/packages/styled-components/src/sheet/test/WindowedTag.test.js
@@ -1,0 +1,172 @@
+// @flow
+
+import { VirtualTag } from '../Tag';
+import { WindowedTag } from '../WindowedTag';
+import { DefaultGroupedTag } from '../GroupedTag';
+
+describe('WindowedTag', () => {
+  it('Correctly builds the linked list', () => {
+    const virtualTag = new VirtualTag();
+    const windowedTag1 = new WindowedTag(virtualTag);
+
+    expect(windowedTag1.prev).toBe(undefined);
+    expect(virtualTag.window).toBe(windowedTag1);
+    const windowedTag2 = new WindowedTag(virtualTag);
+    expect(windowedTag2.prev).toBe(windowedTag1);
+    expect(virtualTag.window).toBe(windowedTag2);
+  });
+
+  it('Inserts rules one window at a time', () => {
+    const virtualTag = new VirtualTag();
+    const windowedTag1 = new WindowedTag(virtualTag);
+    const windowedTag2 = new WindowedTag(virtualTag);
+
+    // Insertions into the windowedTag1
+    expect(windowedTag1.insertRule(0, '.b {}')).toBe(true);
+    expect(windowedTag1.insertRule(0, '.a {}')).toBe(true);
+    expect(windowedTag1.insertRule(2, '.c {}')).toBe(true);
+    expect(windowedTag1.getRule(0)).toBe('.a {}');
+    expect(windowedTag1.getRule(1)).toBe('.b {}');
+    expect(windowedTag1.getRule(2)).toBe('.c {}');
+    expect(windowedTag1.getRule(3)).toBe('');
+    expect(windowedTag1.length).toBe(3);
+
+    // Check some rules in the tag
+    expect(virtualTag.getRule(2)).toBe('.c {}');
+    expect(virtualTag.length).toBe(3);
+
+    // Insertions into the windowedTag2
+    expect(windowedTag2.insertRule(0, '.b-second {}')).toBe(true);
+    expect(windowedTag2.insertRule(0, '.a-second {}')).toBe(true);
+    expect(windowedTag2.insertRule(2, '.c-second {}')).toBe(true);
+    expect(windowedTag2.getRule(0)).toBe('.a-second {}');
+    expect(windowedTag2.getRule(1)).toBe('.b-second {}');
+    expect(windowedTag2.getRule(2)).toBe('.c-second {}');
+    expect(windowedTag2.getRule(3)).toBe('');
+    expect(windowedTag2.length).toBe(3);
+
+    // Check some rules in the tag
+    expect(virtualTag.getRule(2)).toBe('.c {}');
+    expect(virtualTag.getRule(5)).toBe('.c-second {}');
+    expect(virtualTag.length).toBe(6);
+  });
+
+  it('Can interleave rule insertions between two windows', () => {
+    const virtualTag = new VirtualTag();
+    const windowedTag1 = new WindowedTag(virtualTag);
+    const windowedTag2 = new WindowedTag(virtualTag);
+
+    expect(windowedTag1.insertRule(0, '.b {}')).toBe(true);
+    expect(windowedTag2.insertRule(0, '.b-second {}')).toBe(true);
+    expect(windowedTag1.insertRule(0, '.a {}')).toBe(true);
+
+    // Check some rules in the tag
+    expect(virtualTag.getRule(2)).toBe('.b-second {}');
+    expect(virtualTag.length).toBe(3);
+
+    expect(windowedTag2.insertRule(0, '.a-second {}')).toBe(true);
+    expect(windowedTag1.insertRule(2, '.c {}')).toBe(true);
+    expect(windowedTag2.insertRule(2, '.c-second {}')).toBe(true);
+
+    expect(windowedTag1.getRule(0)).toBe('.a {}');
+    expect(windowedTag1.getRule(1)).toBe('.b {}');
+    expect(windowedTag1.getRule(2)).toBe('.c {}');
+    expect(windowedTag1.length).toBe(3);
+
+    // The current implementation allows windows to "bleed" if you request an offset that lands in another window
+    expect(windowedTag1.getRule(3)).toBe('.a-second {}');
+
+    expect(windowedTag2.getRule(0)).toBe('.a-second {}');
+    expect(windowedTag2.getRule(1)).toBe('.b-second {}');
+    expect(windowedTag2.getRule(2)).toBe('.c-second {}');
+    expect(windowedTag2.getRule(3)).toBe('');
+    expect(windowedTag2.length).toBe(3);
+
+    // Check some rules in the tag
+    expect(virtualTag.getRule(2)).toBe('.c {}');
+    expect(virtualTag.getRule(5)).toBe('.c-second {}');
+    expect(virtualTag.length).toBe(6);
+  });
+
+  it('deletes rules that have been inserted one window at a time', () => {
+    const virtualTag = new VirtualTag();
+    const windowedTag1 = new WindowedTag(virtualTag);
+    const windowedTag2 = new WindowedTag(virtualTag);
+    expect(windowedTag1.insertRule(0, '.b {}')).toBe(true);
+    expect(windowedTag1.length).toBe(1);
+    expect(virtualTag.length).toBe(1);
+    expect(windowedTag2.insertRule(0, '.b-second {}')).toBe(true);
+    expect(windowedTag2.length).toBe(1);
+    expect(virtualTag.length).toBe(2);
+    windowedTag1.deleteRule(0);
+    expect(virtualTag.length).toBe(1);
+    expect(virtualTag.getRule(0)).toBe('.b-second {}');
+    windowedTag2.deleteRule(0);
+    expect(virtualTag.length).toBe(0);
+    expect(virtualTag.getRule(0)).toBe('');
+  });
+
+  it('handles interleaving additions and deletes', () => {
+    const virtualTag = new VirtualTag();
+    const windowedTag1 = new WindowedTag(virtualTag);
+    const windowedTag2 = new WindowedTag(virtualTag);
+    expect(windowedTag1.insertRule(0, '.b {}')).toBe(true);
+    expect(windowedTag2.insertRule(0, '.b-second {}')).toBe(true);
+    expect(windowedTag1.insertRule(0, '.a {}')).toBe(true);
+    expect(windowedTag1.length).toBe(2);
+    expect(windowedTag2.length).toBe(1);
+    // Check some rules in the tag
+    expect(virtualTag.getRule(2)).toBe('.b-second {}');
+    expect(virtualTag.length).toBe(3);
+
+    // Delete the second rule added to the first window
+    windowedTag1.deleteRule(1); // This should delete the '.b' rule since '.a' was put in before it
+    expect(windowedTag1.length).toBe(1);
+    expect(windowedTag1.getRule(0)).toBe('.a {}');
+    expect(windowedTag2.length).toBe(1);
+    expect(windowedTag2.getRule(0)).toBe('.b-second {}');
+
+    // Delete the first rule added to the first window
+    windowedTag1.deleteRule(0);
+    expect(windowedTag1.length).toBe(0);
+    //We still bleed, and that should be okay
+    expect(windowedTag1.getRule(0)).toBe('.b-second {}');
+    expect(windowedTag2.length).toBe(1);
+    expect(windowedTag2.getRule(0)).toBe('.b-second {}');
+
+    // Add some more rules to the two tags
+    expect(windowedTag2.insertRule(0, '.a-second {}')).toBe(true);
+    // Note that this is inserted at 0 instead of 2 like the earlier test since we deleted rules
+    // If you inserted at a number greater than offset + length you'd have the windows intermingling rules
+    expect(windowedTag1.insertRule(0, '.c {}')).toBe(true);
+    expect(windowedTag2.insertRule(2, '.c-second {}')).toBe(true);
+
+    expect(windowedTag1.getRule(0)).toBe('.c {}');
+    expect(windowedTag1.length).toBe(1);
+
+    expect(windowedTag2.getRule(0)).toBe('.a-second {}');
+    expect(windowedTag2.getRule(1)).toBe('.b-second {}');
+    expect(windowedTag2.getRule(2)).toBe('.c-second {}');
+    expect(windowedTag2.getRule(3)).toBe('');
+    expect(windowedTag2.length).toBe(3);
+
+    // Check some rules in the tag
+    expect(virtualTag.getRule(2)).toBe('.b-second {}');
+    expect(virtualTag.getRule(5)).toBe('');
+    expect(virtualTag.length).toBe(4);
+
+    // Delete the middle '.b-second' rule
+    windowedTag2.deleteRule(1);
+    // Validate the virtualTag and both windowedTags look right
+    expect(virtualTag.length).toBe(3);
+    expect(virtualTag.getRule(0)).toBe('.c {}');
+    expect(virtualTag.getRule(1)).toBe('.a-second {}');
+    expect(virtualTag.getRule(2)).toBe('.c-second {}');
+    expect(virtualTag.getRule(3)).toBe('');
+    expect(windowedTag1.getRule(0)).toBe('.c {}');
+    expect(windowedTag1.length).toBe(1);
+    expect(windowedTag2.getRule(0)).toBe('.a-second {}');
+    expect(windowedTag2.getRule(1)).toBe('.c-second {}');
+    expect(windowedTag2.length).toBe(2);
+  });
+});

--- a/packages/styled-components/src/sheet/types.js
+++ b/packages/styled-components/src/sheet/types.js
@@ -16,12 +16,16 @@ export interface GroupedTag {
   insertRules(group: number, rules: string[]): void;
   clearGroup(group: number): void;
   getGroup(group: number): string;
-  length: number;
+  groups: number;
 }
 
-export interface HoistedTag extends GroupedTag {
-  hoistedTag: GroupedTag;
-  normalTag: GroupedTag;
+/** Group-aware Tag that hoists @import rules utilizing GroupedWindowedTags */
+export interface HoistedTag {
+  constructor(tag: Tag): void;
+  insertRules(group: number, rules: string[]): void;
+  clearGroup(group: number): void;
+  getHoistedAndNormalGroups(group: number): { hoisted: string, normal: string };
+  groups: number;
 }
 
 export type SheetOptions = {

--- a/packages/styled-components/src/sheet/types.js
+++ b/packages/styled-components/src/sheet/types.js
@@ -4,7 +4,6 @@ import { type Stringifier } from '../utils/stylis';
 
 /** CSSStyleSheet-like Tag abstraction for CSS rules */
 export interface Tag {
-  constructor(target?: HTMLElement): void;
   insertRule(index: number, rule: string): boolean;
   deleteRule(index: number): void;
   getRule(index: number): string;
@@ -20,6 +19,11 @@ export interface GroupedTag {
   length: number;
 }
 
+export interface HoistedTag extends GroupedTag {
+  hoistedTag: GroupedTag;
+  normalTag: GroupedTag;
+}
+
 export type SheetOptions = {
   isServer: boolean,
   stringifier: Stringifier,
@@ -31,7 +35,7 @@ export interface Sheet {
   clearNames(id: string): void;
   clearRules(id: string): void;
   clearTag(): void;
-  getTag(): GroupedTag;
+  getTag(): HoistedTag;
   hasNameForId(id: string, name: string): boolean;
   insertRules(id: string, name: string, rules: string[]): void;
   options: SheetOptions;


### PR DESCRIPTION
> **NOTE:** This is only proof-of-concept quality code

This implements rule hoisting by adding two new abstractions to the `styled-sheet` implementation:

- `WindowedTag`: A wrapper around any Tag that creates a linked list of Tags that all operate on the same underlying tag, with the same interface
- `HoistingTag`: A wrapper around `GroupedTag` that creates two `GroupedTag`s with one `WindowedTag` each internally that are used to separate hoisted from non-hoisted rules

This should work, but I havent tested it yet. It highlights that some things need to be cleaned up. The output logic is pretty ugly now and needs to be put onto the `GroupedTag` itself (?). Not quite sure, but maybe this is fine as it is.

The interfaces worked well when there were three layers, but now that there are five, it seems like an unnecessary addition that leads to indirection. Maybe the code structure can be improved, but that may also be out-of-scope for this PR.

Edit: The SSR output needs to avoid the usual markers for hoisted rules.