### PR TITLE
Expose version in API

### DIFF
--- a/packages/styled-components/src/base.js
+++ b/packages/styled-components/src/base.js
@@ -21,6 +21,9 @@ import withTheme from './hoc/withTheme';
 /* Import hooks */
 import useTheme from './hooks/useTheme';
 
+declare var __VERSION__: string;
+const version = __VERSION__;
+
 /* Warning if you've imported this file on React Native */
 if (
   process.env.NODE_ENV !== 'production' &&
@@ -67,5 +70,6 @@ export {
   ThemeContext,
   ThemeProvider,
   useTheme,
+  version,
   withTheme,
 };

--- a/packages/styled-components/src/base.js
+++ b/packages/styled-components/src/base.js
@@ -21,6 +21,7 @@ import withTheme from './hoc/withTheme';
 /* Import hooks */
 import useTheme from './hooks/useTheme';
 
+/* Export bundle version */
 declare var __VERSION__: string;
 const version = __VERSION__;
 

--- a/packages/styled-components/src/base.js
+++ b/packages/styled-components/src/base.js
@@ -21,7 +21,7 @@ import withTheme from './hoc/withTheme';
 /* Import hooks */
 import useTheme from './hooks/useTheme';
 
-/* Export bundle version */
+/* Define bundle version for export */
 declare var __VERSION__: string;
 const version = __VERSION__;
 


### PR DESCRIPTION
Inspired by React's API: https://github.com/facebook/react/blob/master/packages/react/src/React.js#L105

My company has multiple teams working with styled-components on a shared eco-system. Although there are warnings for multiple style-component versions in the development build, our collisions often occur in the e2e environment where we use the production bundle of styled-components. This, of course, is a specific use case but I'm sure there are similar situations amongst different organizations and exposing the bundle version seems very low-cost to me. 