### PR TITLE
Add componentId to "Over 200 classes..." warning

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -326,7 +326,7 @@ export default function createStyledComponent(target: Target, options: Object, r
 
   if (process.env.NODE_ENV !== 'production') {
     // $FlowFixMe
-    WrappedStyledComponent.warnTooManyClasses = createWarnTooManyClasses(displayName);
+    WrappedStyledComponent.warnTooManyClasses = createWarnTooManyClasses(displayName, styledComponentId);
   }
 
   // $FlowFixMe

--- a/packages/styled-components/src/utils/createWarnTooManyClasses.js
+++ b/packages/styled-components/src/utils/createWarnTooManyClasses.js
@@ -2,7 +2,7 @@
 
 const LIMIT = 200;
 
-export default (displayName: string) => {
+export default (displayName: string, componentId?: string) => {
   let generatedClasses = {};
   let warningSeen = false;
 
@@ -12,8 +12,9 @@ export default (displayName: string) => {
       if (Object.keys(generatedClasses).length >= LIMIT) {
         // Unable to find latestRule in test environment.
         /* eslint-disable no-console, prefer-template */
+        const parsedIdString = componentId ? `with the id of "${componentId.toString()}"` : '';
         console.warn(
-          `Over ${LIMIT} classes were generated for component ${displayName}. \n` +
+          `Over ${LIMIT} classes were generated for component ${displayName}${parsedIdString}.\n` +
             'Consider using the attrs method, together with a style object for frequently changed styles.\n' +
             'Example:\n' +
             '  const Component = styled.div.attrs(props => ({\n' +


### PR DESCRIPTION
Two minor changes:
- Add optional `componentId` parameter to `src/utils/createWarnTooManyClasses.js` that is then rendered in the warning if it exists.
- Pass in `componentId` in `src/models/StyledComponent.js`

Implements #2776