### PR TITLE
Normalizes how & are expanded on rulesets with +1 props

### DIFF
--- a/packages/styled-components/src/test/styles.test.js
+++ b/packages/styled-components/src/test/styles.test.js
@@ -48,6 +48,35 @@ describe('with styles', () => {
     `);
   });
 
+  it('ampersand should refer to static class when using referenced comma separated selectors', () => {
+    const Outer = styled.div``
+    const Inner = styled.div`
+      ${Outer}:active &,
+      ${Outer}:focus & {
+        color: blue;
+      }
+
+      ${Outer}:active &&,
+      ${Outer}:focus && {
+        color: red;
+      }
+    `
+    TestRenderer.create(
+      <Outer>
+        <Inner />
+      </Outer>
+    );
+
+    expect(getRenderedCSS()).toMatchInlineSnapshot(`
+      ".sc-a:active .sc-b, .sc-a:focus .sc-b {
+        color: blue;
+      }
+      .sc-a:active .c.c, .sc-a:focus .c.c {
+        color: red;
+      }"
+    `);
+  })
+
   it('amperstand should refer to the static class when making a self-referential combo selector', () => {
     const Comp = styled.div`
       background: red;

--- a/packages/styled-components/src/utils/stylis.js
+++ b/packages/styled-components/src/utils/stylis.js
@@ -48,7 +48,9 @@ export default function createStylisInstance({
    */
   const selfReferenceReplacementPlugin = element => {
     if (element.type === RULESET && element.value.includes('&')) {
-      element.props[0] = element.props[0].replace(_selectorRegexp, selfReferenceReplacer);
+      for (let i = 0; i < element.props.length; i++) {
+        element.props[i] = element.props[i].replace(_selectorRegexp, selfReferenceReplacer)
+      }
     }
   };
 


### PR DESCRIPTION
So the current behavior of the library, when generating the selectors for a comma separated selector like so:

```jsx
const Outer = styled.div``
const Inner = styled.div`
  ${Outer}:active &,
  ${Outer}:focus & {
    color: blue;
  }
`

render(<Outer><Inner /></Outer>)
```

Would yield the following CSS selector:

```css
.sc-a:active .sc-b, .sc-a:focus .b { color: blue; }
```

Notice that on the first part of the selector, the "stable" class name was used to target the inner component (`.sc-b`) whereas the second part of the selector uses the "instance dependent" class name (`.b`).

According to this documentation change (which at the time of this writing isn't merged yet):

https://github.com/styled-components/styled-components-website/pull/743

The idea is to favour the "stable" class name in this type of scenario.

The root of the problem had to do with the fact that for some reason the stylis utility was only applying the "self-reference replacement magic/logic" to the first `prop` item returned by the pre-processor.

For comma separated rules the preprocessor yields a rule set with as many `props` as the number of CSS rules that were provided as input:

https://github.com/thysultan/stylis.js/tree/5c0f7c77d30bc3a67c387dfa4b7a09dbf659a57b#abstract-syntax-structure

So the proposed patch is to apply the "self-reference replacement" logic to all rules in the ruleset (not just the first one).