### PR TITLE
Remove workarounds for border radius in (RN)

### DIFF
--- a/packages/styled-components/src/models/InlineStyle.js
+++ b/packages/styled-components/src/models/InlineStyle.js
@@ -40,16 +40,7 @@ export default (styleSheet: StyleSheet) => {
             console.warn(`Node of type ${node.type} not supported as an inline style`);
           }
         });
-        // RN currently does not support differing values for the corner radii of Image
-        // components (but does for View). It is almost impossible to tell whether we'll have
-        // support, so we'll just disable multiple values here.
-        // https://github.com/styled-components/css-to-react-native/issues/11
-        const styleObject = transformDeclPairs(declPairs, [
-          'borderRadius',
-          'borderWidth',
-          'borderColor',
-          'borderStyle',
-        ]);
+        const styleObject = transformDeclPairs(declPairs);
         const styles = styleSheet.create({
           generated: styleObject,
         });


### PR DESCRIPTION
So it looks like RN now supports this for the `Image` component! There looks to be issues border width and colour (they don't show up at all), but that's on RN's side.

I think this isn't a breaking change. Technically, you go from `{ borderRadius: 50 }` to `{ borderTopLeftRadius: 50, borderTopRightRadius: … }`, but this shouldn't actually change much

If we remove the blacklist here, we'll remove it in css-to-react-native and there'll be a tiny perf win