### PR TITLE
Update stylis plugin docs url

### DIFF
--- a/packages/styled-components/src/utils/stylis.js
+++ b/packages/styled-components/src/utils/stylis.js
@@ -66,7 +66,7 @@ export default function createStylisInstance({
    * The second ampersand should be a reference to the static component class. stylis
    * has no knowledge of static class so we have to intelligently replace the base selector.
    *
-   * https://github.com/thysultan/stylis.js#plugins <- more info about the context phase values
+   * https://github.com/thysultan/stylis.js/tree/v3.5.4#plugins <- more info about the context phase values
    * "2" means this plugin is taking effect at the very end after all other processing is complete
    */
   const selfReferenceReplacementPlugin = (context, _, selectors) => {


### PR DESCRIPTION
stylis.js has upgrade to v4 on 23 Apr and it's a breaking change. We should also update the url of stylis plugin accordingly, otherwise it's confusing because the current link has no info about stylis plugin. 