### PR TITLE
Fix xhtml compat for ssr stylesheet (works in v4)

### DIFF
--- a/packages/styled-components/src/models/ServerStyleSheet.js
+++ b/packages/styled-components/src/models/ServerStyleSheet.js
@@ -26,7 +26,7 @@ export default class ServerStyleSheet {
   _emitSheetCSS = (): string => {
     const css = this.instance.toString();
     const nonce = getNonce();
-    const attrs = [nonce && `nonce="${nonce}"`, `${SC_ATTR}="${SC_ATTR}"`, `${SC_ATTR_VERSION}="${SC_VERSION}"`];
+    const attrs = [nonce && `nonce="${nonce}"`, `${SC_ATTR}="true"`, `${SC_ATTR_VERSION}="${SC_VERSION}"`];
     const htmlAttr = attrs.filter(Boolean).join(' ');
 
     return `<style ${htmlAttr}>${css}</style>`;

--- a/packages/styled-components/src/models/ServerStyleSheet.js
+++ b/packages/styled-components/src/models/ServerStyleSheet.js
@@ -26,7 +26,7 @@ export default class ServerStyleSheet {
   _emitSheetCSS = (): string => {
     const css = this.instance.toString();
     const nonce = getNonce();
-    const attrs = [nonce && `nonce="${nonce}"`, SC_ATTR, `${SC_ATTR_VERSION}="${SC_VERSION}"`];
+    const attrs = [nonce && `nonce="${nonce}"`, `${SC_ATTR}="${SC_ATTR}"`, `${SC_ATTR_VERSION}="${SC_VERSION}"`];
     const htmlAttr = attrs.filter(Boolean).join(' ');
 
     return `<style ${htmlAttr}>${css}</style>`;

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 2`] = `
-"<style nonce=\\"foo\\" data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style nonce=\\"foo\\" data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -13,7 +13,7 @@ data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 exports[`ssr should extract both global and local CSS 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should extract both global and local CSS 2`] = `
-"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -23,7 +23,7 @@ data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 exports[`ssr should extract the CSS in a simple case 1`] = `"<h1 class=\\"sc-a b\\">Hello SSR!</h1>"`;
 
 exports[`ssr should extract the CSS in a simple case 2`] = `
-"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
+"<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
 data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
 </style>"
 `;
@@ -31,7 +31,7 @@ data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
 exports[`ssr should handle errors while streaming 1`] = `[Invariant Violation: React.Children.only expected to receive a single React element child.]`;
 
 exports[`ssr should interleave styles with rendered HTML when utilitizing streaming 1`] = `
-"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -41,7 +41,7 @@ data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 exports[`ssr should render CSS in the order the components were defined, not rendered 1`] = `"<div><h2 class=\\"TWO a\\"></h2><h1 class=\\"ONE b\\"></h1></div>"`;
 
 exports[`ssr should render CSS in the order the components were defined, not rendered 2`] = `
-"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
+"<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
 data-styled.g1[id=\\"ONE\\"]{content:\\"b,\\"}
 .a{color:blue;}
 data-styled.g2[id=\\"TWO\\"]{content:\\"a,\\"}
@@ -70,7 +70,7 @@ exports[`ssr should throw if getStyleElement is called after interleaveWithNodeS
 `;
 
 exports[`ssr should throw if getStyleElement is called after streaming is complete 1`] = `
-"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -92,7 +92,7 @@ exports[`ssr should throw if getStyleTags is called after interleaveWithNodeStre
 `;
 
 exports[`ssr should throw if getStyleTags is called after streaming is complete 1`] = `
-"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 2`] = `
-"<style nonce=\\"foo\\" data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style nonce=\\"foo\\" data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -13,7 +13,7 @@ data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 exports[`ssr should extract both global and local CSS 1`] = `"<h1 class=\\"sc-b c\\">Hello SSR!</h1>"`;
 
 exports[`ssr should extract both global and local CSS 2`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -23,7 +23,7 @@ data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 exports[`ssr should extract the CSS in a simple case 1`] = `"<h1 class=\\"sc-a b\\">Hello SSR!</h1>"`;
 
 exports[`ssr should extract the CSS in a simple case 2`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
+"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
 data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
 </style>"
 `;
@@ -31,7 +31,7 @@ data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
 exports[`ssr should handle errors while streaming 1`] = `[Invariant Violation: React.Children.only expected to receive a single React element child.]`;
 
 exports[`ssr should interleave styles with rendered HTML when utilitizing streaming 1`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -41,7 +41,7 @@ data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
 exports[`ssr should render CSS in the order the components were defined, not rendered 1`] = `"<div><h2 class=\\"TWO a\\"></h2><h1 class=\\"ONE b\\"></h1></div>"`;
 
 exports[`ssr should render CSS in the order the components were defined, not rendered 2`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
+"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{color:red;}
 data-styled.g1[id=\\"ONE\\"]{content:\\"b,\\"}
 .a{color:blue;}
 data-styled.g2[id=\\"TWO\\"]{content:\\"a,\\"}
@@ -70,7 +70,7 @@ exports[`ssr should throw if getStyleElement is called after interleaveWithNodeS
 `;
 
 exports[`ssr should throw if getStyleElement is called after streaming is complete 1`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}
@@ -92,7 +92,7 @@ exports[`ssr should throw if getStyleTags is called after interleaveWithNodeStre
 `;
 
 exports[`ssr should throw if getStyleTags is called after streaming is complete 1`] = `
-"<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
+"<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.c{color:red;}
 data-styled.g1[id=\\"sc-b\\"]{content:\\"c,\\"}
 body{background:papayawhip;}
 data-styled.g2[id=\\"sc-global-a1\\"]{content:\\"sc-global-a1,\\"}

--- a/packages/styled-components/src/test/ssr.test.js
+++ b/packages/styled-components/src/test/ssr.test.js
@@ -490,7 +490,7 @@ describe('ssr', () => {
 
     expect(html).toMatchInlineSnapshot(`"<h1 class=\\"sc-a b\\">Hello SSR!</h1>"`);
     expect(css).toMatchInlineSnapshot(`
-      "<style data-styled data-styled-version=\\"JEST_MOCK_VERSION\\">.b{padding-right:5px;}
+      "<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{padding-right:5px;}
       data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
       </style>"
     `);

--- a/packages/styled-components/src/test/ssr.test.js
+++ b/packages/styled-components/src/test/ssr.test.js
@@ -490,7 +490,7 @@ describe('ssr', () => {
 
     expect(html).toMatchInlineSnapshot(`"<h1 class=\\"sc-a b\\">Hello SSR!</h1>"`);
     expect(css).toMatchInlineSnapshot(`
-      "<style data-styled=\\"data-styled\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{padding-right:5px;}
+      "<style data-styled=\\"true\\" data-styled-version=\\"JEST_MOCK_VERSION\\">.b{padding-right:5px;}
       data-styled.g1[id=\\"sc-a\\"]{content:\\"b,\\"}
       </style>"
     `);


### PR DESCRIPTION
by mirroring attribute key in value. This fixes xhtml support as xml doesn't support attribute minimization (excluding the attribute value).

More specifically from [xhtml spec](https://www.w3.org/TR/xhtml1/) 4.5. Attribute Minimization
"XML does not support attribute minimization. Attribute-value pairs must be written in full. Attribute names such as compact and checked cannot occur in elements without their value being specified."

Without this, xhtml is not supported rendering the hbbtv tv platform outside the scope of styled-components. This worked in v4 as we are currently running it and are very pleased so thanks for all the good work!

## Environment
ssr of any page with xhtml doctype

## Steps to reproduce
[Borked v5 with xhtml doctype on codesandbox.io](https://codesandbox.io/s/flamboyant-golick-8fbqe)

## Expected Behavior
styled-components ssr renders xhtml compatible markup
[Working v4 with xhtml doctype](https://h6ffw.sse.codesandbox.io/)
[code](https://codesandbox.io/s/floral-thunder-h6ffw)


## Actual Behavior
styled-components ssr renders xhtml incompatible markup
[Borked v5 with xhtml doctype](https://8fbqe.sse.codesandbox.io/)
[code](https://codesandbox.io/s/flamboyant-golick-8fbqe)





