### PR TITLE
[styled-components]: reworked how DISABLE_SPEEDY is computed

### DIFF
--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -18,11 +18,11 @@ function isSpeedyDisabled() {
     return SC_DISABLE_SPEEDY;
   }
   if (typeof process !== 'undefined') {
-    if (typeof process.env.REACT_APP_SC_DISABLE_SPEEDY !== 'undefined') {
-      return process.env.REACT_APP_SC_DISABLE_SPEEDY && process.env.REACT_APP_SC_DISABLE_SPEEDY.toLowerCase() === 'true';
+    if (process.env.REACT_APP_SC_DISABLE_SPEEDY) {
+      return process.env.REACT_APP_SC_DISABLE_SPEEDY.toLowerCase() === 'true';
     }
-    if (typeof process.env.SC_DISABLE_SPEEDY !== 'undefined') {
-      return process.env.SC_DISABLE_SPEEDY && process.env.SC_DISABLE_SPEEDY.toLowerCase() === 'true';
+    if (process.env.SC_DISABLE_SPEEDY) {
+      return process.env.SC_DISABLE_SPEEDY.toLowerCase() === 'true';
     }
 
     return process.env.NODE_ENV !== 'production';

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -13,11 +13,25 @@ export const SC_VERSION = __VERSION__;
 
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
-export const DISABLE_SPEEDY =
-  (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
-  (typeof process !== 'undefined' &&
-    (process.env.REACT_APP_SC_DISABLE_SPEEDY || process.env.SC_DISABLE_SPEEDY)) ||
-  process.env.NODE_ENV !== 'production';
+function isSpeedyDisabled() {
+  if (typeof SC_DISABLE_SPEEDY === 'boolean') {
+    return SC_DISABLE_SPEEDY;
+  }
+  if (typeof process !== 'undefined') {
+    if (typeof process.env.REACT_APP_SC_DISABLE_SPEEDY !== 'undefined') {
+      return process.env.REACT_APP_SC_DISABLE_SPEEDY && process.env.REACT_APP_SC_DISABLE_SPEEDY.toLowerCase() === 'true';
+    }
+    if (typeof process.env.SC_DISABLE_SPEEDY !== 'undefined') {
+      return process.env.SC_DISABLE_SPEEDY && process.env.SC_DISABLE_SPEEDY.toLowerCase() === 'true';
+    }
+
+    return process.env.NODE_ENV !== 'production';
+  }
+
+  return false;
+}
+
+export const DISABLE_SPEEDY = isSpeedyDisabled();
 
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -19,10 +19,10 @@ function isSpeedyDisabled() {
   }
   if (typeof process !== 'undefined') {
     if (process.env.REACT_APP_SC_DISABLE_SPEEDY) {
-      return process.env.REACT_APP_SC_DISABLE_SPEEDY.toLowerCase() === 'true';
+      return process.env.REACT_APP_SC_DISABLE_SPEEDY === 'true';
     }
     if (process.env.SC_DISABLE_SPEEDY) {
-      return process.env.SC_DISABLE_SPEEDY.toLowerCase() === 'true';
+      return process.env.SC_DISABLE_SPEEDY === 'true';
     }
 
     return process.env.NODE_ENV !== 'production';

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -76,6 +76,7 @@ describe('constants', () => {
     afterEach(() => {
       process.env.NODE_ENV = 'test';
       delete process.env.DISABLE_SPEEDY;
+      delete window.SC_DISABLE_SPEEDY;
     });
 
     it('should be false in production NODE_ENV when SC_DISABLE_SPEEDY is not set', () => {
@@ -116,6 +117,22 @@ describe('constants', () => {
 
     it('should work with REACT_APP_SC_DISABLE_SPEEDY environment variable', () => {
       process.env.REACT_APP_SC_DISABLE_SPEEDY = true;
+      renderAndExpect(true, '.b { color:blue; }');
+
+      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
+    });
+
+    it('should override NODE_ENV with REACT_APP_SC_DISABLE_SPEEDY environment variable set to false', () => {
+      process.env.NODE_ENV = 'test';
+      process.env.REACT_APP_SC_DISABLE_SPEEDY = 'false';
+      renderAndExpect(false, '');
+
+      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
+    });
+
+    it('should override NODE_ENV with REACT_APP_SC_DISABLE_SPEEDY environment variable set to true', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.REACT_APP_SC_DISABLE_SPEEDY = 'true';
       renderAndExpect(true, '.b { color:blue; }');
 
       delete process.env.REACT_APP_SC_DISABLE_SPEEDY;


### PR DESCRIPTION
I was trying to turn on SPEEDY just to realize it is not easy (or even possible) inside CRA app.
First of all - CRA's env variables are of type `string | undefined`, so turning SPEEDy "on" by setting `REACT_APP_SC_DISABLE_SPEEDY=false` results in truthy `"false"` and keeping it empty defaults to `true` again, since `NODE_ENV` should remain as `"test"`. Setting `NODE_ENV=production` in `beforeAll` or `beforeEach` does not take effect, since babel && typescripts && jest picks all used modules and execute them before any test is run. So there are more issues there that result in split styles or even errors (like [this one](https://www.styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page)). 

This PR resolves one of them - ability to actually turn on SPEEDy mode for testing purposes.