### PR TITLE
Support <center> / styled.center

### DIFF
--- a/packages/styled-components/src/utils/domElements.js
+++ b/packages/styled-components/src/utils/domElements.js
@@ -20,6 +20,7 @@ export default [
   'button',
   'canvas',
   'caption',
+  'center',
   'cite',
   'code',
   'col',


### PR DESCRIPTION
I searched old issues commits etc. but couldn't find any reason this was omitted, so I propose adding it.


-------


This avoid `TypeError: Cannot read property 'withConfig' of undefined` when doing

```js
const RedCenteredText = styled.center`
  color: red;
`;

export default () => <RedCenteredText>Red Centered Text</RedCenteredText>;
```

or with the babel plugin

```js
export default () => <center css="color: red;">Red Centered Text</center>
```