### PR TITLE
Add useTheme to the list of native exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Read the [v5 release announcement](https://medium.com/styled-components/announci
 
 * Fix regressed behavior between v3 and v4 where className was not correctly aggregated between folded `.attrs` invocations
 
+- Added useTheme hook to named exports for react native  
+
 ## [v4.4.1] - 2019-10-30
 
 - Fix `styled-components`'s `react-native` import for React Native Web, by [@fiberjw](https://github.com/fiberjw) (see [#2797](https://github.com/styled-components/styled-components/pull/2797))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Added useTheme hook to named exports for react native  
+
 ## [v5.0.0] - 2020-01-13
 
 Read the [v5 release announcement](https://medium.com/styled-components/announcing-styled-components-v5-beast-mode-389747abd987)!
@@ -48,8 +50,6 @@ Read the [v5 release announcement](https://medium.com/styled-components/announci
 * Fix certain adblockers messing up styling by purposefully not emitting the substring "ad" (case-insensitive) when generating dynamic class names
 
 * Fix regressed behavior between v3 and v4 where className was not correctly aggregated between folded `.attrs` invocations
-
-- Added useTheme hook to named exports for react native  
 
 ## [v4.4.1] - 2019-10-30
 

--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -8,6 +8,7 @@ import css from '../constructors/css';
 import constructWithOptions from '../constructors/constructWithOptions';
 import ThemeProvider, { ThemeConsumer, ThemeContext } from '../models/ThemeProvider';
 import withTheme from '../hoc/withTheme';
+import useTheme from '../hooks/useTheme';
 import isStyledComponent from '../utils/isStyledComponent';
 
 import type { Target } from '../types';
@@ -40,5 +41,5 @@ aliases.split(/\s+/m).forEach(alias =>
   })
 );
 
-export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme };
+export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme };
 export default styled;


### PR DESCRIPTION
Hi folks, just noticed that useTheme wasn't exported for native so I've added it. First PR to styled-components so apologies if I've missed a contributing rule!