### PR TITLE
fix macro test regression (#3420)

### DIFF
--- a/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
@@ -14,7 +14,6 @@ import _styled from 'styled-components';
 
 _styled.div.withConfig({
   displayName: 'macrotest',
-  componentId: 'sc-11gvsec-0',
 })(['background:', ';'], p => (p.error ? 'red' : 'green'));
 
 

--- a/packages/styled-components/src/macro/test/macro.test.js
+++ b/packages/styled-components/src/macro/test/macro.test.js
@@ -1,9 +1,6 @@
-import cosmiconfigMock from 'cosmiconfig';
 import babel from '@babel/core';
 import pluginTester from 'babel-plugin-tester';
 import plugin from 'babel-plugin-macros';
-
-jest.mock('cosmiconfig', () => jest.fn(jest.requireActual('cosmiconfig')));
 
 const styledExampleCode = `
 import styled from '../../macro'
@@ -153,16 +150,10 @@ pluginTester({
     },
     'should not add componentId with a config disabling ssr': {
       code: styledExampleCode,
-      setup: () => {
-        cosmiconfigMock.mockImplementationOnce(() => ({
-          searchSync: () => ({
-            config: {
-              styledComponents: {
-                ssr: false,
-              },
-            },
-          }),
-        }));
+      pluginOptions: {
+        styledComponents: {
+          ssr: false,
+        },
       },
     },
     'should work with the css prop': { code: cssPropExampleCode },


### PR DESCRIPTION
This fixes a test regression introduced in a6dc34f945b22cfb4e9e7472f5a932a1e9ed8b89

The test originally mocked `cosmiconfig` to return `{ssr: false}`, but that stopped working amongst the various changes in that commit. In the meantime, `babel-plugin-tester` provides `pluginOptions` which is easier than mocking `cosmiconfig` anyway.

Fixes #3420