### PR TITLE
[fix] COMPLEX_SELECTOR_PREFIX.includes wasn't transpiled

### DIFF
--- a/packages/styled-components/src/utils/stylis.js
+++ b/packages/styled-components/src/utils/stylis.js
@@ -46,7 +46,7 @@ export default function createStylisInstance({
   const selfReferenceReplacer = (match, offset, string) => {
     if (
       // do not replace the first occurrence if it is complex (has a modifier)
-      (offset === 0 ? !COMPLEX_SELECTOR_PREFIX.includes(string[_selector.length]) : true) &&
+      (offset === 0 ? COMPLEX_SELECTOR_PREFIX.indexOf(string[_selector.length]) === -1 : true) &&
       // no consecutive self refs (.b.b); that is a precedence boost and treated differently
       !string.match(_consecutiveSelfRefRegExp)
     ) {


### PR DESCRIPTION
COMPLEX_SELECTOR_PREFIX.includes wasn't transpiled,
causing issues in Internet Explorer 11 due lack of compatibility.

The fix is just replacing it for indexOf, in the meantime, the solution is to roll back to v5.2.0

CAUSE

The transpilation done with babel is not transpiling deep enough, as other Array.prototype.includes are being correctly transpiled, this single one (maybe because of being in the middle of an if statement or something fancy like that) seems to not be transpiled.

EFFECT

IE 11 is not compatible with this property of the array object, producing an error.

TEST

Compile the project and search for ".includes" in the minified file.

FIX

Replacing ".includes" for ".indexOf" for compatibility

PREVENTION

Consider adding some bundle validation as part of the Pull Request validation, making sure your bundle transpiles correctly for the browsers supported before merging into master.