### PR TITLE
Update ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,7 +31,7 @@ Please keep it product-centric.
 <!-- BUG TEMPLATE -->
 ## Environment
 <!-- Please run this command inside your project and paste its contents here (it automatically copies to your clipboard) -->
-`npx envinfo --system --binaries --npmPackages styled-components,babel-plugin-styled-components --markdown --clipboard`
+`npx envinfo --system --binaries --npmPackages styled-components,babel-plugin-styled-components --markdown | npx clipboard-cli`
 
 ## Reproduction
 


### PR DESCRIPTION
When running `npx envinfo` command with the flag `clipboard` I get this error:
```
*** Clipboard option removed - use clipboardy or clipboard-cli directly ***
```

So I just replaced the flag with `clipboard-cli` in order to copy the output to my clipboard.