### PR TITLE
Fix `ReferenceError: window is undefined` Server-Side-Rendering

### DIFF
--- a/packages/styled-components/src/utils/nonce.js
+++ b/packages/styled-components/src/utils/nonce.js
@@ -4,7 +4,12 @@
 declare var window: { __webpack_nonce__: string };
 
 const getNonce = () => {
-  return typeof window.__webpack_nonce__ !== 'undefined' ? window.__webpack_nonce__ : null;
+
+  return typeof window !== 'undefined'
+    ? typeof window.__webpack_nonce__ !== 'undefined'
+      ? window.__webpack_nonce__
+      : null
+    : null;
 };
 
 export default getNonce;


### PR DESCRIPTION
fix #3444 by wrapping with `typeof window !== 'undefined'`

Issues was introduced by v5.2.2

Edit: 
Patch for 15b07960718a4fcd0d15ff407a4dee271e8a0c3e

Changed target branch to legacy-v5 (I hope that's the correct one..)