### PR TITLE
Fix upper group limit in GroupedTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
-- Added useTheme hook to named exports for react native  
+- Added useTheme hook to named exports for react native
+
+- Performance enhancements
+  - Refactored hashing function that is a bit faster in benchmarks
+  - Fixed a bitwise math issue that was causing SSR performance degradations due to how we allocate typed arrays under the hood
 
 ## [v5.0.0] - 2020-01-13
 

--- a/packages/styled-components/src/sheet/GroupIDAllocator.js
+++ b/packages/styled-components/src/sheet/GroupIDAllocator.js
@@ -1,5 +1,9 @@
 // @flow
 
+import throwStyledError from '../utils/error';
+
+const MAX_SMI = 1 << 31 - 1;
+
 let groupIDRegister: Map<string, number> = new Map();
 let reverseRegister: Map<number, string> = new Map();
 let nextFreeGroup = 1;
@@ -16,6 +20,13 @@ export const getGroupForId = (id: string): number => {
   }
 
   const group = nextFreeGroup++;
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    ((group | 0) < 0 || group > MAX_SMI)
+  ) {
+    throwStyledError(16, `${group}`);
+  }
+
   groupIDRegister.set(id, group);
   reverseRegister.set(group, id);
   return group;

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -39,11 +39,11 @@ class DefaultGroupedTag implements GroupedTag {
       const oldSize = oldBuffer.length;
 
       let newSize = oldSize;
-      while (group >= newSize && newSize > 0)
-        {newSize <<= 1;}
-
-      if (newSize < 0) {
-        throwStyledError(13, `${group}`);
+      while (group >= newSize) {
+        newSize <<= 1;
+        if (newSize < 0) {
+          throwStyledError(16, `${group}`);
+        }
       }
 
       this.groupSizes = new Uint32Array(newSize);

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -2,13 +2,14 @@
 /* eslint-disable no-use-before-define */
 
 import type { GroupedTag, Tag } from './types';
+import throwStyledError from '../utils/error';
 
 /** Create a GroupedTag with an underlying Tag implementation */
 export const makeGroupedTag = (tag: Tag): GroupedTag => {
   return new DefaultGroupedTag(tag);
 };
 
-const BASE_SIZE = 1 << 8;
+const BASE_SIZE = 1 << 9;
 
 class DefaultGroupedTag implements GroupedTag {
   groupSizes: Uint32Array;
@@ -36,7 +37,14 @@ class DefaultGroupedTag implements GroupedTag {
     if (group >= this.groupSizes.length) {
       const oldBuffer = this.groupSizes;
       const oldSize = oldBuffer.length;
-      const newSize = BASE_SIZE << ((group / BASE_SIZE) | 0);
+
+      let newSize = oldSize;
+      while (group >= newSize && newSize > 0)
+        {newSize <<= 1;}
+
+      if (newSize < 0) {
+        throwStyledError(13, `${group}`);
+      }
 
       this.groupSizes = new Uint32Array(newSize);
       this.groupSizes.set(oldBuffer);

--- a/packages/styled-components/src/sheet/dom.js
+++ b/packages/styled-components/src/sheet/dom.js
@@ -2,6 +2,7 @@
 
 import { SC_ATTR, SC_ATTR_ACTIVE, SC_ATTR_VERSION, SC_VERSION } from '../constants';
 import getNonce from '../utils/nonce';
+import throwStyledError from '../utils/error';
 
 const ELEMENT_TYPE = 1; /* Node.ELEMENT_TYPE */
 
@@ -54,5 +55,6 @@ export const getSheet = (tag: HTMLStyleElement): CSSStyleSheet => {
     }
   }
 
-  throw new TypeError(`CSSStyleSheet could not be found on HTMLStyleElement`);
+  throwStyledError(17);
+  return (undefined: any);
 };

--- a/packages/styled-components/src/sheet/test/GroupIDAllocator.test.js
+++ b/packages/styled-components/src/sheet/test/GroupIDAllocator.test.js
@@ -22,3 +22,17 @@ it('creates continuous group IDs', () => {
   expect(GroupIDAllocator.getIdForGroup(99)).toBe('b');
   expect(GroupIDAllocator.getGroupForId('b')).toBe(99);
 });
+
+it('throws early if the group ID is too large', () => {
+  // Test for SMI overflow with SMIs
+  GroupIDAllocator.setGroupForId('a', Math.pow(2, 31));
+  expect(() => {
+    GroupIDAllocator.getGroupForId('b');
+  }).toThrowError(/reached the limit/i);
+
+  // Test for SMI overflow with regular integers
+  GroupIDAllocator.setGroupForId('a', Math.pow(2, 32));
+  expect(() => {
+    GroupIDAllocator.getGroupForId('b');
+  }).toThrowError(/reached the limit/i);
+});

--- a/packages/styled-components/src/sheet/test/GroupedTag.test.js
+++ b/packages/styled-components/src/sheet/test/GroupedTag.test.js
@@ -91,3 +91,11 @@ it('does supports large group numbers', () => {
   expect(groupedTag.indexOfGroup(group)).toBe(0);
   expect(groupedTag.getGroup(group)).toBe('.test {}\n');
 });
+
+it('throws when the upper group limit is reached', () => {
+  const group = Math.pow(2, 31) + 1; // This can't be converted to an SMI to prevent cutoff
+
+  expect(() => {
+    groupedTag.insertRules(group, ['.test {}']);
+  }).toThrowError(/reached the limit/i);
+});

--- a/packages/styled-components/src/utils/errors.md
+++ b/packages/styled-components/src/utils/errors.md
@@ -86,3 +86,8 @@ Object.defineProperty(importedPlugin, 'name', { value: 'some-unique-name' });
 Reached the limit of how many styled components may be created at group %s.
 You may only create up to 1,073,741,824 components. If you're creating components dynamically,
 as for instance in your render method then you may be running into this limitation.
+
+## 17
+
+CSSStyleSheet could not be found on HTMLStyleElement.
+Has styled-components' style tag been unmounted or altered by another script?

--- a/packages/styled-components/src/utils/errors.md
+++ b/packages/styled-components/src/utils/errors.md
@@ -80,3 +80,9 @@ A stylis plugin has been supplied that is not named. We need a name for each plu
 ```js
 Object.defineProperty(importedPlugin, 'name', { value: 'some-unique-name' });
 ```
+
+## 16
+
+Reached the limit of how many styled components may be created at group %s.
+You may only create up to 1,073,741,824 components. If you're creating components dynamically,
+as for instance in your render method then you may be running into this limitation.


### PR DESCRIPTION
Fix #2994 
Fix #2979

Previously the formula for increasing the size of Uint32Arrays
in the GroupedTag was a little aggressive and would cut of very
short of 2^31 groups. Instead it would cut off between 2^12 and
2^13 components, which isn't quite a lot.

This new upper boundary is the absolute limit of how many slots
a Uint32Array is defined to be able to hold. After this limit we'll
see an error.

Instead of letting this error leak out we now throw a more clear
error that hints at this limitation.

I've also refactored `dom.js` to finally use `throwStyledError` as well.

Tests have been updated to reflect all changes.