### PR TITLE
[BREAKING] remove withConfig API, add options argument to styled()

### DIFF
--- a/packages/styled-components/src/constructors/constructWithOptions.js
+++ b/packages/styled-components/src/constructors/constructWithOptions.js
@@ -19,10 +19,6 @@ export default function constructWithOptions(
   // $FlowFixMe: Not typed to avoid destructuring arguments
   const templateFunction = (...args) => componentConstructor(tag, options, css(...args));
 
-  /* If config methods are called, wrap up a new template function and merge options */
-  templateFunction.withConfig = config =>
-    constructWithOptions(componentConstructor, tag, { ...options, ...config });
-
   /* Modify/inject new props at runtime */
   templateFunction.attrs = attrs =>
     constructWithOptions(componentConstructor, tag, {

--- a/packages/styled-components/src/constructors/styled.js
+++ b/packages/styled-components/src/constructors/styled.js
@@ -5,7 +5,8 @@ import domElements from '../utils/domElements';
 
 import type { Target } from '../types';
 
-const styled = (tag: Target) => constructWithOptions(StyledComponent, tag);
+const styled = (tag: Target, options: ?Object) =>
+  constructWithOptions(StyledComponent, tag, options);
 
 // Shorthands for all valid HTML Elements
 domElements.forEach(domElement => {

--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -17,7 +17,8 @@ const reactNative = require('react-native');
 
 const InlineStyle = _InlineStyle(reactNative.StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);
-const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag);
+const styled = (tag: Target, options: ?Object) =>
+  constructWithOptions(StyledNativeComponent, tag, options);
 
 /* React native lazy-requires each of these modules for some reason, so let's
  *  assume it's for a good reason and not eagerly load them all */

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -381,27 +381,19 @@ Object {
 
       expect(Comp.displayName).toBe('Styled(View)');
 
-      const CompTwo = styled.View.withConfig({ displayName: 'Test' })``;
+      const CompTwo = styled('View', { displayName: 'Test' })``;
       expect(CompTwo.displayName).toBe('Test');
-    });
-
-    it('should allow multiple calls to be chained', () => {
-      const Comp = styled.View.withConfig({ displayName: 'Test1' }).withConfig({
-        displayName: 'Test2',
-      })``;
-
-      expect(Comp.displayName).toBe('Test2');
     });
 
     it('withComponent should work', () => {
       const Dummy = props => <View {...props} />;
 
-      const Comp = styled.View.withConfig({
+      const Comp = styled('View', {
         displayName: 'Comp',
         componentId: 'OMGLOL',
       })``.withComponent(Text);
 
-      const Comp2 = styled.View.withConfig({
+      const Comp2 = styled('View', {
         displayName: 'Comp2',
         componentId: 'OMFG',
       })``.withComponent(Dummy);

--- a/packages/styled-components/src/primitives/test/primitives.test.js
+++ b/packages/styled-components/src/primitives/test/primitives.test.js
@@ -274,16 +274,8 @@ describe('primitives', () => {
       const Comp = styled.View``;
       expect(Comp.displayName).toBe('Styled(View)');
 
-      const CompTwo = styled.View.withConfig({ displayName: 'Test' })``;
+      const CompTwo = styled('View', { displayName: 'Test' })``;
       expect(CompTwo.displayName).toBe('Test');
-    });
-
-    it('should allow multiple calls to be chained', () => {
-      const Comp = styled.View.withConfig({ displayName: 'Test1' }).withConfig({
-        displayName: 'Test2',
-      })``;
-
-      expect(Comp.displayName).toBe('Test2');
     });
 
     it('"as" prop should change the rendered element without affecting the styling', () => {
@@ -303,12 +295,12 @@ describe('primitives', () => {
     it('withComponent should work', () => {
       const Dummy = props => <View {...props} />;
 
-      const Comp = styled.View.withConfig({
+      const Comp = styled('View', {
         displayName: 'Comp',
         componentId: 'OMGLOL',
       })``.withComponent(Text);
 
-      const Comp2 = styled.View.withConfig({
+      const Comp2 = styled('View', {
         displayName: 'Comp2',
         componentId: 'OMFG',
       })``.withComponent(Dummy);

--- a/packages/styled-components/src/test/__snapshots__/expanded-api.test.js.snap
+++ b/packages/styled-components/src/test/__snapshots__/expanded-api.test.js.snap
@@ -44,18 +44,6 @@ exports[`expanded api "as" prop works with custom components 1`] = `
 />
 `;
 
-exports[`expanded api chaining should keep the last value passed in when merging 1`] = `
-<div
-  className="dn-5-id-4 a"
-/>
-`;
-
-exports[`expanded api chaining should merge the options strings 1`] = `
-<div
-  className="dn-2-id-1 a"
-/>
-`;
-
 exports[`expanded api componentId should be attached if passed in 1`] = `
 <div
   className="LOLOMG a"

--- a/packages/styled-components/src/test/basic.test.js
+++ b/packages/styled-components/src/test/basic.test.js
@@ -380,11 +380,11 @@ Object {
     });
 
     it('generates unique classnames when not using babel', () => {
-      const Named1 = styled.div.withConfig({ displayName: 'Name' })`
+      const Named1 = styled('div', { displayName: 'Name' })`
         color: blue;
       `;
 
-      const Named2 = styled.div.withConfig({ displayName: 'Name' })`
+      const Named2 = styled('div', { displayName: 'Name' })`
         color: red;
       `;
 
@@ -392,14 +392,14 @@ Object {
     });
 
     it('honors a passed componentId', () => {
-      const Named1 = styled.div.withConfig({
+      const Named1 = styled('div', {
         componentId: 'foo',
         displayName: 'Name',
       })`
         color: blue;
       `;
 
-      const Named2 = styled.div.withConfig({
+      const Named2 = styled('div', {
         componentId: 'bar',
         displayName: 'Name',
       })`

--- a/packages/styled-components/src/test/expanded-api.test.js
+++ b/packages/styled-components/src/test/expanded-api.test.js
@@ -25,7 +25,7 @@ describe('expanded api', () => {
     });
 
     it('should be attached if supplied', () => {
-      const Comp = styled.div.withConfig({ displayName: 'Comp' })``;
+      const Comp = styled('div', { displayName: 'Comp' })``;
       expect(Comp.displayName).toBe('Comp');
     });
   });
@@ -41,8 +41,8 @@ describe('expanded api', () => {
     });
 
     it('should be generated from displayName + hash', () => {
-      const Comp = styled.div.withConfig({ displayName: 'Comp' })``;
-      const Comp2 = styled.div.withConfig({ displayName: 'Comp2' })``;
+      const Comp = styled('div', { displayName: 'Comp' })``;
+      const Comp2 = styled('div', { displayName: 'Comp2' })``;
       expect(Comp.styledComponentId).toBe('Comp-a');
       expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
       expect(Comp2.styledComponentId).toBe('Comp2-b');
@@ -50,8 +50,8 @@ describe('expanded api', () => {
     });
 
     it('should be attached if passed in', () => {
-      const Comp = styled.div.withConfig({ componentId: 'LOLOMG' })``;
-      const Comp2 = styled.div.withConfig({ componentId: 'OMGLOL' })``;
+      const Comp = styled('div', { componentId: 'LOLOMG' })``;
+      const Comp2 = styled('div', { componentId: 'OMGLOL' })``;
       expect(Comp.styledComponentId).toBe('LOLOMG');
       expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
       expect(Comp2.styledComponentId).toBe('OMGLOL');
@@ -59,11 +59,11 @@ describe('expanded api', () => {
     });
 
     it('should be combined with displayName if both passed in', () => {
-      const Comp = styled.div.withConfig({
+      const Comp = styled('div', {
         displayName: 'Comp',
         componentId: 'LOLOMG',
       })``;
-      const Comp2 = styled.div.withConfig({
+      const Comp2 = styled('div', {
         displayName: 'Comp2',
         componentId: 'OMGLOL',
       })``;
@@ -75,11 +75,11 @@ describe('expanded api', () => {
 
     it('should work with `.withComponent`', () => {
       const Dummy = props => <div {...props} />;
-      const Comp = styled.div.withConfig({
+      const Comp = styled('div', {
         displayName: 'Comp',
         componentId: 'OMGLOL',
       })``.withComponent('h1');
-      const Comp2 = styled.div.withConfig({
+      const Comp2 = styled('div', {
         displayName: 'Comp2',
         componentId: 'OMFG',
       })``.withComponent(Dummy);
@@ -87,24 +87,6 @@ describe('expanded api', () => {
       expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
       expect(Comp2.styledComponentId).toBe('Comp2-OMFG-Dummy');
       expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchSnapshot();
-    });
-  });
-
-  describe('chaining', () => {
-    it('should merge the options strings', () => {
-      const Comp = styled.div
-        .withConfig({ componentId: 'id-1' })
-        .withConfig({ displayName: 'dn-2' })``;
-      expect(Comp.displayName).toBe('dn-2');
-      expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
-    });
-
-    it('should keep the last value passed in when merging', () => {
-      const Comp = styled.div
-        .withConfig({ displayName: 'dn-2', componentId: 'id-3' })
-        .withConfig({ displayName: 'dn-5', componentId: 'id-4' })``;
-      expect(Comp.displayName).toBe('dn-5');
-      expect(TestRenderer.create(<Comp />).toJSON()).toMatchSnapshot();
     });
   });
 

--- a/packages/styled-components/src/test/props.test.js
+++ b/packages/styled-components/src/test/props.test.js
@@ -61,8 +61,8 @@ describe('props', () => {
     // NB existing functionality (when `shouldForwardProp` is not set) is tested elsewhere
 
     it('allows for custom prop filtering for elements', () => {
-      const Comp = styled('div').withConfig({
-        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      const Comp = styled('div', {
+        shouldForwardProp: prop => !['filterThis'].includes(prop),
       })`
         color: red;
       `;
@@ -74,9 +74,9 @@ describe('props', () => {
     });
 
     it('allows custom prop filtering for components', () => {
-      const InnerComp = props => <div {...props} />
-      const Comp = styled(InnerComp).withConfig({
-        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      const InnerComp = props => <div {...props} />;
+      const Comp = styled(InnerComp, {
+        shouldForwardProp: prop => !['filterThis'].includes(prop),
       })`
         color: red;
       `;
@@ -88,13 +88,13 @@ describe('props', () => {
     });
 
     it('composes shouldForwardProp on composed styled components', () => {
-      const StyledDiv = styled('div').withConfig({
-        shouldForwardProp: prop => prop === 'passThru'
+      const StyledDiv = styled('div', {
+        shouldForwardProp: prop => prop === 'passThru',
       })`
         color: red;
       `;
-      const ComposedDiv = styled(StyledDiv).withConfig({
-        shouldForwardProp: () => true
+      const ComposedDiv = styled(StyledDiv, {
+        shouldForwardProp: () => true,
       })``;
       const wrapper = TestRenderer.create(<ComposedDiv filterThis passThru />);
       const { props } = wrapper.root.findByType('div');
@@ -103,8 +103,8 @@ describe('props', () => {
     });
 
     it('should inherit shouldForwardProp for wrapped styled components', () => {
-      const Div1 = styled('div').withConfig({
-        shouldForwardProp: prop => prop !== 'color'
+      const Div1 = styled('div', {
+        shouldForwardProp: prop => prop !== 'color',
       })`
         background-color: ${({ color }) => color};
       `;
@@ -120,9 +120,9 @@ describe('props', () => {
     });
 
     it('should filter out props when using "as" to a custom component', () => {
-      const AsComp = props => <div {...props} />
-      const Comp = styled('div').withConfig({
-        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      const AsComp = props => <div {...props} />;
+      const Comp = styled('div', {
+        shouldForwardProp: prop => !['filterThis'].includes(prop),
       })`
         color: red;
       `;
@@ -134,11 +134,11 @@ describe('props', () => {
     });
 
     it('can set computed styles based on props that are being filtered out', () => {
-      const AsComp = props => <div {...props} />
-      const Comp = styled('div').withConfig({
-        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      const AsComp = props => <div {...props} />;
+      const Comp = styled('div', {
+        shouldForwardProp: prop => !['filterThis'].includes(prop),
       })`
-        color: ${props => props.filterThis === 'abc' ? 'red' : undefined};
+        color: ${props => (props.filterThis === 'abc' ? 'red' : undefined)};
       `;
       const wrapper = TestRenderer.create(<Comp as={AsComp} filterThis="abc" passThru="def" />);
       const { props } = wrapper.root.findByType(AsComp);
@@ -148,13 +148,13 @@ describe('props', () => {
     });
 
     it('should filter our props when using "as" to a different element', () => {
-      const Comp = styled('div').withConfig({
-        shouldForwardProp: prop => !['filterThis'].includes(prop)
+      const Comp = styled('div', {
+        shouldForwardProp: prop => !['filterThis'].includes(prop),
       })`
         color: red;
       `;
       const wrapper = TestRenderer.create(<Comp as="a" filterThis="abc" passThru="def" />);
-      const { props } = wrapper.root.findByType("a");
+      const { props } = wrapper.root.findByType('a');
       expectCSSMatches('.b { color:red; }');
       expect(props.passThru).toBe('def');
       expect(props.filterThis).toBeUndefined();

--- a/packages/styled-components/src/test/rehydration.test.js
+++ b/packages/styled-components/src/test/rehydration.test.js
@@ -55,7 +55,7 @@ describe('rehydration', () => {
     });
 
     it('should append a new component like normal', () => {
-      const Comp = styled.div.withConfig({ componentId: 'ONE' })`
+      const Comp = styled('div', { componentId: 'ONE' })`
         color: blue;
         ${() => ''}
       `;
@@ -64,23 +64,23 @@ describe('rehydration', () => {
     });
 
     it('should reuse a componentId', () => {
-      const A = styled.div.withConfig({ componentId: 'ONE' })`
+      const A = styled('div', { componentId: 'ONE' })`
         color: blue;
         ${() => ''}
       `;
       TestRenderer.create(<A />);
-      const B = styled.div.withConfig({ componentId: 'TWO' })``;
+      const B = styled('div', { componentId: 'TWO' })``;
       TestRenderer.create(<B />);
       expectCSSMatches('.b { color: red; } .a { color:blue; }');
     });
 
     it('should reuse a componentId and generated class', () => {
-      const A = styled.div.withConfig({ componentId: 'ONE' })`
+      const A = styled('div', { componentId: 'ONE' })`
         color: blue;
         ${() => ''}
       `;
       TestRenderer.create(<A />);
-      const B = styled.div.withConfig({ componentId: 'TWO' })`
+      const B = styled('div', { componentId: 'TWO' })`
         color: red;
         ${() => ''}
       `;
@@ -89,16 +89,16 @@ describe('rehydration', () => {
     });
 
     it('should reuse a componentId and inject new classes', () => {
-      const A = styled.div.withConfig({ componentId: 'ONE' })`
+      const A = styled('div', { componentId: 'ONE' })`
         color: blue;
         ${() => ''}
       `;
       TestRenderer.create(<A />);
-      const B = styled.div.withConfig({ componentId: 'TWO' })`
+      const B = styled('div', { componentId: 'TWO' })`
         color: ${() => 'red'};
       `;
       TestRenderer.create(<B />);
-      const C = styled.div.withConfig({ componentId: 'TWO' })`
+      const C = styled('div', { componentId: 'TWO' })`
         color: ${() => 'green'};
       `;
       TestRenderer.create(<C />);
@@ -130,7 +130,7 @@ describe('rehydration', () => {
     });
 
     it('should not inject new styles for a component already rendered', () => {
-      const Comp = styled.div.withConfig({ componentId: 'ONE' })`
+      const Comp = styled('div', { componentId: 'ONE' })`
         color: ${props => props.color};
       `;
       TestRenderer.create(<Comp color="blue" />);
@@ -142,7 +142,7 @@ describe('rehydration', () => {
 
     it('should inject new styles for a new computed style of a component', () => {
       seedNextClassnames(['x']);
-      const Comp = styled.div.withConfig({ componentId: 'ONE' })`
+      const Comp = styled('div', { componentId: 'ONE' })`
         color: ${props => props.color};
       `;
       TestRenderer.create(<Comp color="green" />);
@@ -209,7 +209,7 @@ describe('rehydration', () => {
         body { color: tomato; }
       `;
 
-      const A = styled.div.withConfig({ componentId: 'ONE' })`
+      const A = styled('div', { componentId: 'ONE' })`
         color: blue;
         ${() => ''}
       `;
@@ -261,11 +261,11 @@ describe('rehydration', () => {
         body { background: papayawhip; }
       `;
       TestRenderer.create(<Component2 />);
-      const A = styled.div.withConfig({ componentId: 'ONE' })`
+      const A = styled('div', { componentId: 'ONE' })`
         color: blue;
       `;
       TestRenderer.create(<A />);
-      const B = styled.div.withConfig({ componentId: 'TWO' })`
+      const B = styled('div', { componentId: 'TWO' })`
         color: red;
       `;
       TestRenderer.create(<B />);
@@ -281,7 +281,7 @@ describe('rehydration', () => {
     it('should still not change styles if rendered in a different order', () => {
       seedNextClassnames(['d', 'a', 'b', 'c']);
 
-      const B = styled.div.withConfig({ componentId: 'TWO' })`
+      const B = styled('div', { componentId: 'TWO' })`
         color: red;
       `;
       TestRenderer.create(<B />);
@@ -293,7 +293,7 @@ describe('rehydration', () => {
         body { background: papayawhip; }
       `;
       TestRenderer.create(<Component2 />);
-      const A = styled.div.withConfig({ componentId: 'ONE' })`
+      const A = styled('div', { componentId: 'ONE' })`
         color: blue;
       `;
       TestRenderer.create(<A />);

--- a/packages/styled-components/src/test/ssr.test.js
+++ b/packages/styled-components/src/test/ssr.test.js
@@ -109,10 +109,10 @@ describe('ssr', () => {
   });
 
   it('should render CSS in the order the components were defined, not rendered', () => {
-    const ONE = styled.h1.withConfig({ componentId: 'ONE' })`
+    const ONE = styled('h1', { componentId: 'ONE' })`
       color: red;
     `;
-    const TWO = styled.h2.withConfig({ componentId: 'TWO' })`
+    const TWO = styled('h2', { componentId: 'TWO' })`
       color: blue;
     `;
 

--- a/packages/styled-components/src/test/warnOnDynamicCreation.test.js
+++ b/packages/styled-components/src/test/warnOnDynamicCreation.test.js
@@ -23,7 +23,7 @@ describe('warns on dynamic creation', () => {
         color: palevioletred;
       `;
 
-      return <Inner />
+      return <Inner />;
     };
 
     TestRenderer.create(<Outer />);
@@ -33,14 +33,14 @@ describe('warns on dynamic creation', () => {
 
   it('should warn only once for a given ID', () => {
     const Outer = () => {
-      const Inner = styled.div.withConfig({
+      const Inner = styled('div', {
         displayName: 'Inner',
         componentId: 'Inner',
       })`
         color: palevioletred;
       `;
 
-      return <Inner />
+      return <Inner />;
     };
 
     TestRenderer.create(<Outer />);


### PR DESCRIPTION
closes #3053

This change aligns our API more closely to emotion's styled API to allow more easy portability between libraries. As an aside, this also removes the ability to progressively chain different options together, though I think this is a rare edge case. A corresponding babel plugin change is also needed.