### PR TITLE
Unnecessary flattening and interleave of css without interpolations

### DIFF
--- a/packages/styled-components/src/constructors/css.js
+++ b/packages/styled-components/src/constructors/css.js
@@ -12,6 +12,11 @@ export default function css(styles: Styles, ...interpolations: Array<Interpolati
     return flatten(interleave(EMPTY_ARRAY, [styles, ...interpolations]));
   }
 
+  if(interpolations.length === 0 && styles.length === 1 && typeof styles[0] === "string") {
+    // $FlowFixMe
+    return styles;
+  }
+
   // $FlowFixMe
   return flatten(interleave(styles, interpolations));
 }


### PR DESCRIPTION
Based on previous question on twitter: https://twitter.com/elvepor/status/1200172654340259840

I believe that some performance of `css` construct could be saved when it doesn't have any interpolations. IMHO we can return just the styles that doesn't have to be flattened and interleaved.

Flow suppress comment is not necessary, but then I have to declare new array and return it: `[styles[0]]`.

I didn't add any new tests as this case is already covered.