### PR TITLE
Improve GroupedTag#insertRules performance in speedy disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Enable new style rules can be inserted in the middle of existing sheet when rendering on client after rehydrate. `GroupIDAllocator` is now changed to find `nextFreeGroup` by checking `reverseRegister`, instead of setting it to the end of existing groups. (see [#3233](https://github.com/styled-components/styled-components/pull/3233)) thanks @mu29!
 
+- Improve rendering performance about style tag with many rules in non speedy mode (see [#3295](https://github.com/styled-components/styled-components/pull/3295)) thanks @strozw
+
 ## [v5.1.1] - 2020-04-07
 
 ### New Functionality

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.js
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.js
@@ -488,6 +488,7 @@ describe(`createGlobalStyle`, () => {
   it(`removes style tag in StyleSheetManager.target when unmounted after target detached and no other global styles`, () => {
     // Set DISABLE_SPEEDY flag to false to force using speedy tag
     const flag = constants.DISABLE_SPEEDY;
+    // eslint-disable-next-line no-import-assign
     constants.DISABLE_SPEEDY = false;
 
     const container = document.createElement('div');
@@ -528,6 +529,7 @@ describe(`createGlobalStyle`, () => {
     }
 
     // Reset DISABLE_SPEEDY flag
+    // eslint-disable-next-line no-import-assign
     constants.DISABLE_SPEEDY = flag;
   });
 

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -56,13 +56,9 @@ class DefaultGroupedTag implements GroupedTag {
       }
     }
 
-    let ruleIndex = this.indexOfGroup(group + 1);
-    for (let i = 0, l = rules.length; i < l; i++) {
-      if (this.tag.insertRule(ruleIndex, rules[i])) {
-        this.groupSizes[group]++;
-        ruleIndex++;
-      }
-    }
+    const ruleIndex = this.indexOfGroup(group + 1);
+
+    this.groupSizes[group] += this.tag.insertRules(ruleIndex, rules)
   }
 
   clearGroup(group: number): void {

--- a/packages/styled-components/src/sheet/test/Tag.test.js
+++ b/packages/styled-components/src/sheet/test/Tag.test.js
@@ -14,6 +14,15 @@ const describeTag = (TagClass: Class<Tag>) => {
     expect(tag.getRule(2)).toBe('.c {}');
     expect(tag.getRule(3)).toBe('');
     expect(tag.length).toBe(3);
+
+    const rules = [
+      '.x {}',
+      '.y {}',
+      '.z {}'
+    ];
+    expect(tag.insertRules(99, rules)).toBe(0);
+    expect(tag.insertRules(2, rules)).toBe(3);
+    expect(tag.length).toBe(6);
   });
 
   it('deletes rules that have been inserted', () => {

--- a/packages/styled-components/src/sheet/types.js
+++ b/packages/styled-components/src/sheet/types.js
@@ -4,6 +4,7 @@
 export interface Tag {
   constructor(target?: HTMLElement): void;
   insertRule(index: number, rule: string): boolean;
+  insertRules(startRuleIndex: number, rules: string[]): number;
   deleteRule(index: number): void;
   getRule(index: number): string;
   length: number;

--- a/packages/styled-components/src/test/basic.test.js
+++ b/packages/styled-components/src/test/basic.test.js
@@ -95,6 +95,7 @@ describe('basic', () => {
   });
 
   it('Should have the correct styled(component) displayName', () => {
+    // eslint-disable-next-line react/display-name
     const CompWithoutName = () => () => <div />;
 
     const StyledTag = styled.div``;


### PR DESCRIPTION
If components have many style rules, GroupedTag#insertRules bring many reflow (layout) in speedy disabled.
This PR improve it by using DocumentFragment.

In the sample below, you can see the difference in CRA behavior when using this PR branch and v5.2.
https://github.com/strozw/sample-many-rules-styled-components

You can also check by loading the following json on the Performance tab of chrome devtools.

* [v5_2-performance.json.txt](https://github.com/strozw/styled-components/files/5300755/v5_2-performance.json.txt)
* [fixed-profile.json.txt](https://github.com/strozw/styled-components/files/5300762/fixed-profile.json.txt)

Or you can check this problem in [this codesandobx](https://codesandbox.io/s/has-many-rules-styled-componetns-cra-9lg1b?file=/src/App.js)

