### PR TITLE
Update `inclusive organization` action to add contributors to a team and add a comment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Invite contributor to the organization
-        uses: lekterable/inclusive-organization-action@v1.0.0
+        uses: lekterable/inclusive-organization-action@v1.1.0
         with:
           organization: styled-components
+          team: Collaborators
+          comment: >
+            Thank you so much for helping us improve styled-components! Based on our [Community Guidelines](https://github.com/styled-components/styled-components/blob/master/CONTRIBUTING.md) every person that has a PR of any kind merged is offered **an invitation to the styled-components organization**—that is you right now!
+            
+            
+            Should you accept, you'll get write access to the main repository. (and a fancy `styled-components` logo on your GitHub profile!) You'll be able to label and close issues, merge pull requests, create new branches, etc. We want you to help us out with those things, so don't be scared to do them! Make sure to read our [contribution and community guidelines](https://github.com/styled-components/styled-components/blob/master/CONTRIBUTING.md), which explains all of this in more detail. Of course, if you have any questions just let me know!
         env:
           ACCESS_TOKEN: ${{ secrets.ORG_ADMIN_ACCESS_TOKEN }}


### PR DESCRIPTION
Closes #2836

Comment should look exactly as https://github.com/styled-components/styled-components/pull/1652#issuecomment-380669357

I'll need you @mxstbr to add a scope of `public_repo` to the token so that it has rights to comment.

After the merge, as I'm not in the collaborators team I should be added there and get a comment. On the next PR's I should no longer receive a comment.