### PR TITLE
Refactor isElement component selector warning to be an error

### DIFF
--- a/packages/benchmarks/src/implementations/styled-components-v5/styled-components-v5.esm.js
+++ b/packages/benchmarks/src/implementations/styled-components-v5/styled-components-v5.esm.js
@@ -1099,7 +1099,7 @@ function flatten(chunk, executionContext, styleSheet) {
 
       if (process.env.NODE_ENV !== 'production' && isElement(_result)) {
         // eslint-disable-next-line no-console
-        console.error(
+        console.warn(
           getComponentName(chunk) +
             ' is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.'
         );

--- a/packages/benchmarks/src/implementations/styled-components-v5/styled-components-v5.esm.js
+++ b/packages/benchmarks/src/implementations/styled-components-v5/styled-components-v5.esm.js
@@ -1099,7 +1099,7 @@ function flatten(chunk, executionContext, styleSheet) {
 
       if (process.env.NODE_ENV !== 'production' && isElement(_result)) {
         // eslint-disable-next-line no-console
-        console.warn(
+        console.error(
           getComponentName(chunk) +
             ' is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.'
         );

--- a/packages/styled-components/src/utils/flatten.js
+++ b/packages/styled-components/src/utils/flatten.js
@@ -72,7 +72,7 @@ export default function flatten(chunk: any, executionContext: ?Object, styleShee
 
       if (process.env.NODE_ENV !== 'production' && isElement(result)) {
         // eslint-disable-next-line no-console
-        console.warn(
+        console.error(
           `${getComponentName(
             chunk
           )} is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.`

--- a/packages/styled-components/src/utils/test/flatten.test.js
+++ b/packages/styled-components/src/utils/test/flatten.test.js
@@ -145,8 +145,8 @@ describe('flatten', () => {
     );
   });
 
-  it('does not warn for regular functions', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  it('does not error for regular functions', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const SvgIcon = styled.svg`
       vertical-align: middle;
@@ -164,6 +164,6 @@ describe('flatten', () => {
       )
     ).not.toThrowError();
 
-    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/styled-components/src/utils/test/flatten.test.js
+++ b/packages/styled-components/src/utils/test/flatten.test.js
@@ -129,7 +129,7 @@ describe('flatten', () => {
   });
 
   it('throws if trying to interpolate a normal React component', () => {
-    jest.spyOn(console, 'err0r').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const Foo = ({ className }) => <div className={className}>hello there!</div>;
 
     const Bar = styled.div`

--- a/packages/styled-components/src/utils/test/flatten.test.js
+++ b/packages/styled-components/src/utils/test/flatten.test.js
@@ -129,7 +129,7 @@ describe('flatten', () => {
   });
 
   it('throws if trying to interpolate a normal React component', () => {
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'err0r').mockImplementation(() => {});
     const Foo = ({ className }) => <div className={className}>hello there!</div>;
 
     const Bar = styled.div`
@@ -140,7 +140,7 @@ describe('flatten', () => {
 
     TestRenderer.create(<Bar />);
 
-    expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
+    expect(console.error.mock.calls[0][0]).toMatchInlineSnapshot(
       `"Foo is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details."`
     );
   });


### PR DESCRIPTION
### Code example
Here's an example of how this warning works now:
https://codesandbox.io/s/iselement-warning-example-32xrd

### Warning
![image](https://user-images.githubusercontent.com/11010928/75061288-32716380-54bf-11ea-94c5-d311abe7ba48.png)

### Suggestion
I would like to suggest to make this an error to prevent adding styles that won't work.

#3032 