### PR TITLE
Implement shouldForwardProp for React Native/Primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Implement `shouldForwardProp` API for native and primitive platforms (see [#3093](https://github.com/styled-components/styled-components/issues/3093))
+
 ## [v5.1.0] - 2020-04-07
 
 ### New Functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ### Bugfixes
 
-- Added `useTheme` hook to named exports for react-primitives entrypoint (see [#2982](https://github.com/styled-components/styled-components/pull/3108))
+- Added `useTheme` hook to named exports for react-primitives entrypoint (see [#2982](https://github.com/styled-components/styled-components/pull/2982)) thanks @jladuval!
 - Escape every CSS ident character necessary when converting component display names to class names (see [#3102](https://github.com/styled-components/styled-components/pull/3102)) thanks @kripod!
 
 ## [v5.1.0] - 2020-04-07

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -1,5 +1,4 @@
 // @flow
-import validAttr from '@emotion/is-prop-valid';
 import React, { createElement, Component } from 'react';
 import hoist from 'hoist-non-react-statics';
 import merge from '../utils/mixinDeep';
@@ -16,6 +15,9 @@ import type { Attrs, RuleSet, Target } from '../types';
 
 // NOTE: no hooks available for react-native yet;
 // if the user makes use of ThemeProvider or StyleSheetManager things will break.
+
+// Validator defaults to true if not in HTML/DOM env
+const validAttr = () => true;
 
 class StyledNativeComponent extends Component<*, *> {
   root: ?Object;
@@ -56,7 +58,7 @@ class StyledNativeComponent extends Component<*, *> {
             else if (key === 'forwardedAs') {
               propsForElement.as = props[key];
             } else if (!propFilterFn || propFilterFn(key, validAttr)) {
-              // Don't pass through non HTML tags through to HTML elements
+              // Don't pass through filtered tags through to native elements
               propsForElement[key] = computedProps[key];
             }
           }

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -1,4 +1,5 @@
 // @flow
+import validAttr from '@emotion/is-prop-valid';
 import React, { createElement, Component } from 'react';
 import hoist from 'hoist-non-react-statics';
 import merge from '../utils/mixinDeep';
@@ -35,7 +36,7 @@ class StyledNativeComponent extends Component<*, *> {
             ...props
           } = this.props;
 
-          const { defaultProps, target } = forwardedComponent;
+          const { defaultProps, target, shouldForwardProp } = forwardedComponent;
           const elementToBeRendered =
             this.attrs.$as || this.attrs.as || transientAsProp || renderAs || target;
 
@@ -44,15 +45,20 @@ class StyledNativeComponent extends Component<*, *> {
             this.props
           );
 
+          const isTargetTag = isTag(elementToBeRendered);
+          const computedProps = this.attrs !== props ? { ...props, ...this.attrs } : props;
+          const propFilterFn = shouldForwardProp || (isTargetTag && validAttr);
           const propsForElement = {};
           let key;
 
-          for (key in props) {
-            if (key[0] !== '$') propsForElement[key] = props[key];
-          }
-
-          for (key in this.attrs) {
-            if (key[0] !== '$') propsForElement[key] = this.attrs[key];
+          for (key in computedProps) {
+            if (key[0] === '$' || key === 'as') continue;
+            else if (key === 'forwardedAs') {
+              propsForElement.as = props[key];
+            } else if (!propFilterFn || propFilterFn(key, validAttr)) {
+              // Don't pass through non HTML tags through to HTML elements
+              propsForElement[key] = computedProps[key];
+            }
           }
 
           propsForElement.style = [generatedStyles].concat(style);
@@ -145,6 +151,22 @@ export default (InlineStyle: Function) => {
         ? Array.prototype.concat(target.attrs, attrs).filter(Boolean)
         : attrs;
 
+    // eslint-disable-next-line prefer-destructuring
+    let shouldForwardProp = options.shouldForwardProp;
+
+    // $FlowFixMe
+    if (isTargetStyledComp && target.shouldForwardProp) {
+      if (shouldForwardProp) {
+        // compose nested shouldForwardProp calls
+        shouldForwardProp = (prop, filterFn) =>
+          // $FlowFixMe
+          target.shouldForwardProp(prop, filterFn) && options.shouldForwardProp(prop, filterFn);
+      } else {
+        // eslint-disable-next-line prefer-destructuring
+        shouldForwardProp = target.shouldForwardProp;
+      }
+    }
+
     /**
      * forwardRef creates a new interim component, which we'll take advantage of
      * instead of extending ParentComponent to create _another_ interim class
@@ -154,6 +176,9 @@ export default (InlineStyle: Function) => {
     WrappedStyledNativeComponent.attrs = finalAttrs;
 
     WrappedStyledNativeComponent.displayName = displayName;
+
+    // $FlowFixMe
+    WrappedStyledNativeComponent.shouldForwardProp = shouldForwardProp;
 
     // $FlowFixMe
     WrappedStyledNativeComponent.inlineStyle = new InlineStyle(
@@ -197,6 +222,7 @@ export default (InlineStyle: Function) => {
         // all SC-specific things should not be hoisted
         attrs: true,
         displayName: true,
+        shouldForwardProp: true,
         inlineStyle: true,
         styledComponentId: true,
         target: true,


### PR DESCRIPTION
Tested with `react-figma` (with `styled-components/primitives`). Should work with React Native, but would be great if someone could test it before merging 🙂.

I had to do `npm i -D bundlesize jest` in the package folder. Should I commit the `package.json` with them as local dependencies? I try to avoid global dependencies where possible (to avoid version mismatches between packages, and make sure people have up-to-date versions).

fixes #3093 