### PR TITLE
use funding field instead of postinstall script

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -29,8 +29,7 @@
     "lint:size": "bundlesize",
     "prettier": "prettier */**/*.js --write",
     "prepublishOnly": "npm run build",
-    "dev": "cross-env BABEL_ENV=cjs babel-node example/startServer.js",
-    "postinstall": "node ./scripts/postinstall.js || exit 0"
+    "dev": "cross-env BABEL_ENV=cjs babel-node example/startServer.js"
   },
   "repository": {
     "type": "git",
@@ -97,6 +96,10 @@
     }
   ],
   "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/styled-components"
+  },
+  "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/styled-components"
   }

--- a/packages/styled-components/scripts/postinstall.js
+++ b/packages/styled-components/scripts/postinstall.js
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-/* eslint-disable */
-/* Adapted from nodemon's postinstall: https://github.com/remy/nodemon/blob/master/package.json */
-
-var msg =
-  'Use styled-components at work? Consider supporting our development efforts at https://opencollective.com/styled-components';
-
-console.log(msg);


### PR DESCRIPTION
Thank you for the amazing library!!!

npm supports the`funding` field at v6.13 and Node has updated the bundled npm version to v6.13.4 because of the vulnerability so I think many people are able to use the `fund` subcommand.

- https://github.com/npm/cli/releases/tag/v6.13.0
- https://nodejs.org/en/blog/vulnerability/december-2019-security-releases/

So could you consider to use the `funding` field instead of `postinstall`? 🙏 
I understand that printing a message while installing the package is effective to reach out to many developers but the script is very dangerous so it would be nice if the ecosystem could avoid using this.
Yarn is considering to disable the script by default.
https://github.com/yarnpkg/yarn/issues/7761#issuecomment-565493023
