### PR TITLE
Support use of css tagged template inside style objects

### DIFF
--- a/packages/styled-components/src/constructors/css.js
+++ b/packages/styled-components/src/constructors/css.js
@@ -6,17 +6,29 @@ import isFunction from '../utils/isFunction';
 import flatten from '../utils/flatten';
 import type { Interpolation, RuleSet, Styles } from '../types';
 
+/**
+ * Used when flattening object styles to determine if we should
+ * expand an array of styles.
+ */
+const addTag = arg => {
+  if (Array.isArray(arg)) {
+    // eslint-disable-next-line no-param-reassign
+    arg.isCss = true;
+  }
+  return arg;
+};
+
 export default function css(styles: Styles, ...interpolations: Array<Interpolation>): RuleSet {
   if (isFunction(styles) || isPlainObject(styles)) {
     // $FlowFixMe
-    return flatten(interleave(EMPTY_ARRAY, [styles, ...interpolations]));
+    return addTag(flatten(interleave(EMPTY_ARRAY, [styles, ...interpolations])));
   }
 
-  if(interpolations.length === 0 && styles.length === 1 && typeof styles[0] === "string") {
+  if (interpolations.length === 0 && styles.length === 1 && typeof styles[0] === 'string') {
     // $FlowFixMe
     return styles;
   }
 
   // $FlowFixMe
-  return flatten(interleave(styles, interpolations));
+  return addTag(flatten(interleave(styles, interpolations)));
 }

--- a/packages/styled-components/src/constructors/test/keyframes.test.js
+++ b/packages/styled-components/src/constructors/test/keyframes.test.js
@@ -87,6 +87,112 @@ describe('keyframes', () => {
     `);
   });
 
+  it('should insert the correct styles for objects', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    getRenderedCSS('');
+
+    const Comp = styled.div({
+      animation: css`
+        ${animation} 2s linear infinite
+      `,
+    });
+
+    TestRenderer.create(<Comp />);
+
+    getRenderedCSS(`
+      .a {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+      @-webkit-keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+      @keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+    `);
+  });
+
+  it('should insert the correct styles for objects with nesting', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+
+    getRenderedCSS('');
+
+    const Comp = styled.div({
+      '@media(max-width: 700px)': {
+        animation: css`
+          ${animation} 2s linear infinite
+        `,
+        ':hover': {
+          animation: css`
+            ${animation} 10s linear infinite
+          `,
+        },
+      },
+    });
+
+    TestRenderer.create(<Comp />);
+
+    getRenderedCSS(`
+     @media(max-width: 700px) {
+      .a {
+        -webkit-animation: jgzmJZ 2s linear infinite;
+        animation: jgzmJZ 2s linear infinite;
+       }
+     }
+    .a:hover {
+      -webkit-animation: jgzmJZ 10s linear infinite;
+      animation: jgzmJZ 10s linear infinite;
+    }
+    @-webkit-keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    @keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    `);
+  });
+
   it('should insert the correct styles when keyframes in props', () => {
     const rules = `
       0% {
@@ -154,7 +260,10 @@ describe('keyframes', () => {
     const getAnimation = animation => {
       if (Array.isArray(animation)) {
         return animation.reduce(
-          (ret, a, index) => css`${ret}${index > 0 ? ',' : ''} ${getAnimation(a)}`,
+          (ret, a, index) =>
+            css`
+              ${ret}${index > 0 ? ',' : ''} ${getAnimation(a)}
+            `,
           ''
         );
       } else {

--- a/packages/styled-components/src/utils/flatten.js
+++ b/packages/styled-components/src/utils/flatten.js
@@ -21,10 +21,10 @@ export const objToCssArray = (obj: Object, prevKey?: string): Array<string | Fun
   for (const key in obj) {
     if (!obj.hasOwnProperty(key) || isFalsish(obj[key])) continue;
 
-    if (isPlainObject(obj[key])) {
-      rules.push(...objToCssArray(obj[key], key));
-    } else if (isFunction(obj[key])) {
+    if ((Array.isArray(obj[key]) && obj[key].isCss) || isFunction(obj[key])) {
       rules.push(`${hyphenate(key)}:`, obj[key], ';');
+    } else if (isPlainObject(obj[key])) {
+      rules.push(...objToCssArray(obj[key], key));
     } else {
       rules.push(`${hyphenate(key)}: ${addUnitIfNeeded(key, obj[key])};`);
     }


### PR DESCRIPTION
Reimplementation of #3080. Tests pass, and I was able to recreate the intended behavior in the sandbox app.

Adds support for the following syntax:

```js
const animation = keyframes({
  from: { opacity: 0 },
  to: { opacity: 1 }
})

const Animated = styled.div({ animation: css`${animation} 3s` })

const Animated2 = styled.div(({time = 1}) => ({
  animation: css`${animation} ${time}s infinite` 
}))
```

This addresses issue:
#2561

Note on implementation: adding the `isCss` property isn't entirely necessary. Doing a check for whether the value is an Array is sufficient. But it does seem worthwhile to refine that condition with this `isCss` check to account for other array values (perhaps someday down the road supporting fallback values with the object syntax)