### PR TITLE
Add support for animations in objects

### DIFF
--- a/packages/styled-components/src/constructors/css.js
+++ b/packages/styled-components/src/constructors/css.js
@@ -6,17 +6,29 @@ import isFunction from '../utils/isFunction';
 import flatten from '../utils/flatten';
 import type { Interpolation, RuleSet, Styles } from '../types';
 
+/**
+ * Used when flattening object styles to determine if we should
+ * expand an array of styles.
+ */
+const addTag = arg => {
+  if (Array.isArray(arg)) {
+    // eslint-disable-next-line no-param-reassign
+    arg.isCss = true;
+  }
+  return arg;
+};
+
 export default function css(styles: Styles, ...interpolations: Array<Interpolation>): RuleSet {
   if (isFunction(styles) || isPlainObject(styles)) {
     // $FlowFixMe
-    return flatten(interleave(EMPTY_ARRAY, [styles, ...interpolations]));
+    return addTag(flatten(interleave(EMPTY_ARRAY, [styles, ...interpolations])));
   }
 
-  if(interpolations.length === 0 && styles.length === 1 && typeof styles[0] === "string") {
+  if (interpolations.length === 0 && styles.length === 1 && typeof styles[0] === 'string') {
     // $FlowFixMe
     return styles;
   }
 
   // $FlowFixMe
-  return flatten(interleave(styles, interpolations));
+  return addTag(flatten(interleave(styles, interpolations)));
 }

--- a/packages/styled-components/src/constructors/test/keyframes.test.js
+++ b/packages/styled-components/src/constructors/test/keyframes.test.js
@@ -88,6 +88,114 @@ describe('keyframes', () => {
     `);
   });
 
+  it('should insert the correct styles for objects', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    expectCSSMatches('');
+
+    const Comp = styled.div({
+      animation: css`
+        ${animation} 2s linear infinite
+      `,
+    });
+
+    TestRenderer.create(<Comp />);
+
+    expectCSSMatches(`
+      .a {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+
+      @-webkit-keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+
+      @keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+    `);
+  });
+
+  it('should insert the correct styles for objects with nesting', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+
+    expectCSSMatches('');
+
+    const Comp = styled.div({
+      '@media(max-width: 700px)': {
+        animation: css`
+          ${animation} 2s linear infinite
+        `,
+        ':hover': {
+          animation: css`
+            ${animation} 10s linear infinite
+          `,
+        },
+      },
+    });
+
+    TestRenderer.create(<Comp />);
+
+    expectCSSMatches(`
+     @media(max-width: 700px) {
+      .a {
+        -webkit-animation: jgzmJZ 2s linear infinite;
+        animation: jgzmJZ 2s linear infinite;
+       }
+     }
+    .a:hover {
+      -webkit-animation: jgzmJZ 10s linear infinite;
+      animation: jgzmJZ 10s linear infinite;
+    }
+    @-webkit-keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    @keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    `);
+  });
+
   it('should insert the correct styles when keyframes in props', () => {
     const rules = `
       0% {

--- a/packages/styled-components/src/utils/stylis.js
+++ b/packages/styled-components/src/utils/stylis.js
@@ -83,7 +83,7 @@ export default function createStylisInstance({
     const cssStr = selector && prefix ? `${prefix} ${selector} { ${flatCSS} }` : flatCSS;
 
     // stylis has no concept of state to be passed to plugins
-    // but since JS is single=threaded, we can rely on that to ensure
+    // but since JS is single-threaded, we can rely on that to ensure
     // these properties stay in sync with the current stylis run
     _componentId = componentId;
     _selector = selector;


### PR DESCRIPTION
This PR adds support for animations in styled objects.
Example usage:

```jsx
const animation = keyframes({
  from: { opacity: 0 },
  to: { opacity: 1 }
})

const Animated = styled.div({ animation: css`${animation} 3s` })

const Animated2 = styled.div(({time = 1}) => ({
  animation: css`${animation} ${time}s infinite` 
}))
```
This addresses issue:
https://github.com/styled-components/styled-components/issues/2561

The implementation detects arrays in value position during `objToCssArray` expansion
and mutually recurses into `flatten` to further transform nested forms of styles.

---
update:
After seeing the feedback here (and a similar implementation):
https://github.com/styled-components/styled-components/pull/2612

I updated this implementation to add a flag on arrays returned by `css` to determine if we should expand the nested styles within `objToCssArray`.