### PR TITLE
Add new param shouldForwardProps to allow the passing in of 'invalid' attributes

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -102,7 +102,7 @@
   "bundlesize": [
     {
       "path": "./dist/styled-components.min.js",
-      "maxSize": "16.25kB"
+      "maxSize": "16.26kB"
     }
   ],
   "collective": {

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -136,6 +136,7 @@ class StyledComponent extends Component<*> {
 
     const elementToBeCreated = this.props.as || this.attrs.as || target;
     const isTargetTag = isTag(elementToBeCreated);
+    const { shouldForwardProps } = this.props;
 
     const propsForElement = {};
     const computedProps = { ...this.props, ...this.attrs };
@@ -147,11 +148,11 @@ class StyledComponent extends Component<*> {
         this.warnInnerRef(displayName);
       }
 
-      if (key === 'forwardedComponent' || key === 'as') {
+      if (key === 'forwardedComponent' || key === 'as' || key === 'shouldForwardProps') {
         continue;
       } else if (key === 'forwardedRef') propsForElement.ref = computedProps[key];
       else if (key === 'forwardedAs') propsForElement.as = computedProps[key];
-      else if (!isTargetTag || validAttr(key)) {
+      else if (!isTargetTag || shouldForwardProps || validAttr(key)) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }


### PR DESCRIPTION
This PR came up because we were using v3 and were passing in what are being determined as invalid attributes. We upgrade for v4 to fix another styling issue and found out our analytics broke.

We use these attributes for our analytics tracking to have simple event listeners set up globally.

```<button anclick="home_page_button" type="primary" class="buttonstyled__Button-sc-1t8li5e-0 YHsJf">HomePage</button>```

The usage to achieve bring the attributes back is by simply adding `shouldForwardProps` to the styled component.

```
return <StyledButton
          anclick={anclick}
          anevent={anevent}
          atc={atc}
          btnsize={btnsize}
          btnwidth={btnwidth}
          disabled={disabled}
          id={id}
          onClick={this.onClick}
          type={type}
          ref={forwardedRef}
          shouldForwardProps
          {...this.props}
        >
          {children}
        </StyledButton>;
```