### PR TITLE
Ensure components for react-native pass testID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- For React Native based components, pass `testID` down to the native component if specified for an easier time testing. (see [#3365](https://github.com/styled-components/styled-components/pull/3365))
+
 ## [v5.2.1] - 2020-10-30
 
 - Tweak server-side build settings to resolve an issue with jest-dom not being able to pick up generated styles (see [#3308](https://github.com/styled-components/styled-components/pull/3308)) thanks @Lazyuki

--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -34,6 +34,7 @@ class StyledNativeComponent extends Component<*, *> {
             forwardedComponent,
             forwardedAs,
             forwardedRef,
+            testID,
             style = [],
             ...props
           } = this.props;
@@ -64,6 +65,7 @@ class StyledNativeComponent extends Component<*, *> {
           }
 
           propsForElement.style = [generatedStyles].concat(style);
+          propsForElement.testID = testID;
 
           if (forwardedRef) propsForElement.ref = forwardedRef;
           if (forwardedAs) propsForElement.as = forwardedAs;

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -182,6 +182,15 @@ Object {
       });
     });
 
+    it('should pass "testID" prop to the native element when provided', () => {
+      const Comp = styled.View``;
+
+      const wrapper = TestRenderer.create(<Comp testID="for-some-test" />);
+      const view = wrapper.root.findByType('View');
+
+      expect(view.props.testID).toEqual('for-some-test');
+    });
+
     it('passes simple props on', () => {
       const Comp = styled.View.attrs(() => ({
         test: true,


### PR DESCRIPTION
When developing for react native, components are sometimes marked with
the `testID` prop. This prop is functionally similar to the
`data-testid` attached for react web components.

Unfortunately, styled components for react native didn't pass this prop
down, making it difficult for react native test frameworks like Detox to
test.

This change fixes that so when a `testID` prop is specified for a styled
component for react-native, it is passed down to the corresponding
native component it represents.

**NOTE**: Since this only affects `react-native`, it **ONLY** makes a change to `StyledNativeComponent`

**NOTE2**: I was hoping to use this change in the next minor version (`5.3.0`) which is why I branched off `legacy-v5`. Hopefully that's alright.

For context:

* [React Native Docs on `testID`](https://reactnative.dev/docs/view#testid)
* [The original issue that tried to start this](https://github.com/styled-components/styled-components/pull/1698)
* [Detox `by.id`Matcher that utilizes `testID`](https://github.com/wix/Detox/blob/master/docs/APIRef.Matchers.md#byidid)
* [React Testing Library's use via `byTestId`](https://callstack.github.io/react-native-testing-library/docs/api-queries#bytestid)