### PR TITLE
WIP: Fix: SSR doesn't include styles

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -87,6 +87,7 @@
     "react-native": "^0.59.8",
     "react-primitives": "^0.8.0",
     "react-test-renderer": "^16.8.6",
+    "stream-to-promise": "^2.2.0",
     "stylis-plugin-rtl": "^1.0.0"
   },
   "bundlesize": [

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -20,6 +20,7 @@
     "flow:watch": "flow-watch",
     "pretest": "npm run generateErrors",
     "test": "npm run test:web && npm run test:native && npm run test:primitives",
+    "pretest:web": "npm run build",
     "test:web": "jest -c ../../scripts/jest/config.main.js",
     "test:native": "jest -c ../../scripts/jest/config.native.js",
     "test:primitives": "jest -c ../../scripts/jest/config.primitives.js",

--- a/packages/styled-components/src/test/ssr.test.js
+++ b/packages/styled-components/src/test/ssr.test.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { renderToString, renderToNodeStream } from 'react-dom/server';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import ofStream from 'stream-to-promise';
-import ServerStyleSheet from '../models/ServerStyleSheet';
+import { ServerStyleSheet } from '../../dist/styled-components.esm';
 import { resetStyled } from './utils';
 import createGlobalStyle from '../constructors/createGlobalStyle';
 import StyleSheetManager from '../models/StyleSheetManager';

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,10 +957,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
 
-"@emotion/is-prop-valid@0.8.6", "@emotion/is-prop-valid@^0.8.3":
+"@emotion/is-prop-valid@0.8.6":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz#4757646f0a58e9dec614c47c838e7147d88c263c"
   integrity sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
   dependencies:
     "@emotion/memoize" "0.7.4"
 
@@ -1696,6 +1703,11 @@ any-observable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
   integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
+
+any-promise@^1.1.0, any-promise@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -3752,6 +3764,13 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+end-of-stream@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.1.0.tgz#e9353258baa9108965efc41cb0ef8ade2f3cfb07"
+  integrity sha1-6TUyWLqpEIll78QcsO+K3i88+wc=
+  dependencies:
+    once "~1.3.0"
 
 enhanced-resolve@4.1.0:
   version "4.1.0"
@@ -7954,6 +7973,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+once@~1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
+  integrity sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=
+  dependencies:
+    wrappy "1"
+
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -10048,6 +10074,22 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+stream-to-array@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/stream-to-array/-/stream-to-array-2.3.0.tgz#bbf6b39f5f43ec30bc71babcb37557acecf34353"
+  integrity sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=
+  dependencies:
+    any-promise "^1.1.0"
+
+stream-to-promise@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stream-to-promise/-/stream-to-promise-2.2.0.tgz#b1edb2e1c8cb11289d1b503c08d3f2aef51e650f"
+  integrity sha1-se2y4cjLESidG1A8CNPyrvUeZQ8=
+  dependencies:
+    any-promise "~1.3.0"
+    end-of-stream "~1.1.0"
+    stream-to-array "~2.3.0"
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Note: this is extremely early, I'm opening the PR to work out in the open and leave some documentation with regards to how to debug & fix these kind of issues.

## Todo
- [x] Clean up SSR tests a bit
- [x] Write failing test case based on https://github.com/StevenLangbroek/sc-v5-streaming-repro
- [ ] Investigate root cause
- [ ] Fix test
- [ ] Profit

Resolves #2962 

The problem appears only in the built version of `sc`, if you want I can duplicate the ssr test suite but run it against built version as a separate step to prevent this in the future. Thoughts? /cc @kitten @probablyup 

## Result so far
I've narrowed the problem down to this:

If I run the tests as normal, the `DefaultGroupedTag` contains a normal amount of `rules` (found by logging `tag` in `outputSheet`). If I build `sc`, and point the `ServerStyleSheet` import at the built assets (as this branch does now), the `rules` array is empty however. My best guess is the bug is somewhere in `insertRules` on `DefaultGroupedTag` or `insertRule` on the underlying `Tag`.

Development:
![image](https://user-images.githubusercontent.com/296796/76556199-d70c1300-6477-11ea-8a0a-8357a4ed4e9b.png)

Production:
![image](https://user-images.githubusercontent.com/296796/76565243-ed6e9a80-6488-11ea-98dc-dd9b1e6d5a21.png)
