### PR TITLE
Update StyledNativeComponent to hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,7 @@
   "globals": {
     "$Call": true,
     "$Keys": true,
-    "$PropertyType": true
+    "$PropertyType": true,
+    "Class": true
   }
 }

--- a/packages/styled-components/src/models/InlineStyle.js
+++ b/packages/styled-components/src/models/InlineStyle.js
@@ -3,7 +3,7 @@
 import transformDeclPairs from 'css-to-react-native';
 
 import generateComponentId from '../utils/generateComponentId';
-import type { RuleSet, StyleSheet } from '../types';
+import type { RuleSet, StyleSheet, IInlineStyle } from '../types';
 import flatten from '../utils/flatten';
 // $FlowFixMe
 import parse from '../vendor/postcss-safe-parser/parse';
@@ -18,7 +18,7 @@ export const resetStyleCache = () => {
  InlineStyle takes arbitrary CSS and generates a flat object
  */
 export default (styleSheet: StyleSheet) => {
-  class InlineStyle {
+  class InlineStyle implements IInlineStyle {
     rules: RuleSet;
 
     constructor(rules: RuleSet) {

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -198,7 +198,7 @@ export default function createStyledComponent(
   // fold the underlying StyledComponent attrs up (implicit extend)
   const finalAttrs =
     isTargetStyledComp && ((target: any): IStyledComponent).attrs
-      ? Array.prototype.concat(((target: any): IStyledComponent).attrs, attrs).filter(Boolean)
+      ? ((target: any): IStyledComponent).attrs.concat(attrs).filter(Boolean)
       : attrs;
 
   // eslint-disable-next-line prefer-destructuring
@@ -249,8 +249,7 @@ export default function createStyledComponent(
   // this static is used to preserve the cascade of static classes for component selector
   // purposes; this is especially important with usage of the css prop
   WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
-    ? Array.prototype.concat(
-        ((target: any): IStyledComponent).foldedComponentIds,
+    ? ((target: any): IStyledComponent).foldedComponentIds.concat(
         ((target: any): IStyledComponent).styledComponentId
       )
     : EMPTY_ARRAY;

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -1,12 +1,6 @@
 // @flow
 import hoist from 'hoist-non-react-statics';
-import React, {
-  createElement,
-  useContext,
-  useDebugValue,
-  type AbstractComponent,
-  type Ref,
-} from 'react';
+import React, { createElement, useContext, type AbstractComponent, type Ref } from 'react';
 import type { Attrs, RuleSet, Target } from '../types';
 import determineTheme from '../utils/determineTheme';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '../utils/empties';
@@ -59,7 +53,6 @@ interface StyledComponentWrapperProperties {
   attrs: Attrs;
   inlineStyle: Function;
   displayName: string;
-  foldedComponentIds: Array<string>;
   target: Target;
   shouldForwardProp: ?(prop: string, isValidAttr: (prop: string) => boolean) => boolean;
   styledComponentId: string;
@@ -83,11 +76,8 @@ function useStyledComponentImpl<Config: {}, Instance>(
     defaultProps,
     // $FlowFixMe
     shouldForwardProp,
-    styledComponentId,
     target,
   } = forwardedComponent;
-
-  useDebugValue(styledComponentId);
 
   // NOTE: the non-hooks version only subscribes to this when !componentStyle.isStatic,
   // but that'd be against the rules-of-hooks. We could be naughty and do it anyway as it
@@ -180,13 +170,6 @@ export default (InlineStyle: Function) => {
     WrappedStyledComponent.displayName = displayName;
     WrappedStyledComponent.shouldForwardProp = shouldForwardProp;
 
-    // this static is used to preserve the cascade of static classes for component selector
-    // purposes; this is especially important with usage of the css prop
-    WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
-      ? // $FlowFixMe
-        target.foldedComponentIds.concat(target.styledComponentId)
-      : EMPTY_ARRAY;
-
     WrappedStyledComponent.styledComponentId = styledComponentId;
 
     // fold the underlying StyledComponent target up since we folded the styles
@@ -231,7 +214,6 @@ export default (InlineStyle: Function) => {
       attrs: true,
       inlineStyle: true,
       displayName: true,
-      foldedComponentIds: true,
       shouldForwardProp: true,
       self: true,
       styledComponentId: true,

--- a/packages/styled-components/src/types.js
+++ b/packages/styled-components/src/types.js
@@ -72,5 +72,4 @@ export interface IStyledNativeStatics {
 
 export interface IStyledNativeComponent extends Component<*>, IStyledNativeStatics {
   defaultProps?: Object;
-  toString: () => string;
 }

--- a/packages/styled-components/src/types.js
+++ b/packages/styled-components/src/types.js
@@ -53,3 +53,24 @@ export interface IStyledComponent extends Component<*>, IStyledStatics {
   defaultProps?: Object;
   toString: () => string;
 }
+
+export interface IInlineStyle {
+  constructor(rules: RuleSet): void;
+  rules: RuleSet;
+  generateStyleObject(executionContext: Object): Object;
+}
+
+export interface IStyledNativeStatics {
+  attrs: Attrs;
+  inlineStyle: IInlineStyle;
+  displayName: string;
+  target: Target | IStyledNativeComponent;
+  shouldForwardProp?: ShouldForwardProp;
+  styledComponentId: string;
+  withComponent: (tag: Target) => IStyledNativeComponent;
+}
+
+export interface IStyledNativeComponent extends Component<*>, IStyledNativeStatics {
+  defaultProps?: Object;
+  toString: () => string;
+}

--- a/packages/styled-components/src/utils/generateDisplayName.js
+++ b/packages/styled-components/src/utils/generateDisplayName.js
@@ -1,10 +1,12 @@
 // @flow
-import type { IStyledComponent } from '../types';
+import type { IStyledComponent, IStyledNativeComponent } from '../types';
 import getComponentName from './getComponentName';
 import isTag from './isTag';
 
 export default function generateDisplayName(
-  target: $PropertyType<IStyledComponent, 'target'>
+  target:
+    | $PropertyType<IStyledComponent, 'target'>
+    | $PropertyType<IStyledNativeComponent, 'target'>
 ): string {
   return isTag(target) ? `styled.${target}` : `Styled(${getComponentName(target)})`;
 }

--- a/packages/styled-components/src/utils/getComponentName.js
+++ b/packages/styled-components/src/utils/getComponentName.js
@@ -1,8 +1,10 @@
 // @flow
-import type { IStyledComponent } from '../types';
+import type { IStyledComponent, IStyledNativeComponent } from '../types';
 
 export default function getComponentName(
-  target: $PropertyType<IStyledComponent, 'target'>
+  target:
+    | $PropertyType<IStyledComponent, 'target'>
+    | $PropertyType<IStyledNativeComponent, 'target'>
 ): string {
   return (
     (process.env.NODE_ENV !== 'production' ? typeof target === 'string' && target : false) ||

--- a/packages/styled-components/src/utils/isTag.js
+++ b/packages/styled-components/src/utils/isTag.js
@@ -1,7 +1,11 @@
 // @flow
-import type { IStyledComponent } from '../types';
+import type { IStyledComponent, IStyledNativeComponent } from '../types';
 
-export default function isTag(target: $PropertyType<IStyledComponent, 'target'>): boolean %checks {
+export default function isTag(
+  target:
+    | $PropertyType<IStyledComponent, 'target'>
+    | $PropertyType<IStyledNativeComponent, 'target'>
+): boolean %checks {
   return (
     typeof target === 'string' &&
     (process.env.NODE_ENV !== 'production'


### PR DESCRIPTION
This tries to follow the same structure as `StyledComponent.js` while making the required changes for react-native.

Differences from `StyledComponent.js`

- Use `InlineStyle` instead of `ComponentStyle`
- Remove special `className` handling
- Remove too many classes warning

Differences from class implementation:

- Removed `setNativeProps` warning. This is actually tricky to do with hooks and I didn't see much value added from this warning.

### Test plan

- Tests / flow pass
- Tested the a large RN app using styled components still renders as before
- Tested that styled components render nicely in React DevTools (No more context provider 🎉 )