### PR TITLE
allocate cGS instances from the stylesheet instead

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -20,7 +20,6 @@ export default function createGlobalStyle(
   const rules = css(strings, ...interpolations);
   const styledComponentId = `sc-global-${generateComponentId(JSON.stringify(rules))}`;
   const globalStyle = new GlobalStyle(rules, styledComponentId);
-  let count = 0;
 
   function GlobalStyleComponent(props: GlobalStyleComponentPropsType) {
     const styleSheet = useStyleSheet();
@@ -28,7 +27,9 @@ export default function createGlobalStyle(
     const theme = useContext(ThemeContext);
     const instanceRef = useRef(null);
 
-    if (instanceRef.current === null) instanceRef.current = ++count;
+    if (instanceRef.current === null) {
+      instanceRef.current = styleSheet.allocateGSInstance(styledComponentId);
+    }
 
     const instance = instanceRef.current;
 

--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -5,6 +5,7 @@ import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheet, useStylis } from '../models/StyleSheetManager';
 import determineTheme from '../utils/determineTheme';
 import { ThemeContext } from '../models/ThemeProvider';
+import { EMPTY_ARRAY } from '../utils/empties';
 import generateComponentId from '../utils/generateComponentId';
 import css from './css';
 
@@ -49,7 +50,7 @@ export default function createGlobalStyle(
       globalStyle.renderStyles(instance, context, styleSheet, stylis);
     }
 
-    useEffect(() => () => globalStyle.removeStyles(instance, styleSheet), []);
+    useEffect(() => () => globalStyle.removeStyles(instance, styleSheet), EMPTY_ARRAY);
 
     return null;
   }

--- a/packages/styled-components/src/sheet/types.js
+++ b/packages/styled-components/src/sheet/types.js
@@ -25,6 +25,7 @@ export type SheetOptions = {
 };
 
 export interface Sheet {
+  allocateGSInstance(id: string): number;
   clearNames(id: string): void;
   clearRules(id: string): void;
   clearTag(): void;

--- a/packages/styled-components/src/test/rehydration.test.js
+++ b/packages/styled-components/src/test/rehydration.test.js
@@ -24,6 +24,7 @@ const getStyleTags = () =>
 let styled;
 
 const resetSheet = sheet => {
+  sheet.gs = {};
   sheet.names = new Map();
   sheet.clearTag();
   rehydrateSheet(sheet);


### PR DESCRIPTION
fixes #2913

Previously the cGS instance count was managed locally in the cGS factory,
which works fine client-side but will never be reset properly for
server-side rendering (in this case, each cGS factory should be reset
to an instance count of 0 per rendering run.)