### PR TITLE
fix styles not being added when using toHaveStyle()

### DIFF
--- a/packages/styled-components/rollup.config.js
+++ b/packages/styled-components/rollup.config.js
@@ -119,7 +119,6 @@ const serverConfig = {
   ],
   plugins: configBase.plugins.concat(
     replace({
-      window: undefined,
       __SERVER__: JSON.stringify(true),
     }),
     minifierPlugin


### PR DESCRIPTION
Fixes: #3297 

I checked out every commit to find what caused this, and it seems that [this commit](https://github.com/styled-components/styled-components/commit/2214485f9cf5f0e0ca6b7caffd93351b2e4130d3) and [this commit](https://github.com/styled-components/styled-components/commit/4351e2b6da2d82f1167a73fe1f4aff23ba264178) were the culprit. It seems like having `window` as either `false` or `undefined` makes `jest-dom`'s `toHaveStyle` function fail by not rendering any styles at all. I imagine this has something to do with how jest interacts with the window object.

@probablyup I don't exactly know the reason behind these commits so I hope this doesn't break things elsewhere. I tested the build locally and I can confirm that this will fix `toHaveStyle`