### PR TITLE
Revert "Use ownerDocument instead of global document (#2726)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Remove deprecated functionality (object-form `.attrs({})`)
 
-- Fix to use `ownerDocument` instead of global `document`, by [@yamachig](https://github.com/yamachig) (see [#2721](https://github.com/styled-components/styled-components/pull/2721))
-
 - Fix attrs not taking precedence over props when overriding a given prop
 
 ## [v4.3.2] - 2019-06-19

--- a/packages/styled-components/src/sheet/Rehydration.js
+++ b/packages/styled-components/src/sheet/Rehydration.js
@@ -88,9 +88,7 @@ const rehydrateSheetFromTag = (sheet: Sheet, style: HTMLStyleElement) => {
 };
 
 export const rehydrateSheet = (sheet: Sheet) => {
-  let targetDocument = document;
-  if(sheet.options.target) targetDocument = sheet.options.target.ownerDocument;
-  const nodes = targetDocument.querySelectorAll(SELECTOR);
+  const nodes = document.querySelectorAll(SELECTOR);
 
   for (let i = 0, l = nodes.length; i < l; i++) {
     const node = ((nodes[i]: any): HTMLStyleElement);

--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -26,7 +26,7 @@ export class CSSOMTag implements Tag {
     const element = (this.element = makeStyleTag(target));
 
     // Avoid Edge bug where empty style elements don't create sheets
-    element.appendChild(element.ownerDocument.createTextNode(''));
+    element.appendChild(document.createTextNode(''));
 
     this.sheet = getSheet(element);
     this.length = 0;
@@ -74,7 +74,7 @@ export class TextTag implements Tag {
 
   insertRule(index: number, rule: string): boolean {
     if (index <= this.length && index >= 0) {
-      const node = this.element.ownerDocument.createTextNode(rule);
+      const node = document.createTextNode(rule);
       const refNode = this.nodes[index];
       this.element.insertBefore(node, refNode || null);
       this.length++;

--- a/packages/styled-components/src/sheet/dom.js
+++ b/packages/styled-components/src/sheet/dom.js
@@ -21,11 +21,9 @@ const findLastStyleTag = (target: HTMLElement): void | HTMLStyleElement => {
 
 /** Create a style element inside `target` or <head> after the last */
 export const makeStyleTag = (target?: HTMLElement): HTMLStyleElement => {
-  let targetDocument = document;
-  if(target) targetDocument = target.ownerDocument;
-  const head = ((targetDocument.head: any): HTMLElement);
+  const head = ((document.head: any): HTMLElement);
   const parent = target || head;
-  const style = targetDocument.createElement('style');
+  const style = document.createElement('style');
   const prevStyle = findLastStyleTag(parent);
   const nextSibling = prevStyle !== undefined ? prevStyle.nextSibling : null;
 


### PR DESCRIPTION
This reverts commit 51bf23de7d6c0832189147d492aa8574d5692011.

This appears to break SSR rehydration for some reason.