### PR TITLE
fix: escape every CSS ident character necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+### Bugfixes
+
+- Escape every CSS ident character necessary when converting component display names to class names (see [#3102](https://github.com/styled-components/styled-components/pull/3102)) thanks @kripod!
+
 ## [v5.1.0] - 2020-04-07
 
 ### New Functionality

--- a/packages/styled-components/src/utils/escape.js
+++ b/packages/styled-components/src/utils/escape.js
@@ -2,7 +2,7 @@
 
 // Source: https://www.w3.org/TR/cssom-1/#serialize-an-identifier
 // Control characters and non-letter first symbols are not supported
-const escapeRegex = /[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]+/g;
+const escapeRegex = /[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g;
 
 const dashesAtEnds = /(^-|-$)/g;
 

--- a/packages/styled-components/src/utils/escape.js
+++ b/packages/styled-components/src/utils/escape.js
@@ -2,7 +2,7 @@
 
 // Source: https://www.w3.org/TR/cssom-1/#serialize-an-identifier
 // Control characters and non-letter first symbols are not supported
-const escapeRegex = /[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g;
+const escapeRegex = /[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]+/g;
 
 const dashesAtEnds = /(^-|-$)/g;
 

--- a/packages/styled-components/src/utils/escape.js
+++ b/packages/styled-components/src/utils/escape.js
@@ -1,5 +1,9 @@
 // @flow
-const escapeRegex = /[[\].#*$><+~=|^:(),"'`-]+/g;
+
+// Source: https://www.w3.org/TR/cssom-1/#serialize-an-identifier
+// Control characters and non-letter first symbols are not supported
+const escapeRegex = /[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g;
+
 const dashesAtEnds = /(^-|-$)/g;
 
 /**


### PR DESCRIPTION
The list of characters to be escaped was determined by the [_serialize an identifier_](https://www.w3.org/TR/cssom-1/#serialize-an-identifier) idiom of the CSSOM spec:

>- _[Ignored rules about control characters and non-letter first symbols…]_
>- If the character is not handled by one of the above rules and is greater than or equal to U+0080, is "-" (U+002D) or "_" (U+005F), or is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to U+005A), or \[a-z] (U+0061 to U+007A), then the character itself.
>- Otherwise, the escaped character. 

The new list of characters in `escapeRegex` was generated by applying the rules above:

```js
const arr = [];
for (let i = 0x20; i < 0x80; ++i) {
  if (
    i !== 0x7f &&
    i !== 0x2d &&
    !(i >= 0x30 && i <= 0x39) &&
    !(i >= 0x41 && i <= 0x5a) &&
    i !== 0x5f &&
    !(i >= 0x61 && i <= 0x7a)
  )
    arr.push(String.fromCharCode(i));
}
console.log(arr.join("")); // !"#$%&'()*+,./:;<=>?@[\]^`{|}~
```