### PR TITLE
shouldForwardProp support

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -75,6 +75,7 @@ interface StyledComponentWrapperProperties {
   displayName: string;
   foldedComponentIds: Array<string>;
   target: Target;
+  shouldForwardProp: Function;
   styledComponentId: string;
   warnTooManyClasses: $Call<typeof createWarnTooManyClasses, string, string>;
 }
@@ -119,6 +120,7 @@ function useStyledComponentImpl<Config: {}, Instance>(
     // $FlowFixMe
     defaultProps,
     foldedComponentIds,
+    shouldForwardProp,
     styledComponentId,
     target,
   } = forwardedComponent;
@@ -145,15 +147,25 @@ function useStyledComponentImpl<Config: {}, Instance>(
 
   const isTargetTag = isTag(elementToBeCreated);
   const computedProps = attrs !== props ? { ...props, ...attrs } : props;
-  const shouldFilterProps = isTargetTag || 'as' in computedProps || 'forwardedAs' in computedProps;
+  const shouldFilterProps = shouldForwardProp || isTargetTag || 'as' in computedProps || 'forwardedAs' in computedProps;
   const propsForElement = shouldFilterProps ? {} : { ...computedProps };
+
+  // use explicit `shouldForwardProp` function if one is set, otherwise
+  // if no explicit `shouldForwardProp` set then
+  //   if we're on a tag, use `validAttr`
+  //     i.e. Don't pass through non HTML tags through to HTML elements
+  // else (we're on a component - pass through all by default)
+  //   () => true
+  const shouldReallyForwardProp = shouldForwardProp || (
+    isTargetTag ? validAttr : () => true
+  );
 
   if (shouldFilterProps) {
     // eslint-disable-next-line guard-for-in
     for (const key in computedProps) {
       if (key === 'forwardedAs') {
         propsForElement.as = computedProps[key];
-      } else if (key !== 'as' && key !== 'forwardedAs' && (!isTargetTag || validAttr(key))) {
+      } else if (key !== 'as' && key !== 'forwardedAs' && (shouldReallyForwardProp(key))) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }
@@ -178,6 +190,20 @@ function useStyledComponentImpl<Config: {}, Instance>(
   propsForElement.ref = refToForward;
 
   return createElement(elementToBeCreated, propsForElement);
+}
+
+function getShouldForwardProp(options, target, isTargetStyledComp) {
+  // $FlowFixMe
+  if (isTargetStyledComp && target.shouldForwardProp) {
+    if (options.shouldForwardProp) {
+      // compose nested shouldForwardProp calls
+      // $FlowFixMe
+      return prop => target.shouldForwardProp(prop) && options.shouldForwardProp(prop);
+    }
+    return target.shouldForwardProp;
+  }
+
+  return options.shouldForwardProp;
 }
 
 export default function createStyledComponent(
@@ -232,6 +258,7 @@ export default function createStyledComponent(
   WrappedStyledComponent.attrs = finalAttrs;
   WrappedStyledComponent.componentStyle = componentStyle;
   WrappedStyledComponent.displayName = displayName;
+  WrappedStyledComponent.shouldForwardProp = getShouldForwardProp(options, target, isTargetStyledComp);
 
   // this static is used to preserve the cascade of static classes for component selector
   // purposes; this is especially important with usage of the css prop
@@ -296,6 +323,7 @@ export default function createStyledComponent(
       componentStyle: true,
       displayName: true,
       foldedComponentIds: true,
+      shouldForwardProp: true,
       self: true,
       styledComponentId: true,
       target: true,

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -156,7 +156,7 @@ function useStyledComponentImpl<Config: {}, Instance>(
     for (const key in computedProps) {
       if (key === 'forwardedAs') {
         propsForElement.as = computedProps[key];
-      } else if (key !== 'as' && key !== 'forwardedAs' && (!propFilterFn || propFilterFn(key))) {
+      } else if (key !== 'as' && (!propFilterFn || propFilterFn(key))) {
         // Don't pass through non HTML tags through to HTML elements
         propsForElement[key] = computedProps[key];
       }
@@ -209,15 +209,18 @@ export default function createStyledComponent(
       ? Array.prototype.concat(target.attrs, attrs).filter(Boolean)
       : attrs;
 
-  let { shouldForwardProp } = options;
+  // eslint-disable-next-line prefer-destructuring
+  let shouldForwardProp = options.shouldForwardProp;
   // $FlowFixMe
   if (isTargetStyledComp && target.shouldForwardProp) {
     if (shouldForwardProp) {
       // compose nested shouldForwardProp calls
       // $FlowFixMe
       shouldForwardProp = prop => target.shouldForwardProp(prop) && options.shouldForwardProp(prop);
+    } else {
+      // eslint-disable-next-line prefer-destructuring
+      shouldForwardProp = target.shouldForwardProp
     }
-    ({ shouldForwardProp } = target);
   }
 
   const componentStyle = new ComponentStyle(

--- a/packages/styled-components/src/test/__snapshots__/props.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/props.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`props shouldForwardProp should inherit shouldForwardProp for wrapped styled components 1`] = `
+Array [
+  <div
+    className="sc-a c"
+    id="test-1"
+  />,
+  <div
+    className="sc-a sc-b d"
+    id="test-2"
+  />,
+]
+`;

--- a/packages/styled-components/src/test/props.test.js
+++ b/packages/styled-components/src/test/props.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Fragment } from 'react';
 import TestRenderer from 'react-test-renderer';
 
 import { resetStyled, expectCSSMatches } from './utils';
@@ -55,5 +55,109 @@ describe('props', () => {
     `);
 
     expectCSSMatches('.b { background: red; }');
+  });
+
+  describe('shouldForwardProp', () => {
+    // NB existing functionality (when `shouldForwardProp` is not set) is tested elsewhere
+
+    it('allows for custom prop filtering for elements', () => {
+      const Comp = styled('div').withConfig({
+        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      })`
+        color: red;
+      `;
+      const wrapper = TestRenderer.create(<Comp filterThis="abc" passThru="def" />);
+      const { props } = wrapper.root.findByType('div');
+      expectCSSMatches('.b { color:red; }');
+      expect(props.passThru).toBe('def');
+      expect(props.filterThis).toBeUndefined();
+    });
+
+    it('allows custom prop filtering for components', () => {
+      const InnerComp = props => <div {...props} />
+      const Comp = styled(InnerComp).withConfig({
+        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      })`
+        color: red;
+      `;
+      const wrapper = TestRenderer.create(<Comp filterThis="abc" passThru="def" />);
+      const { props } = wrapper.root.findByType('div');
+      expectCSSMatches('.b { color:red; }');
+      expect(props.passThru).toBe('def');
+      expect(props.filterThis).toBeUndefined();
+    });
+
+    it('composes shouldForwardProp on composed styled components', () => {
+      const StyledDiv = styled('div').withConfig({
+        shouldForwardProp: prop => prop === 'passThru'
+      })`
+        color: red;
+      `;
+      const ComposedDiv = styled(StyledDiv).withConfig({
+        shouldForwardProp: () => true
+      })``;
+      const wrapper = TestRenderer.create(<ComposedDiv filterThis passThru />);
+      const { props } = wrapper.root.findByType('div');
+      expect(props.passThru).toBeDefined();
+      expect(props.filterThis).toBeUndefined();
+    });
+
+    it('should inherit shouldForwardProp for wrapped styled components', () => {
+      const Div1 = styled('div').withConfig({
+        shouldForwardProp: prop => prop !== 'color'
+      })`
+        background-color: ${({ color }) => color};
+      `;
+      const Div2 = styled(Div1)``;
+      const wrapper = TestRenderer.create(
+        <Fragment>
+          <Div1 color="red" id="test-1" />
+          <Div2 color="green" id="test-2" />
+        </Fragment>
+      );
+      expectCSSMatches('.c { background-color:red; }.d { background-color: green; }');
+      expect(wrapper.toJSON()).toMatchSnapshot();
+    });
+
+    it('should filter out props when using "as" to a custom component', () => {
+      const AsComp = props => <div {...props} />
+      const Comp = styled('div').withConfig({
+        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      })`
+        color: red;
+      `;
+      const wrapper = TestRenderer.create(<Comp as={AsComp} filterThis="abc" passThru="def" />);
+      const { props } = wrapper.root.findByType(AsComp);
+      expectCSSMatches('.b { color:red; }');
+      expect(props.passThru).toBe('def');
+      expect(props.filterThis).toBeUndefined();
+    });
+
+    it('can set computed styles based on props that are being filtered out', () => {
+      const AsComp = props => <div {...props} />
+      const Comp = styled('div').withConfig({
+        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      })`
+        color: ${props => props.filterThis === 'abc' ? 'red' : undefined};
+      `;
+      const wrapper = TestRenderer.create(<Comp as={AsComp} filterThis="abc" passThru="def" />);
+      const { props } = wrapper.root.findByType(AsComp);
+      expectCSSMatches('.b { color:red; }');
+      expect(props.passThru).toBe('def');
+      expect(props.filterThis).toBeUndefined();
+    });
+
+    it('should filter our props when using "as" to a different element', () => {
+      const Comp = styled('div').withConfig({
+        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      })`
+        color: red;
+      `;
+      const wrapper = TestRenderer.create(<Comp as="a" filterThis="abc" passThru="def" />);
+      const { props } = wrapper.root.findByType("a");
+      expectCSSMatches('.b { color:red; }');
+      expect(props.passThru).toBe('def');
+      expect(props.filterThis).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Following discussion elsewhere, such as on #2780, re-opening this PR (previously #2392)

adds support for use of `shouldForwardProp` config method, which can be used to explicitly determine which props should be forwarded on
if this config is not provided then existing functionality is preserved (i.e. all props passed to components, or for HTML elements check using `validAttr`)

Inspired by the same feature in emotion

Resolve #439 
Resolve #2878 