### PR TITLE
Native supports a stable style prop reference with React.memo

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -69,6 +69,8 @@
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^3.0.0",
     "hoist-non-react-statics": "^3.0.0",
+    "memoize-one": "^5.1.1",
+    "react-fast-compare": "^3.1.1",
     "shallowequal": "^1.1.0",
     "supports-color": "^5.5.0"
   },

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -11,6 +11,7 @@ import isFunction from '../utils/isFunction';
 import isTag from '../utils/isTag';
 import isStyledComponent from '../utils/isStyledComponent';
 import { ThemeConsumer } from './ThemeProvider';
+import isElementTypeMemo from '../utils/isElementTypeMemo';
 
 import type { Theme } from './ThemeProvider';
 import type { Attrs, RuleSet, Target } from '../types';
@@ -37,7 +38,6 @@ class StyledNativeComponent extends Component<*, *> {
             forwardedAs,
             forwardedRef,
             style = [],
-            __scIsMemo,
             ...props
           } = this.props;
 
@@ -66,7 +66,10 @@ class StyledNativeComponent extends Component<*, *> {
             }
           }
 
-          propsForElement.style = __scIsMemo ? this.getStyles(generatedStyles, style) : this.getMemoStyles(generatedStyles, style);
+          const isTargetMemo = !isTargetTag && isElementTypeMemo(elementToBeRendered);
+          propsForElement.style = isTargetMemo
+            ? this.getMemoStyles(generatedStyles, style)
+            : this.getStyles(generatedStyles, style);
 
           if (forwardedRef) propsForElement.ref = forwardedRef;
           if (forwardedAs) propsForElement.as = forwardedAs;
@@ -136,7 +139,7 @@ class StyledNativeComponent extends Component<*, *> {
   }
 }
 
-export default (InlineStyle: Function, isMemo: boolean = false) => {
+export default (InlineStyle: Function) => {
   const createStyledNativeComponent = (target: Target, options: Object, rules: RuleSet) => {
     const {
       attrs = EMPTY_ARRAY,
@@ -151,7 +154,6 @@ export default (InlineStyle: Function, isMemo: boolean = false) => {
     const WrappedStyledNativeComponent = React.forwardRef((props, ref) => (
       <ParentComponent
         {...props}
-        __scIsMemo={isMemo}
         forwardedComponent={WrappedStyledNativeComponent}
         forwardedRef={ref}
       />

--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -18,6 +18,8 @@ const reactNative = require('react-native');
 const InlineStyle = _InlineStyle(reactNative.StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);
 const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag);
+const StyledNativeMemoComponent = _StyledNativeComponent(InlineStyle, true);
+const styledMemo = (tag: Target) => constructWithOptions(StyledNativeMemoComponent, tag);
 
 /* React native lazy-requires each of these modules for some reason, so let's
  *  assume it's for a good reason and not eagerly load them all */
@@ -41,5 +43,5 @@ aliases.split(/\s+/m).forEach(alias =>
   })
 );
 
-export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme };
+export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme, styledMemo };
 export default styled;

--- a/packages/styled-components/src/native/index.js
+++ b/packages/styled-components/src/native/index.js
@@ -18,8 +18,6 @@ const reactNative = require('react-native');
 const InlineStyle = _InlineStyle(reactNative.StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);
 const styled = (tag: Target) => constructWithOptions(StyledNativeComponent, tag);
-const StyledNativeMemoComponent = _StyledNativeComponent(InlineStyle, true);
-const styledMemo = (tag: Target) => constructWithOptions(StyledNativeMemoComponent, tag);
 
 /* React native lazy-requires each of these modules for some reason, so let's
  *  assume it's for a good reason and not eagerly load them all */
@@ -43,5 +41,5 @@ aliases.split(/\s+/m).forEach(alias =>
   })
 );
 
-export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme, styledMemo };
+export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme };
 export default styled;

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -169,6 +169,41 @@ Object {
     expect(wrapper.root.findByType('Text')).not.toBeUndefined();
   });
 
