### PR TITLE
[bugfix] fix imports for react-native-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Fix `styled-components`'s `react-native` import for React Native Web, by [@fiberjw](https://github.com/fiberjw) (see [#2797](https://github.com/styled-components/styled-components/pull/2797))
+
 ## [v4.4.0] - 2019-09-23
 
 - Fix to use `ownerDocument` instead of global `document`, by [@yamachig](https://github.com/yamachig) (see [#2721](https://github.com/styled-components/styled-components/pull/2721))

--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -1,8 +1,5 @@
 // @flow
 
-/* eslint-disable import/no-unresolved */
-import reactNative, { StyleSheet } from 'react-native';
-
 import _InlineStyle from '../models/InlineStyle';
 import _StyledNativeComponent from '../models/StyledNativeComponent';
 
@@ -13,6 +10,10 @@ import withTheme from '../hoc/withTheme';
 import isStyledComponent from '../utils/isStyledComponent';
 
 import type { Target } from '../types';
+
+const reactNative = require('react-native');
+
+const { StyleSheet } = reactNative;
 
 const InlineStyle = _InlineStyle(StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);


### PR DESCRIPTION
Hello 👋🏾,

This bug surfaced as a result of trying to use styled-components in an Expo universal project (React Native + React Native Web). `react-native-web` doesn't use default exports like `react-native` official does, so importing using ES6 default imports breaks it for that react native renderer (`TypeError: Cannot read property 'View' of undefined`). Using `require` creates the desired behavior both in `react-native` and `react-native-web` without tripping up the `navigator is deprecated and has been removed from this package.` invariant that pops up when trying to use `import  * as reactNative from 'react-native'`.

It's a pretty simple fix and all of the tests passed, so I hope that this is easy to review and possibly merge.

Thanks!

fixes #2624

-- Juwan Wheatley (@fiberjw)