### PR TITLE
Failing test for comments with styled-components/native

### DIFF
--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -140,7 +140,6 @@ Object {
       console.warn = oldConsoleWarn;
     }
   });
-
   // https://github.com/styled-components/styled-components/issues/1266
   it('should update when props change', () => {
     const Comp = styled.View`
@@ -167,6 +166,26 @@ Object {
     const wrapper = TestRenderer.create(<Comp2 forwardedAs={Text} />);
 
     expect(wrapper.root.findByType('Text')).not.toBeUndefined();
+  });
+
+  it('should handle comments', () => {
+    const Comp = styled.View`
+      /* background: red */
+      background: green;
+    `;
+
+    expect(
+      TestRenderer.create(<Comp />).root.findByType('View').props.style
+    ).toEqual([{ backgroundColor: 'green' }]);
+
+    const Comp2 = styled.View`
+      // background: red;
+      background: green;
+    `;
+
+    expect(
+      TestRenderer.create(<Comp2 />).root.findByType('View').props.style
+    ).toEqual([{ backgroundColor: 'green' }]);
   });
 
   describe('attrs', () => {


### PR DESCRIPTION
Posted this in https://github.com/styled-components/css-to-react-native/issues/133, but later realised that it probably fits better here.

```ts
styled.View`
  // background: green;
  background: red;
`;
```

Yields:
```
Invariant Violation: "//" is not a valid style property.
StyleSheet generated: {
  "//": "green",
  "backgroundColor": "red"
}
Valid style props: [
  "alignContent",
  "alignItems",
  "alignSelf",
  "aspectRatio",
   ...etc
]
```