### PR TITLE
Pass empty `names` option to Sheet when using StyleSheetManager with custom target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+### Bugfixes
+
+- Make sure `StyleSheetManager` renders all styles in iframe / child windows (see [#3159](https://github.com/styled-components/styled-components/pull/3159)) thanks @eramdam!
+
 ## [v5.1.1] - 2020-04-07
 
 ### New Functionality

--- a/packages/styled-components/src/models/StyleSheetManager.js
+++ b/packages/styled-components/src/models/StyleSheetManager.js
@@ -40,7 +40,7 @@ export default function StyleSheetManager(props: Props) {
       // eslint-disable-next-line prefer-destructuring
       sheet = props.sheet;
     } else if (props.target) {
-      sheet = sheet.reconstructWithOptions({ target: props.target });
+      sheet = sheet.reconstructWithOptions({ target: props.target }, false);
     }
 
     if (props.disableCSSOMInjection) {

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.js
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.js
@@ -165,6 +165,7 @@ describe('StyleSheetManager', () => {
           // Render two iframes. each iframe should have the styles for the child injected into their head
           render(
             <div>
+              <Title />
               <Frame>
                 <FrameContextConsumer>
                   {({ document }) => (

--- a/packages/styled-components/src/sheet/Sheet.js
+++ b/packages/styled-components/src/sheet/Sheet.js
@@ -57,8 +57,12 @@ export default class StyleSheet implements Sheet {
     }
   }
 
-  reconstructWithOptions(options: SheetConstructorArgs) {
-    return new StyleSheet({ ...this.options, ...options }, this.gs, this.names);
+  reconstructWithOptions(options: SheetConstructorArgs, withNames?: boolean = true) {
+    return new StyleSheet(
+      { ...this.options, ...options },
+      this.gs,
+      (withNames && this.names) || undefined
+    );
   }
 
   allocateGSInstance(id: string) {


### PR DESCRIPTION
Fixes https://github.com/styled-components/styled-components/issues/2973

When looking at the thread for the above issue, I noticed that after undoing the changes from https://github.com/styled-components/styled-components/pull/2937, the issue was fixed.

It seems obvious that the `names` map change was made for a reason and I didn't want to break SSR so I settled with that solution which looks "fine" 😅

But maybe there's a better approach, if so I'd be happy to oblige 🙇‍♂️ 

I also updated the test for StyleSheetManager in order to mount `Title` both in the parent document _and_ in the iframes, as to trigger the bug in a test environment.