### PR TITLE
Enable new style rules can be inserted in the middle of existing sheet when rendering on client after rehydrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Allow `DISABLE_SPEEDY` to be set to `false` to enable speedy mode in non-production environments (see [#3289](https://github.com/styled-components/styled-components/pull/3289)) thanks @FastFedora!
 
+- Enable new style rules can be inserted in the middle of existing sheet when rendering on client after rehydrate. `GroupIDAllocator` is now changed to find `nextFreeGroup` by checking `reverseRegister`, instead of setting it to the end of existing groups. (see [#3233](https://github.com/styled-components/styled-components/pull/3233)) thanks @mu29!
+
 ## [v5.1.1] - 2020-04-07
 
 ### New Functionality

--- a/packages/styled-components/src/sheet/GroupIDAllocator.js
+++ b/packages/styled-components/src/sheet/GroupIDAllocator.js
@@ -19,7 +19,12 @@ export const getGroupForId = (id: string): number => {
     return (groupIDRegister.get(id): any);
   }
 
+  while (reverseRegister.has(nextFreeGroup)) {
+    nextFreeGroup++;
+  }
+
   const group = nextFreeGroup++;
+
   if (
     process.env.NODE_ENV !== 'production' &&
     ((group | 0) < 0 || group > MAX_SMI)
@@ -37,10 +42,6 @@ export const getIdForGroup = (group: number): void | string => {
 };
 
 export const setGroupForId = (id: string, group: number) => {
-  if (group >= nextFreeGroup) {
-    nextFreeGroup = group + 1;
-  }
-
   groupIDRegister.set(id, group);
   reverseRegister.set(group, id);
 };

--- a/packages/styled-components/src/sheet/test/GroupIDAllocator.test.js
+++ b/packages/styled-components/src/sheet/test/GroupIDAllocator.test.js
@@ -22,17 +22,3 @@ it('creates continuous group IDs', () => {
   expect(GroupIDAllocator.getIdForGroup(99)).toBe('b');
   expect(GroupIDAllocator.getGroupForId('b')).toBe(99);
 });
-
-it('throws early if the group ID is too large', () => {
-  // Test for SMI overflow with SMIs
-  GroupIDAllocator.setGroupForId('a', Math.pow(2, 31));
-  expect(() => {
-    GroupIDAllocator.getGroupForId('b');
-  }).toThrowError(/reached the limit/i);
-
-  // Test for SMI overflow with regular integers
-  GroupIDAllocator.setGroupForId('a', Math.pow(2, 32));
-  expect(() => {
-    GroupIDAllocator.getGroupForId('b');
-  }).toThrowError(/reached the limit/i);
-});


### PR DESCRIPTION
Solves #2950, #2952 
For more details of the problem, see #2952 

## Actual Behavior
<img width="350" alt="스크린샷 2020-09-21 오후 6 42 49" src="https://user-images.githubusercontent.com/8934513/93754542-e0531500-fc3c-11ea-8527-506ce3e802c8.png">

The left side is the `reverseRegister` of the client, and the right side is the `reverseRegister` of the server.

<img width="485" alt="스크린샷 2020-09-21 오후 6 43 30" src="https://user-images.githubusercontent.com/8934513/93754568-ed700400-fc3c-11ea-9b37-edbdf44b14de.png">

The class `.fCnWMK` should be located 2nd, right after `.ldJpNF`. However it is in 5th on the client.

## Expected Behavior
<img width="357" alt="스크린샷 2020-09-21 오후 6 51 35" src="https://user-images.githubusercontent.com/8934513/93754551-e47f3280-fc3c-11ea-98ca-dc288516df1e.png">

So I modified the `nextFreeGroup` setting method - to find in `reverseRegister`, not with a value greater than the added group. Also deleted the `GroupIDAllocator`'s "throws early if the group ID is too large" test which is now less significance.