### PR TITLE
feat: add patch for inserting css in qiankun environment

### DIFF
--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -42,7 +42,7 @@ export class CSSOMTag implements Tag {
        * this.element.sheet.cssRules and this.sheet.cssRules are not the same pointer application
        * 
        */
-      if (this.element.sheet.cssRules !== this.sheet.cssRules) {
+      if (this.element.sheet !== this.sheet) {
         this.element.sheet.insertRule(rule, index);
       }
 

--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -34,6 +34,18 @@ export class CSSOMTag implements Tag {
 
   insertRule(index: number, rule: string): boolean {
     try {
+
+       /**
+       * There is an error when using qiankun to build front-end microservices, 
+       * which occurs when switching sub-applications, 
+       * resulting in the loss of css styles of newly added styled-components components on some pages.
+       * this.element.sheet.cssRules and this.sheet.cssRules are not the same pointer application
+       * 
+       */
+      if (this.element.sheet.cssRules !== this.sheet.cssRules) {
+        this.element.sheet.insertRule(rule, index);
+      }
+
       this.sheet.insertRule(rule, index);
       this.length++;
       return true;


### PR DESCRIPTION
### What happens?
> qiankun used with styled components；
1. Load qiankun front-end application；
2. Switch A application to B application, and then switch back to A application；
3. A application switch react router, css style of styled-components used on this page will be lost；

### Context
qiankun: 2.0.12:
styled-components: 4.4.1/5.1.0/5.1.1:
Chrome:  83.0.4103.97:

#### When I debugger, I found that there is an exception here, which is obviously caused when accessing qiankun. The real tag sheet.cssRules does not add css style. In the correct case, this.element.sheet and this.sheet refer to the same reference.

![avatar](https://by-fe-cdn.oss-cn-hangzhou.aliyuncs.com/static/images/%E4%BC%81%E4%B8%9A%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_6d6eaf51-acb4-4342-8ef4-198dfb8f9945.png)
![avatar](https://by-fe-cdn.oss-cn-hangzhou.aliyuncs.com/static/images/%E4%BC%81%E4%B8%9A%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_7c7690e7-4210-4f4c-8fed-60493e0a9452.png)

### Here are two qiankun styled-componets related issues that have not been resolved

1. https://github.com/umijs/qiankun/issues/637；
2. https://github.com/umijs/qiankun/issues/617；



## 🌹🌹🌹🙏🙏🙏 The twelve sub-applications of our project all have the problem of CSS style loss, so I eagerly hope that the styled-componets organization can give us help. The styled-componets organization can pass this pull request.

