### PR TITLE
(v5) aggregate classNames passed via attrs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Fix certain adblockers messing up styling by purposefully not emitting the substring "ad" (case-insensitive) when generating dynamic class names
 
+- Fix regressed behavior between v3 and v4 where className was not correctly aggregated between folded `.attrs` invocations
+
 ## [v4.3.2] - 2019-06-19
 
 - Fix usage of the "css" prop with the styled-components babel macro (relevant to CRA 2.x users), by [@jamesknelson](http://github.com/jamesknelson) (see [#2633](https://github.com/styled-components/styled-components/issues/2633))

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -57,7 +57,10 @@ function useResolvedAttrs<Config>(theme: any = EMPTY_OBJECT, props: Config, attr
 
     /* eslint-disable guard-for-in */
     for (key in resolvedAttrDef) {
-      context[key] = resolvedAttrs[key] = resolvedAttrDef[key];
+      context[key] = resolvedAttrs[key] =
+        key === 'className'
+          ? [resolvedAttrs[key], resolvedAttrDef[key]].filter(Boolean).join(' ')
+          : resolvedAttrDef[key];
     }
     /* eslint-enable guard-for-in */
   });

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -14,11 +14,12 @@ import determineTheme from '../utils/determineTheme';
 import escape from '../utils/escape';
 import generateDisplayName from '../utils/generateDisplayName';
 import getComponentName from '../utils/getComponentName';
+import hasher from '../utils/hasher';
 import hoist from '../utils/hoist';
 import isFunction from '../utils/isFunction';
-import isTag from '../utils/isTag';
 import isStyledComponent from '../utils/isStyledComponent';
-import hasher from '../utils/hasher';
+import isTag from '../utils/isTag';
+import joinStrings from '../utils/joinStrings';
 import { ThemeContext } from './ThemeProvider';
 import { useStyleSheet } from './StyleSheetManager';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '../utils/empties';
@@ -58,7 +59,7 @@ function useResolvedAttrs<Config>(theme: any = EMPTY_OBJECT, props: Config, attr
     for (key in resolvedAttrDef) {
       context[key] = resolvedAttrs[key] =
         key === 'className'
-          ? [resolvedAttrs[key], resolvedAttrDef[key]].filter(Boolean).join(' ')
+          ? joinStrings(resolvedAttrs[key], resolvedAttrDef[key])
           : resolvedAttrDef[key];
     }
     /* eslint-enable guard-for-in */

--- a/packages/styled-components/src/test/attrs.test.js
+++ b/packages/styled-components/src/test/attrs.test.js
@@ -86,11 +86,11 @@ describe('attrs', () => {
         </ThemeProvider>
       ).toJSON()
     ).toMatchInlineSnapshot(`
-      <button
-        className="sc-a b"
-        data-color="red"
-      />
-    `);
+            <button
+              className="sc-a b"
+              data-color="red"
+            />
+        `);
   });
 
   it('defaultProps are merged into what function attrs receives', () => {
@@ -105,11 +105,11 @@ describe('attrs', () => {
     };
 
     expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
-      <button
-        className="sc-a b"
-        data-color="red"
-      />
-    `);
+            <button
+              className="sc-a b"
+              data-color="red"
+            />
+        `);
   });
 
   it('pass props to the attr function', () => {
@@ -138,6 +138,20 @@ describe('attrs', () => {
     }))``;
 
     expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
+  });
+
+  it('should merge className from folded attrs', () => {
+    const Inner = styled.div.attrs({ className: 'foo' })``;
+
+    const Comp = styled(Inner).attrs(() => ({
+      className: 'meow nya',
+    }))``;
+
+    expect(TestRenderer.create(<Comp className="something" />).toJSON()).toMatchInlineSnapshot(`
+      <div
+        className="sc-a sc-b c something foo meow nya"
+      />
+    `);
   });
 
   it('should merge className even if its a function', () => {
@@ -258,18 +272,18 @@ describe('attrs', () => {
 
     expectCSSMatches(`.d {background: red;} .c {background: blue;}`);
     expect(rendered.toJSON()).toMatchInlineSnapshot(`
-      <p
-        className="sc-a d sc-b c"
-        style={
-          Object {
-            "color": "blue",
-            "fontSize": "4em",
-          }
-        }
-      >
-        Hello
-      </p>
-    `);
+            <p
+              className="sc-a d sc-b c"
+              style={
+                Object {
+                  "color": "blue",
+                  "fontSize": "4em",
+                }
+              }
+            >
+              Hello
+            </p>
+        `);
   });
 
   it('does not pass non html tags to HTML element', () => {

--- a/packages/styled-components/src/utils/joinStrings.js
+++ b/packages/styled-components/src/utils/joinStrings.js
@@ -1,0 +1,6 @@
+/**
+ * Convenience function for joining strings to form className chains
+ */
+export default function joinStrings(a, b) {
+  return a && b ? `${a} ${b}` : a || b;
+}

--- a/packages/styled-components/src/utils/joinStrings.js
+++ b/packages/styled-components/src/utils/joinStrings.js
@@ -1,6 +1,6 @@
 /**
  * Convenience function for joining strings to form className chains
  */
-export default function joinStrings(a, b) {
+export default function joinStrings(a: ?String, b: ?String): ?String {
   return a && b ? `${a} ${b}` : a || b;
 }

--- a/packages/styled-components/src/utils/test/joinStrings.test.js
+++ b/packages/styled-components/src/utils/test/joinStrings.test.js
@@ -1,0 +1,17 @@
+import joinStrings from '../joinStrings';
+
+describe('joinStrings(string?, string?)', () => {
+  it('joins the two strings with a space between', () => {
+    expect(joinStrings('a', 'b')).toBe('a b');
+    expect(joinStrings('a ', 'b')).toBe('a  b');
+    expect(joinStrings('a ', ' b')).toBe('a   b');
+  });
+
+  it('ignores falsy inputs', () => {
+    expect(joinStrings('a')).toBe('a');
+    expect(joinStrings('a', null)).toBe('a');
+    expect(joinStrings('a', '')).toBe('a');
+    expect(joinStrings(null, 'b')).toBe('b');
+    expect(joinStrings('', 'b')).toBe('b');
+  });
+});


### PR DESCRIPTION
fixes #2839

Normally attrs fully override the previous value, but in the case of
className they're often composed additively and it's desired to retain
the previous value in a HOC or folding scenario.