### PR TITLE
feat: add failing unit test for selection issue

### DIFF
--- a/packages/styled-components/src/test/basic.test.js
+++ b/packages/styled-components/src/test/basic.test.js
@@ -389,6 +389,17 @@ Object {
 
       expect(spy).not.toHaveBeenCalled();
     });
+
+    it('Should allow selection by data props', () => {
+      const Comp = styled.div`
+        color: red;
+      `;
+
+      const output = TestRenderer.create(<Comp data-cy="custom-data" />);
+      const selection = output.root.findAllByProps({ 'data-cy': 'custom-data' });
+      
+      expect(selection.length).toEqual(1);
+    });
   });
 
   describe('warnings', () => {


### PR DESCRIPTION
There is an open issue where styled-components are breaking unit tests by returning too many items when you select by properties. Here is a failing unit test to show the issue.

https://github.com/styled-components/styled-components/issues/2774