### PR TITLE
Add SC_CLASS_PREFIX which can be configured during bundle time to avo…

### DIFF
--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -7,6 +7,12 @@ export const SC_ATTR =
   (typeof process !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
   'data-styled';
 
+// Allowing user to add class prefix to all generated class names to avoid class name collision.
+// This is very handy when it comes to situation where different styled-components might co-exist
+// in different JS bundles.
+export const SC_CLASS_PREFIX =
+  (typeof process !== 'undefined' && process.env.SC_CLASS_PREFIX) || '';
+
 export const SC_ATTR_ACTIVE = 'active';
 export const SC_ATTR_VERSION = 'data-styled-version';
 export const SC_VERSION = __VERSION__;

--- a/packages/styled-components/src/utils/generateAlphabeticName.js
+++ b/packages/styled-components/src/utils/generateAlphabeticName.js
@@ -1,6 +1,8 @@
 // @flow
 /* eslint-disable no-bitwise */
 
+import { SC_CLASS_PREFIX } from '../constants';
+
 const AD_REPLACER_R = /(a)(d)/gi;
 
 /* This is the "capacity" of our alphabet i.e. 2x26 for all letters plus their capitalised
@@ -21,5 +23,5 @@ export default function generateAlphabeticName(code: number): string {
     name = getAlphabeticChar(x % charsLength) + name;
   }
 
-  return (getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2');
+  return SC_CLASS_PREFIX + (getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2');
 }


### PR DESCRIPTION
Add `SC_CLASS_PREFIX` which can be configured during bundle time to avoid class name collision issue occurred when multiple styled-components co-exist in one page.