### PR TITLE
shard cGS by runtime instance

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -1,6 +1,6 @@
 // @flow
-import React, { useContext, useEffect } from 'react';
-import { IS_BROWSER, STATIC_EXECUTION_CONTEXT } from '../constants';
+import React, { useContext, useEffect, useMemo } from 'react';
+import { STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheet } from '../models/StyleSheetManager';
 import determineTheme from '../utils/determineTheme';
@@ -12,11 +12,6 @@ import type { Interpolation } from '../types';
 
 type GlobalStyleComponentPropsType = Object;
 
-// place our cache into shared context so it'll persist between HMRs
-if (IS_BROWSER) {
-  window.scCGSHMRCache = {};
-}
-
 export default function createGlobalStyle(
   strings: Array<string>,
   ...interpolations: Array<Interpolation>
@@ -24,10 +19,12 @@ export default function createGlobalStyle(
   const rules = css(strings, ...interpolations);
   const styledComponentId = `sc-global-${hasher(JSON.stringify(rules))}`;
   const globalStyle = new GlobalStyle(rules, styledComponentId);
+  let count = 0;
 
   function GlobalStyleComponent(props: GlobalStyleComponentPropsType) {
     const styleSheet = useStyleSheet();
     const theme = useContext(ThemeContext);
+    const instance = useMemo(() => String(++count), []);
 
     if (process.env.NODE_ENV !== 'production' && React.Children.count(props.children)) {
       // eslint-disable-next-line no-console
@@ -37,37 +34,17 @@ export default function createGlobalStyle(
     }
 
     if (globalStyle.isStatic) {
-      globalStyle.renderStyles(STATIC_EXECUTION_CONTEXT, styleSheet);
+      globalStyle.renderStyles(instance, STATIC_EXECUTION_CONTEXT, styleSheet);
     } else {
       const context = {
         ...props,
         theme: determineTheme(props, theme, GlobalStyleComponent.defaultProps),
       };
 
-      globalStyle.renderStyles(context, styleSheet);
+      globalStyle.renderStyles(instance, context, styleSheet);
     }
 
-    useEffect(() => {
-      if (IS_BROWSER) {
-        window.scCGSHMRCache[styledComponentId] =
-          (window.scCGSHMRCache[styledComponentId] || 0) + 1;
-
-        return () => {
-          if (window.scCGSHMRCache[styledComponentId]) {
-            window.scCGSHMRCache[styledComponentId] -= 1;
-          }
-          /**
-           * Depending on the order "render" is called this can cause the styles to be lost
-           * until the next render pass of the remaining instance, which may
-           * not be immediate.
-           */
-          if (window.scCGSHMRCache[styledComponentId] === 0) {
-            globalStyle.removeStyles(styleSheet);
-          }
-        };
-      }
-      return undefined;
-    }, []);
+    useEffect(() => () => globalStyle.removeStyles(instance, styleSheet), []);
 
     return null;
   }

--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -26,7 +26,7 @@ export default function createGlobalStyle(
     const theme = useContext(ThemeContext);
     const instanceRef = useRef(null);
 
-    if (instanceRef.current === null) instanceRef.current = String(++count);
+    if (instanceRef.current === null) instanceRef.current = ++count;
 
     const instance = instanceRef.current;
 

--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheet } from '../models/StyleSheetManager';
@@ -24,7 +24,11 @@ export default function createGlobalStyle(
   function GlobalStyleComponent(props: GlobalStyleComponentPropsType) {
     const styleSheet = useStyleSheet();
     const theme = useContext(ThemeContext);
-    const instance = useMemo(() => String(++count), []);
+    const instanceRef = useRef(null);
+
+    if (instanceRef.current === null) instanceRef.current = String(++count);
+
+    const instance = instanceRef.current;
 
     if (process.env.NODE_ENV !== 'production' && React.Children.count(props.children)) {
       // eslint-disable-next-line no-console

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.js
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.js
@@ -69,7 +69,7 @@ describe(`createGlobalStyle`, () => {
 
     expect(html).toBe('');
     expect(stripWhitespace(stripComments(style.textContent))).toMatchInlineSnapshot(
-      `"[data-test-inject]{ color:red; } data-styled.g1[id=\\"sc-global-a\\"]{ content:\\"sc-global-a,\\"} "`
+      `"[data-test-inject]{ color:red; } data-styled.g1[id=\\"sc-global-a1\\"]{ content:\\"sc-global-a1,\\"} "`
     );
   });
 
@@ -372,7 +372,7 @@ describe(`createGlobalStyle`, () => {
       document.body.removeChild(styleContainer);
 
       ReactDOM.unmountComponentAtNode(container);
-    } catch(e) {
+    } catch (e) {
       fail('should not throw exception');
     }
 

--- a/packages/styled-components/src/models/GlobalStyle.js
+++ b/packages/styled-components/src/models/GlobalStyle.js
@@ -18,7 +18,7 @@ export default class GlobalStyle {
     this.isStatic = isStaticRules(rules);
   }
 
-  createStyles(instance: string, executionContext: Object, styleSheet: StyleSheet) {
+  createStyles(instance: number, executionContext: Object, styleSheet: StyleSheet) {
     const flatCSS = flatten(this.rules, executionContext, styleSheet);
     const css = styleSheet.options.stringifier(flatCSS.join(''), '');
     const id = this.componentId + instance;
@@ -27,11 +27,11 @@ export default class GlobalStyle {
     styleSheet.insertRules(id, id, css);
   }
 
-  removeStyles(instance: string, styleSheet: StyleSheet) {
+  removeStyles(instance: number, styleSheet: StyleSheet) {
     styleSheet.clearRules(this.componentId + instance);
   }
 
-  renderStyles(instance: string, executionContext: Object, styleSheet: StyleSheet) {
+  renderStyles(instance: number, executionContext: Object, styleSheet: StyleSheet) {
     StyleSheet.registerId(this.componentId + instance);
 
     // NOTE: Remove old styles, then inject the new ones

--- a/packages/styled-components/src/models/GlobalStyle.js
+++ b/packages/styled-components/src/models/GlobalStyle.js
@@ -16,25 +16,26 @@ export default class GlobalStyle {
     this.rules = rules;
     this.componentId = componentId;
     this.isStatic = isStaticRules(rules);
-    StyleSheet.registerId(componentId);
   }
 
-  createStyles(executionContext: Object, styleSheet: StyleSheet) {
+  createStyles(instance: string, executionContext: Object, styleSheet: StyleSheet) {
     const flatCSS = flatten(this.rules, executionContext, styleSheet);
     const css = styleSheet.options.stringifier(flatCSS.join(''), '');
-    const id = this.componentId;
+    const id = this.componentId + instance;
 
     // NOTE: We use the id as a name as well, since these rules never change
     styleSheet.insertRules(id, id, css);
   }
 
-  removeStyles(styleSheet: StyleSheet) {
-    styleSheet.clearRules(this.componentId);
+  removeStyles(instance: string, styleSheet: StyleSheet) {
+    styleSheet.clearRules(this.componentId + instance);
   }
 
-  renderStyles(executionContext: Object, styleSheet: StyleSheet) {
+  renderStyles(instance: string, executionContext: Object, styleSheet: StyleSheet) {
+    StyleSheet.registerId(this.componentId + instance);
+
     // NOTE: Remove old styles, then inject the new ones
-    this.removeStyles(styleSheet);
-    this.createStyles(executionContext, styleSheet);
+    this.removeStyles(instance, styleSheet);
+    this.createStyles(instance, executionContext, styleSheet);
   }
 }

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
@@ -3,20 +3,20 @@
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 2`] = `
-"<style nonce=\\"foo\\" data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">body{background:papayawhip;}
-data-styled.g1[id=\\"sc-global-a\\"]{content:\\"sc-global-a,\\"}
-.c{color:red;}
-data-styled.g2[id=\\"sc-b\\"]{content:\\"c,\\"}
+"<style nonce=\\"foo\\" data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
+body{background:papayawhip;}
+data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 </style>"
 `;
 
 exports[`ssr should extract both global and local CSS 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should extract both global and local CSS 2`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">body{background:papayawhip;}
-data-styled.g1[id=\\"sc-global-a\\"]{content:\\"sc-global-a,\\"}
-.c{color:red;}
-data-styled.g2[id=\\"sc-b\\"]{content:\\"c,\\"}
+"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
+body{background:papayawhip;}
+data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 </style>"
 `;
 
@@ -31,10 +31,10 @@ data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
 exports[`ssr should handle errors while streaming 1`] = `[Invariant Violation: React.Children.only expected to receive a single React element child.]`;
 
 exports[`ssr should interleave styles with rendered HTML when utilitizing streaming 1`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">body{background:papayawhip;}
-data-styled.g1[id=\\"sc-global-a\\"]{content:\\"sc-global-a,\\"}
-.c{color:red;}
-data-styled.g2[id=\\"sc-b\\"]{content:\\"c,\\"}
+"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
+body{background:papayawhip;}
+data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 </style><h1 class=\\"sc-b c\\">Hello SSR!</h1>"
 `;
 
@@ -51,10 +51,10 @@ data-styled.g2[id=\\"TWO\\"]{content:\\"a,\\"}
 exports[`ssr should return a generated React style element 1`] = `
 Object {
   "dangerouslySetInnerHTML": Object {
-    "__html": "body{background:papayawhip;}
-data-styled.g1[id=\\"sc-global-a\\"]{content:\\"sc-global-a,\\"}
-.c{color:red;}
-data-styled.g2[id=\\"sc-b\\"]{content:\\"c,\\"}
+    "__html": ".c{color:red;}
+data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
+body{background:papayawhip;}
+data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 ",
   },
   "data-styled": "",
@@ -70,10 +70,10 @@ exports[`ssr should throw if getStyleElement is called after interleaveWithNodeS
 `;
 
 exports[`ssr should throw if getStyleElement is called after streaming is complete 1`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">body{background:papayawhip;}
-data-styled.g1[id=\\"sc-global-a\\"]{content:\\"sc-global-a,\\"}
-.c{color:red;}
-data-styled.g2[id=\\"sc-b\\"]{content:\\"c,\\"}
+"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
+body{background:papayawhip;}
+data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 </style><h1 class=\\"sc-b c\\">Hello SSR!</h1>"
 `;
 
@@ -92,10 +92,10 @@ exports[`ssr should throw if getStyleTags is called after interleaveWithNodeStre
 `;
 
 exports[`ssr should throw if getStyleTags is called after streaming is complete 1`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">body{background:papayawhip;}
-data-styled.g1[id=\\"sc-global-a\\"]{content:\\"sc-global-a,\\"}
-.c{color:red;}
-data-styled.g2[id=\\"sc-b\\"]{content:\\"c,\\"}
+"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
+body{background:papayawhip;}
+data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 </style><h1 class=\\"sc-b c\\">Hello SSR!</h1>"
 `;
 

--- a/packages/styled-components/src/test/rehydration.test.js
+++ b/packages/styled-components/src/test/rehydration.test.js
@@ -207,44 +207,37 @@ describe('rehydration', () => {
       const Component = createGlobalStyle`
         body { color: tomato; }
       `;
+
       const A = styled.div.withConfig({ componentId: 'ONE' })`
         color: blue;
         ${() => ''}
       `;
+
       TestRenderer.create(<Component />);
       TestRenderer.create(<A />);
 
+      // although `<Component />` is rendered before `<A />`, the global style isn't registered until render time
+      // compared to typical component styles which are registered at creation time
       expectCSSMatches(
-        'body { background: papayawhip; } .a { color: red; } body { color:tomato; } .b { color:blue; }'
+        'body { background: papayawhip; } .a { color: red; } .b { color:blue; } body { color:tomato; }'
       );
-
-      expect(getStyleTags()).toEqual([
-        {
-          css:
-            'body {background: papayawhip;}' +
-            '.a {color: red;}' +
-            'body{color:tomato;}.b{color:blue;}',
-        },
-      ]);
     });
   });
 
   describe('with all styles already rendered', () => {
-    let styleTags;
     beforeEach(() => {
       document.head.innerHTML = `
         <style ${SC_ATTR} ${SC_ATTR_VERSION}="${__VERSION__}">
           html { font-size: 16px; }
-          ${SC_ATTR}.g1[id="sc-global-a"]{content: "sc-global-a,"}
+          ${SC_ATTR}.g1[id="sc-global-a1"]{content: "sc-global-a1,"}
           body { background: papayawhip; }
-          ${SC_ATTR}.g2[id="sc-global-b"]{content: "sc-global-b,"}
+          ${SC_ATTR}.g2[id="sc-global-b1"]{content: "sc-global-b1,"}
           .c { color: blue; }
           ${SC_ATTR}.g3[id="ONE"]{content: "c,"}
           .d { color: red; }
           ${SC_ATTR}.g4[id="TWO"]{content: "d,"}
         </style>
       `;
-      styleTags = Array.from(document.querySelectorAll('style'));
 
       resetSheet(masterSheet);
     });


### PR DESCRIPTION
fixes #2769 #2739

cGS has a different injection profile than typical components, in that
there is a single component ID for the global style and any number of
instances. This creates problems when rendering multiple of the same
cGS with different props, as it is a defacto singleton but we don't
enforce a single cGS instance at once...

Utilizing a simple sharding strategy will create duplicate styles, but
ensure that when instances are removed from the page they're taken out
of the stylesheet in the proper order such that previous still-live
instances will continue to function and not be removed as well.

Not working: https://codesandbox.io/embed/style-with-styled-components-kvsrk
Working: https://codesandbox.io/s/style-with-styled-components-bs4mw