### PR TITLE
append "class" instead of "className" for unidentified DOM elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Use `class` instead of `className` for unidentified DOM elements (better support for styling web components)
+
+- Upgrade to stylis v4
+
+## [v5.2.0] - 2020-09-04
+
 - Make sure `StyleSheetManager` renders all styles in iframe / child windows (see [#3159](https://github.com/styled-components/styled-components/pull/3159)) thanks @eramdam!
 
 - Rework how components self-reference in extension scenarios (see [#3236](https://github.com/styled-components/styled-components/pull/3236)); should fix a bunch of subtle bugs around patterns like `& + &`
@@ -1147,7 +1153,8 @@ _v3.3.1 was skipped due to a bad deploy._
 
 - Fixed compatibility with other react-broadcast-based systems (like `react-router` v4)
 
-[unreleased]: https://github.com/styled-components/styled-components/compare/v5.1.0...master
+[unreleased]: https://github.com/styled-components/styled-components/compare/v5.2.0...master
+[v5.2.0]: https://github.com/styled-components/styled-components/compare/v5.1.0...v5.2.0
 [v5.1.1]: https://github.com/styled-components/styled-components/compare/v5.1.0...v5.1.1
 [v5.1.0]: https://github.com/styled-components/styled-components/compare/v5.0.1...v5.1.0
 [v5.0.1]: https://github.com/styled-components/styled-components/compare/v5.0.0...v5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,8 @@ Read the [v5 release announcement](https://medium.com/styled-components/announci
 
 * Fix regressed behavior between v3 and v4 where className was not correctly aggregated between folded `.attrs` invocations
 
+- Fix support for styling custom elements (https://github.com/styled-components/styled-components/pull/2819)
+
 ## [v4.4.1] - 2019-10-30
 
 - Fix `styled-components`'s `react-native` import for React Native Web, by [@fiberjw](https://github.com/fiberjw) (see [#2797](https://github.com/styled-components/styled-components/pull/2797))

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -14,6 +14,7 @@ import type {
 import { checkDynamicCreation } from '../utils/checkDynamicCreation';
 import createWarnTooManyClasses from '../utils/createWarnTooManyClasses';
 import determineTheme from '../utils/determineTheme';
+import domElements from '../utils/domElements';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '../utils/empties';
 import escape from '../utils/escape';
 import generateComponentId from '../utils/generateComponentId';
@@ -154,9 +155,11 @@ function useStyledComponentImpl(
     propsForElement.style = { ...props.style, ...attrs.style };
   }
 
-  propsForElement.className = Array.prototype
+  propsForElement[
+    // handle custom elements which React doesn't properly alias
+    isTargetTag && domElements.indexOf(elementToBeCreated) === -1 ? 'class' : 'className'
+  ] = foldedComponentIds
     .concat(
-      foldedComponentIds,
       styledComponentId,
       generatedClassName !== styledComponentId ? generatedClassName : null,
       props.className,

--- a/packages/styled-components/src/test/basic.test.js
+++ b/packages/styled-components/src/test/basic.test.js
@@ -231,6 +231,18 @@ describe('basic', () => {
     expect(Comp.displayName).toBe('Styled(Comp)');
   });
 
+  it('works with custom elements (use class instead of className)', () => {
+    const Comp = styled('custom-element')`
+      color: red;
+    `;
+
+    expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
+      <custom-element
+        class="sc-a b"
+      />
+    `);
+  });
+
   describe('jsdom tests', () => {
     class InnerComponent extends Component<*, *> {
       render() {


### PR DESCRIPTION
fixes #2802

React doesn't alias className -> class for custom elements, so appending
styles doesn't work properly without this change