### PR TITLE
fix: Allow `DISABLE_SPEEDY` to be set to `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Add "engines" to package.json (currently set to Node 10, the oldest supported LTS distribution) (see [#3201](https://github.com/styled-components/styled-components/pull/3201)) thanks @MichaelDeBoey!
 
+- Allow `DISABLE_SPEEDY` to be set to `false` to enable speedy mode in non-production environments (see [#3289](https://github.com/styled-components/styled-components/pull/3289)) thanks @FastFedora!
+
 ## [v5.1.1] - 2020-04-07
 
 ### New Functionality

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -14,22 +14,13 @@ export const SPLITTER = '/*!sc*/\n';
 
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
-function hasEnvValue(name) {
-  return typeof process !== 'undefined' && typeof process.env[name] !== 'undefined' &&
-    process.env[name] !== '';
-}
-
-function getEnvValue(name) {
-  return process.env[name] === 'false' ? false : process.env[name];
-}
-
 export const DISABLE_SPEEDY =
   Boolean(typeof SC_DISABLE_SPEEDY === 'boolean'
     ? SC_DISABLE_SPEEDY
-    : (hasEnvValue('REACT_APP_SC_DISABLE_SPEEDY')
-      ? getEnvValue('REACT_APP_SC_DISABLE_SPEEDY')
-      : (hasEnvValue('SC_DISABLE_SPEEDY')
-        ? getEnvValue('SC_DISABLE_SPEEDY')
+    : (typeof process !== 'undefined' && typeof process.env.REACT_APP_SC_DISABLE_SPEEDY !== 'undefined' && process.env.REACT_APP_SC_DISABLE_SPEEDY !== ''
+      ? process.env.REACT_APP_SC_DISABLE_SPEEDY === 'false' ? false : process.env.REACT_APP_SC_DISABLE_SPEEDY
+      : (typeof process !== 'undefined' && typeof process.env.SC_DISABLE_SPEEDY !== 'undefined' && process.env.SC_DISABLE_SPEEDY !== ''
+        ? process.env.SC_DISABLE_SPEEDY === 'false' ? false : process.env.SC_DISABLE_SPEEDY
         : process.env.NODE_ENV !== 'production'
       )
     ));

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -14,11 +14,25 @@ export const SPLITTER = '/*!sc*/\n';
 
 export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in window;
 
+function hasEnvValue(name) {
+  return typeof process !== 'undefined' && typeof process.env[name] !== 'undefined' &&
+    process.env[name] !== '';
+}
+
+function getEnvValue(name) {
+  return process.env[name] === 'false' ? false : process.env[name];
+}
+
 export const DISABLE_SPEEDY =
-  (typeof SC_DISABLE_SPEEDY === 'boolean' && SC_DISABLE_SPEEDY) ||
-  (typeof process !== 'undefined' &&
-    (process.env.REACT_APP_SC_DISABLE_SPEEDY || process.env.SC_DISABLE_SPEEDY)) ||
-  process.env.NODE_ENV !== 'production';
+  typeof SC_DISABLE_SPEEDY === 'boolean'
+    ? SC_DISABLE_SPEEDY
+    : (hasEnvValue('REACT_APP_SC_DISABLE_SPEEDY')
+      ? getEnvValue('REACT_APP_SC_DISABLE_SPEEDY')
+      : (hasEnvValue('SC_DISABLE_SPEEDY')
+        ? getEnvValue('SC_DISABLE_SPEEDY')
+        : process.env.NODE_ENV !== 'production'
+      )
+    );
 
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -24,7 +24,7 @@ function getEnvValue(name) {
 }
 
 export const DISABLE_SPEEDY =
-  typeof SC_DISABLE_SPEEDY === 'boolean'
+  Boolean(typeof SC_DISABLE_SPEEDY === 'boolean'
     ? SC_DISABLE_SPEEDY
     : (hasEnvValue('REACT_APP_SC_DISABLE_SPEEDY')
       ? getEnvValue('REACT_APP_SC_DISABLE_SPEEDY')
@@ -32,7 +32,7 @@ export const DISABLE_SPEEDY =
         ? getEnvValue('SC_DISABLE_SPEEDY')
         : process.env.NODE_ENV !== 'production'
       )
-    );
+    ));
 
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -76,6 +76,7 @@ describe('constants', () => {
     afterEach(() => {
       process.env.NODE_ENV = 'test';
       delete process.env.DISABLE_SPEEDY;
+      delete window.SC_DISABLE_SPEEDY;
     });
 
     it('should be false in production NODE_ENV when SC_DISABLE_SPEEDY is not set', () => {
@@ -83,6 +84,12 @@ describe('constants', () => {
     });
 
     it('should be false in production NODE_ENV when window.SC_DISABLE_SPEEDY is set to false', () => {
+      window.SC_DISABLE_SPEEDY = false;
+      renderAndExpect(false, '');
+    });
+
+    it('should be false in development NODE_ENV when window.SC_DISABLE_SPEEDY is set to false', () => {
+      process.env.NODE_ENV = 'development';
       window.SC_DISABLE_SPEEDY = false;
       renderAndExpect(false, '');
     });
@@ -114,9 +121,41 @@ describe('constants', () => {
       delete process.env.SC_DISABLE_SPEEDY;
     });
 
+    it('should work with SC_DISABLE_SPEEDY environment variable when set to `false` in development NODE_ENV', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.SC_DISABLE_SPEEDY = false;
+      renderAndExpect(false, '');
+
+      delete process.env.SC_DISABLE_SPEEDY;
+    });
+
+    it('should work with SC_DISABLE_SPEEDY environment variable when set to "false" in development NODE_ENV', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.SC_DISABLE_SPEEDY = 'false';
+      renderAndExpect(false, '');
+
+      delete process.env.SC_DISABLE_SPEEDY;
+    });
+
     it('should work with REACT_APP_SC_DISABLE_SPEEDY environment variable', () => {
       process.env.REACT_APP_SC_DISABLE_SPEEDY = true;
       renderAndExpect(true, '.b { color:blue; }');
+
+      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
+    });
+
+    it('should work with REACT_APP_SC_DISABLE_SPEEDY environment variable when set to `false` in development NODE_ENV', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.REACT_APP_SC_DISABLE_SPEEDY = false;
+      renderAndExpect(false, '');
+
+      delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
+    });
+
+    it('should work with REACT_APP_SC_DISABLE_SPEEDY environment variable when set to "false" in development NODE_ENV', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.REACT_APP_SC_DISABLE_SPEEDY = 'false';
+      renderAndExpect(false, '');
 
       delete process.env.REACT_APP_SC_DISABLE_SPEEDY;
     });


### PR DESCRIPTION
The old initialization of `DISABLE_SPEEDY` meant that the only way it could be set to a falsey value was if `NODE_ENV` was set to `production` and no other setting was set. Setting `SC_DISABLE_SPEEDY` or the environment variables to false would be overridden by `NODE_ENV`.

The new initialization ensures that if one of these options is set to false, its value is respected.

This change should only affect the computed value of `DISABLE_SPEEDY` if one of the settings has the value `false` or `’false’`. Otherwise it should have the same truthy or falsey value as before.

This basically fixes the expected behavior of setting one of the configuration variables to `false` to set `DISABLE_SPEEDY`  to false.

Note that aims to fix the same problem fixed by PR #2951, but does so without any unexpected breaking changes.