### PR TITLE
Add react-is package as a dependency

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -69,6 +69,7 @@
     "babel-plugin-styled-components": ">= 1",
     "css-to-react-native": "^3.0.0",
     "hoist-non-react-statics": "^3.0.0",
+    "react-is": "^16.8.6",
     "shallowequal": "^1.1.0",
     "stylis": "^4.0.2",
     "supports-color": "^7.2.0"
@@ -96,7 +97,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-frame-component": "^4.0.2",
-    "react-is": "^16.8.6",
     "react-native": "^0.63.3",
     "react-primitives": "^0.8.0",
     "react-test-renderer": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2433,11 +2433,6 @@ axobject-query@^2.1.2:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-core@^7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-eslint@^10.0.1:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -10884,6 +10879,7 @@ style-loader@^0.23.1:
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^3.0.0"
     hoist-non-react-statics "^3.0.0"
+    react-is "^16.8.6"
     shallowequal "^1.1.0"
     stylis "^4.0.2"
     supports-color "^7.2.0"


### PR DESCRIPTION
React-is is not a dev dependency. React-is tests the arbitrary values at runtime, so it does not make much sense to install react-is as a dev dependency.
