### PR TITLE
Fix sandbox error displaying "__SERVER__ is not defined"

### DIFF
--- a/packages/sandbox/server/webpack.config.js
+++ b/packages/sandbox/server/webpack.config.js
@@ -60,6 +60,7 @@ const createPlugins = () => [
   }),
   new webpack.DefinePlugin({
     // eslint-disable-next-line global-require
+    __SERVER__: true,
     __VERSION__: JSON.stringify(require('../../styled-components/package.json').version),
   }),
 ];


### PR DESCRIPTION
It's PR for the following sandbox issue.
https://github.com/styled-components/styled-components/issues/3270