+  describe('style prop reference stability on custom components', () => {
+    it('should not optimize non-React.memo components', () => {
+      const styleCache = [];
+      const CustomComponent = ({ style }) => {
+        styleCache.push(style);
+        return null;
+      };
+      const Comp = styled(CustomComponent)`
+        margin: 16px;
+      `;
+
+      const wrapper = TestRenderer.create(<Comp />);
+      wrapper.update(<Comp />);
+
+      expect(styleCache.length).toBe(2);
+      expect(styleCache[0]).not.toBe(styleCache[1]);
+    });
+
+    it('should not cause React.memo(CustomComponent) to re-render', () => {
+      const styleCache = [];
+      const CustomComponent = React.memo(({ style }) => {
+        styleCache.push(style);
+        return null;
+      });
+      const Comp = styled(CustomComponent)`
+        margin: 16px;
+      `;
+
+      const wrapper = TestRenderer.create(<Comp />);
+      wrapper.update(<Comp />);
+
+      expect(styleCache.length).toBe(1);
+    });
+  });
+
   describe('attrs', () => {
     beforeEach(() => jest.spyOn(console, 'warn').mockImplementation(() => {}));
 

--- a/packages/styled-components/src/utils/isElementTypeMemo.js
+++ b/packages/styled-components/src/utils/isElementTypeMemo.js
@@ -6,7 +6,7 @@ const hasSymbol = typeof Symbol === 'function' && Symbol.for;
 const TypeOfReactMemo = hasSymbol
   ? Symbol.for('react.memo')
   : // $FlowFixMe — accessing impl detail (see https://github.com/facebook/react/issues/12882#issuecomment-440227651)
-    typeof React.memo === 'function' && React.memo((props: any) => null)['$$typeof'];
+    typeof React.memo === 'function' && React.memo(() => null).$$typeof;
 
 /**
  * Determines whether an element type is the result of `React.memo`.
@@ -14,5 +14,5 @@ const TypeOfReactMemo = hasSymbol
  * This fn is in lieu of the currently unmerged https://github.com/facebook/react/pull/15349
  */
 export default function isElementTypeMemo(test: any): boolean %checks {
-  return TypeOfReactMemo && test && test['$$typeof'] === TypeOfReactMemo;
+  return TypeOfReactMemo && test && test.$$typeof === TypeOfReactMemo;
 }

--- a/packages/styled-components/src/utils/isElementTypeMemo.js
+++ b/packages/styled-components/src/utils/isElementTypeMemo.js
@@ -1,0 +1,18 @@
+// @flow
+import React from 'react';
+
+const hasSymbol = typeof Symbol === 'function' && Symbol.for;
+
+const TypeOfReactMemo = hasSymbol
+  ? Symbol.for('react.memo')
+  : // $FlowFixMe — accessing impl detail (see https://github.com/facebook/react/issues/12882#issuecomment-440227651)
+    typeof React.memo === 'function' && React.memo((props: any) => null)['$$typeof'];
+
+/**
+ * Determines whether an element type is the result of `React.memo`.
+ * Note: Use `ReactIs.isMemo()` if you need to test an actual react element (ie. the return of `React.createElement`).
+ * This fn is in lieu of the currently unmerged https://github.com/facebook/react/pull/15349
+ */
+export default function isElementTypeMemo(test: any): boolean %checks {
+  return TypeOfReactMemo && test && test['$$typeof'] === TypeOfReactMemo;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7081,7 +7081,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.4:
+memoize-one@^5.0.4, memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -8943,6 +8943,11 @@ react-dom@^16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-fast-compare@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.1.1.tgz#0becf31e3812fa70dc231e259f40d892d4767900"
+  integrity sha512-SCsAORWK59BvauR2L1BTdjQbJcSGJJz03U0awektk2hshLKrITDDFTlgGCqIZpTDlPC/NFlZee6xTMzXPVLiHw==
 
 react-fela@^10.5.0:
   version "10.8.2"


### PR DESCRIPTION
This is a follow up to the closed #3020 (cc: @Federkun, @kitten) and I have raised the following new issue which provides a rationale for the proposed changes: #3149

In #3020, the consensus was that memoization of the resulting style prop would be too expensive to run on every instance when only a subset of use cases would benefit.

**Update:**
This PR initially explored this approach:
```js
import { styledMemo } from 'styled-components/native';
```

But then after feedback, that was reverted and it now only employs a memoize optimisation for `React.memo` components.

#### Caveats
* I haven't used flowtype before, so might need a hand with anything flow specific