### PR TITLE
Add coverage folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.log
 package-lock.json
 **/styled-components/src/utils/errors.js
+coverage


### PR DESCRIPTION
When running tests locally these folders are created and should be ignored.