### PR TITLE
Added check to flag isStatic to be true if in production or development.

### DIFF
--- a/packages/styled-components/src/models/ComponentStyle.js
+++ b/packages/styled-components/src/models/ComponentStyle.js
@@ -28,7 +28,7 @@ export default class ComponentStyle {
 
   constructor(rules: RuleSet, attrs: Attrs, componentId: string) {
     this.rules = rules;
-    this.isStatic = process.env.NODE_ENV === 'production' && isStaticRules(rules, attrs);
+    this.isStatic = process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'development' && isStaticRules(rules, attrs);
     this.componentId = componentId;
 
     if (!StyleSheet.master.hasId(componentId)) {


### PR DESCRIPTION
The ssr classname conflict error is still being thrown in development for the latest release of 4.4.0. Upon checking the fix that was implemented for this in that version I noticed that this flag was only true if in a production environment. The commit I am referring to was in #2701