### PR TITLE
Render global styles with useEffect hook

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.js
+++ b/packages/styled-components/src/constructors/createGlobalStyle.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useContext, useEffect, useLayoutEffect, useRef } from 'react';
 import { STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheet, useStylis } from '../models/StyleSheetManager';
@@ -13,6 +13,8 @@ import css from './css';
 import type { Interpolation } from '../types';
 
 type GlobalStyleComponentPropsType = Object;
+
+declare var __SERVER__: boolean;
 
 export default function createGlobalStyle(
   strings: Array<string>,
@@ -49,7 +51,7 @@ export default function createGlobalStyle(
 
     const instanceRef = useRef(null);
 
-    function renderStyles() {
+    function renderGlobalStyles() {
       if (instanceRef.current === null) {
         instanceRef.current = styleSheet.allocateGSInstance(styledComponentId);
       }
@@ -68,16 +70,13 @@ export default function createGlobalStyle(
       }
     }
 
-    if (typeof window !== 'undefined' && window.document && window.document.createElement) {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      useEffect(renderStyles);
-    } else {
-      // Server-side rendering
-      renderStyles();
+    useLayoutEffect(renderGlobalStyles);
+    if (__SERVER__) {
+      renderGlobalStyles();
     }
 
     useEffect(() => () => {
-      if (instanceRef.current !== null) {
+      if (instanceRef.current) {
         globalStyle.removeStyles(instanceRef.current, styleSheet);
       }
     }, EMPTY_ARRAY);

--- a/packages/styled-components/src/test/rehydration.test.js
+++ b/packages/styled-components/src/test/rehydration.test.js
@@ -172,8 +172,6 @@ describe('rehydration', () => {
   });
 
   describe('with global styles', () => {
-    const { createElement } = window.document;
-
     beforeEach(() => {
       /* Adding a non-local stylesheet with a hash 557410406 which is
        * derived from "body { background: papayawhip; }" so be careful
@@ -190,12 +188,6 @@ describe('rehydration', () => {
       `;
 
       resetSheet(masterSheet);
-
-      window.document.createElement = undefined;
-    });
-
-    afterEach(() => {
-      window.document.createElement = createElement;
     });
 
     it('should leave the existing styles there', () => {

--- a/packages/styled-components/src/test/rehydration.test.js
+++ b/packages/styled-components/src/test/rehydration.test.js
@@ -172,6 +172,8 @@ describe('rehydration', () => {
   });
 
   describe('with global styles', () => {
+    const { createElement } = window.document;
+
     beforeEach(() => {
       /* Adding a non-local stylesheet with a hash 557410406 which is
        * derived from "body { background: papayawhip; }" so be careful
@@ -188,6 +190,12 @@ describe('rehydration', () => {
       `;
 
       resetSheet(masterSheet);
+
+      window.document.createElement = undefined;
+    });
+
+    afterEach(() => {
+      window.document.createElement = createElement;
     });
 
     it('should leave the existing styles there', () => {


### PR DESCRIPTION
Fixes [#3076](https://github.com/styled-components/styled-components/issues/3076)

Rendering of styles is a side-effect and should not be performed before mounting.
React.StrictMode helps to enforce this rule by running various functions (lifecycle methods or the function itself in case of function components) twice to make sure that they are idempotent. GlobalStyleComponent was not idempotent, calling Sheet#allocateGSInstance on render, which led to generating a different id on the second render and absence of corresponding unmount callback for the first one.