### PR TITLE
Keep the style prop stable for React Native

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -69,6 +69,8 @@
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^3.0.0",
     "hoist-non-react-statics": "^3.0.0",
+    "lodash.isequal": "^4.5.0",
+    "memoize-one": "^5.1.1",
     "shallowequal": "^1.1.0",
     "supports-color": "^5.5.0"
   },

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -24,7 +24,10 @@ class StyledNativeComponent extends Component<*, *> {
 
   attrs = {};
 
-  generateStyles = memoize((...styles) => styles, isDeepEqual);
+  generateStyles = memoize(
+    (generatedStyles, style) => [generatedStyles].concat(style),
+    isDeepEqual
+  );
 
   render() {
     return (

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -1,5 +1,8 @@
 // @flow
 import React, { createElement, Component } from 'react';
+// $FlowFixMe
+import memoize from 'memoize-one';
+import isDeepEqual from 'lodash.isequal';
 import hoist from 'hoist-non-react-statics';
 import merge from '../utils/mixinDeep';
 import determineTheme from '../utils/determineTheme';
@@ -20,6 +23,8 @@ class StyledNativeComponent extends Component<*, *> {
   root: ?Object;
 
   attrs = {};
+
+  generateStyles = memoize((...styles) => styles, isDeepEqual);
 
   render() {
     return (
@@ -44,7 +49,7 @@ class StyledNativeComponent extends Component<*, *> {
           const propsForElement = {
             ...props,
             ...this.attrs,
-            style: [generatedStyles].concat(style),
+            style: this.generateStyles(generatedStyles, style),
           };
 
           if (forwardedRef) propsForElement.ref = forwardedRef;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6819,6 +6819,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.mergewith@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
@@ -6999,7 +7004,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.4:
+memoize-one@^5.0.4, memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==


### PR DESCRIPTION
When trying to styling a `memo` component in React Native, the identity of `style` prop makes it to re-render nonetheless. This behaviour is different from ReactJS.

What happens on reactjs: https://codesandbox.io/s/react-hooks-counter-demo-dx4c2
The className doesn't change between renders, so the component skip rendering correctly.

What happens on react native: https://codesandbox.io/s/react-hooks-counter-demo-edh0d
Since the `style` props change every time, the component will render as a normal non-pure component.

This PR is a PoC, and try to address that issue.

Cons:

- Adding two extra deps
- Styling a `React.memo` component is rare, and having a deep compare operation may hurt performance more than less.

I had this unexpected issue at work, when working with some animation. Even providing some sort of warning as an alternative would do the job.