### PR TITLE
Make ThemeProvider error straightforward

### DIFF
--- a/packages/styled-components/src/models/ThemeProvider.js
+++ b/packages/styled-components/src/models/ThemeProvider.js
@@ -17,6 +17,10 @@ export const ThemeContext: Context<Theme | void> = React.createContext();
 export const ThemeConsumer = ThemeContext.Consumer;
 
 function useMergedTheme(theme: ThemeArgument, outerTheme?: Theme): Theme {
+  if (!theme) {
+    return throwStyledError(14);
+  }
+
   if (isFunction(theme)) {
     const mergedTheme = theme(outerTheme);
 
@@ -30,7 +34,7 @@ function useMergedTheme(theme: ThemeArgument, outerTheme?: Theme): Theme {
     return mergedTheme;
   }
 
-  if (theme === null || Array.isArray(theme) || typeof theme !== 'object') {
+  if (Array.isArray(theme) || typeof theme !== 'object') {
     return throwStyledError(8);
   }
 

--- a/packages/styled-components/src/utils/errors.md
+++ b/packages/styled-components/src/utils/errors.md
@@ -68,3 +68,7 @@ It seems you are interpolating a keyframe declaration (%s) into an untagged stri
 ## 13
 
 %s is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.
+
+## 14
+
+Theme Provider: "theme" prop is required.


### PR DESCRIPTION
Super small change, just for the sake of keeping errors dead simple and straightforward.
I think that theres a chance that it might save someone a bit of confusion.