### PR TITLE
Fix style prop accepts function in native components #3384

### DIFF
--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -99,7 +99,11 @@ function useStyledComponentImpl(
     }
   }
 
-  propsForElement.style = [generatedStyles].concat(props.style || []);
+  propsForElement.style = typeof props.style === 'function' ?
+  (state) => {
+    return [generatedStyles].concat(props.style(state))
+  }
+  : [generatedStyles].concat(props.style || []);
 
   propsForElement.ref = refToForward;
 

--- a/packages/styled-components/src/native/test/native.test.js
+++ b/packages/styled-components/src/native/test/native.test.js
@@ -1,6 +1,6 @@
 // @flow
-/* eslint-disable no-console */
-import { Text, View } from 'react-native';
+/* eslint-disable no-console,import/named */
+import { Text, View, Pressable } from 'react-native';
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
@@ -40,9 +40,9 @@ describe('native', () => {
       null,
       123,
       [],
-      <View />,
-      <FunctionalComponent />,
-      <ClassComponent />,
+      <View key="a" />,
+      <FunctionalComponent key="b" />,
+      <ClassComponent key="c" />,
     ];
     invalidComps.forEach(comp => {
       expect(() => {
@@ -114,17 +114,51 @@ Object {
 `);
   });
 
-  it('should combine inline styles and the style prop', () => {
-    const Comp = styled.View`
-      padding-top: 10;
-    `;
+  describe('style',() => {
+    it('should combine inline styles and the style prop', () => {
+      const Comp = styled.View`
+        padding-top: 10;
+      `;
 
-    const style = { opacity: 0.9 };
-    const wrapper = TestRenderer.create(<Comp style={style} />);
-    const view = wrapper.root.findByType('View');
+      const style = { opacity: 0.9 };
+      const wrapper = TestRenderer.create(<Comp style={style} />);
+      const view = wrapper.root.findByType('View');
 
-    expect(view.props.style).toEqual([{ paddingTop: 10 }, style]);
-  });
+      expect(view.props.style).toEqual([{ paddingTop: 10 }, style]);
+    });
+
+    it('should allow style function prop when available as builtin', () => {
+      const Comp = styled.Pressable`
+        padding-top: 10;
+      `;
+
+      const style = (_) => ({ opacity: 0.9 });
+      const wrapper = TestRenderer.create(
+        <Comp style={style}>
+          <Text>test</Text>
+        </Comp>
+      );
+      const view = wrapper.root.findByType(Pressable);
+
+      expect(view.props.style()).toEqual([{ paddingTop: 10 }, style()]);
+    });
+
+    it('should allow style function prop when available as extended', () => {
+      const Comp = styled(Pressable)`
+        padding-top: 10;
+      `;
+
+      const style = (_) => ({ opacity: 0.9 });
+      const wrapper = TestRenderer.create(
+        <Comp style={style}>
+          <Text>test</Text>
+        </Comp>
+      );
+      const view = wrapper.root.findByType(Pressable);
+
+      expect(view.props.style()).toEqual([{ paddingTop: 10 }, style()]);
+    });
+  })
 
   it('should not console.warn if a comment is seen', () => {
     const oldConsoleWarn = console.warn;


### PR DESCRIPTION
Closes #3384

New RN Pressable components interface have function style prop then this make it available.

I confirmed fixing in the branch , https://github.com/tkow/ReactNativeWebPlayGround/tree/styled-pressable-test.

## Check

```shell
git clone https://github.com/tkow/ReactNativeWebPlayGround.git;
cd ./ReactNativeWebPlayGround;
git checkout -b styled-pressable-test origin/styled-pressable-test;
git submodule update --init
cd ./styled-components;
yarn;
yarn build;
cd ../;
yarn;
yarn storybook;
```

then see stories of StyledExtendPressableTest and BuiltinPressableStyleTest.

Also, I remained the bug branch bug/styled-pressable of  https://github.com/tkow/ReactNativeWebPlayGround to reproduce.
