### PR TITLE
feat: allow using multiple style tags for rule updates

### DIFF
--- a/packages/sandbox/src/AppWithManySheets.js
+++ b/packages/sandbox/src/AppWithManySheets.js
@@ -1,0 +1,51 @@
+import React, { useState, memo } from 'react';
+import styled, { StyleSheetManager } from 'styled-components';
+
+const colors = ["bda779", "5b2ae8", "f3912d", "85120b", "92414d", "c3866e", "2c8bda", "e1fbb", "2ce471", "ed91c6", "e38f2f", "d31016", "176b1e", "3be33d", "b5c51a", "c496c5", "b5013a", "b0e764", "fa0f7b", "32e9de", "e81de3", "260e57", "7c2114", "892e29", "5acf1d", "ffa963", "677387", "96e65f", "729a2c", "513689"]
+
+const Header = styled.div`
+  height: 50px;
+  padding: 30px;
+`
+
+const ColoredComponents = colors.reduce((components, color) => {
+  const component = styled.div`
+    min-height: 20px;
+    padding: 30px;
+    background-color: #${color};
+  `
+  return { ...components, [color]: memo(component) }
+}, {})
+
+const ComponentsList = memo(({ children, reversed }) => (
+  <>
+    {(reversed ? colors.reverse() : colors).map(color => {
+      const ColoredComponent = ColoredComponents[color];
+
+      return <ColoredComponent key={color}>{children}</ColoredComponent>
+    })}
+  </>
+));
+
+const App = () => {
+  const [shouldShowHeader, toggleHeader] = useState(false)
+
+  return (
+    <StyleSheetManager useMultipleStyles>
+      <>
+        <button type='button' onClick={() => toggleHeader(!shouldShowHeader)}>
+          Toggle Header
+        </button>
+        <br />
+        <ComponentsList>
+          {shouldShowHeader && <Header>I AM HEADER</Header>}
+          <ComponentsList reversed>
+            <ComponentsList reversed />
+          </ComponentsList>
+        </ComponentsList>
+      </>
+    </StyleSheetManager>
+  )
+};
+
+export default App;

--- a/packages/sandbox/src/browser.js
+++ b/packages/sandbox/src/browser.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { hydrate } from 'react-dom';
 
-import App from './App';
+import App from './AppWithManySheets';
 
 const render = Component => {
   hydrate(<Component />, document.querySelector('#react-root'));

--- a/packages/sandbox/src/server.js
+++ b/packages/sandbox/src/server.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { ServerStyleSheet } from 'styled-components';
-import App from './App';
+import App from './AppWithManySheets';
 
 const sheet = new ServerStyleSheet();
 

--- a/packages/styled-components/src/models/StyleSheetManager.js
+++ b/packages/styled-components/src/models/StyleSheetManager.js
@@ -9,6 +9,7 @@ type Props = {
   children?: Node,
   disableCSSOMInjection?: boolean,
   disableVendorPrefixes?: boolean,
+  useMultipleStyles?: boolean,
   sheet?: StyleSheet,
   stylisPlugins?: Array<Function>,
   target?: HTMLElement,
@@ -46,6 +47,10 @@ export default function StyleSheetManager(props: Props) {
 
     if (props.disableCSSOMInjection) {
       sheet = sheet.reconstructWithOptions({ useCSSOMInjection: false });
+    }
+
+    if (props.useMultipleStyles) {
+      sheet = sheet.reconstructWithOptions({ useMultipleStyles: true });
     }
 
     return sheet;

--- a/packages/styled-components/src/sheet/GroupedTag.js
+++ b/packages/styled-components/src/sheet/GroupedTag.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-use-before-define */
 
 import type { GroupedTag, SheetOptions, Tag } from './types';
-import { makeTag } from './Tag'
+import { makeTag } from './Tag';
 import { SPLITTER } from '../constants';
 import throwStyledError from '../utils/error';
 
@@ -104,25 +104,25 @@ class DefaultGroupedTag implements GroupedTag {
 
 class MultipleSheetsGroupedTag implements GroupedTag {
   tags: Map<number, Tag>;
-  length: number
-  options: SheetOptions
+  length: number;
+  options: SheetOptions;
 
   constructor(options: SheetOptions) {
-    this.options = options
-    this.tags = new Map()
-    this.length = 0
+    this.options = options;
+    this.tags = new Map();
+    this.length = 0;
   }
 
   insertRules(group: number, rules: string[]): void {
-    let tag = this.tags.get(group)
+    let tag = this.tags.get(group);
 
     if (!tag) {
-      tag = makeTag(this.options)
-      this.tags.set(group, tag)
-      this.length = this.tags.size
+      tag = makeTag(this.options);
+      this.tags.set(group, tag);
+      this.length = this.tags.size;
     }
 
-    let ruleIndex = 0
+    let ruleIndex = 0;
     for (let i = 0, l = rules.length; i < l; i++) {
       if (tag.insertRule(ruleIndex, rules[i])) {
         ruleIndex++;
@@ -131,17 +131,17 @@ class MultipleSheetsGroupedTag implements GroupedTag {
   }
 
   clearGroup(group: number): void {
-    const tag = this.tags.get(group)
+    const tag = this.tags.get(group);
     if (tag) {
-      tag.destroy()
+      tag.destroy();
     }
-    this.tags.delete(group)
+    this.tags.delete(group);
   }
 
   getGroup(group: number): string {
     let css = '';
-    const tag = this.tags.get(group)
-    if (!tag) return css
+    const tag = this.tags.get(group);
+    if (!tag) return css;
 
     for (let i = 0; i < tag.length; i++) {
       css += `${tag.getRule(i)}${SPLITTER}`;

--- a/packages/styled-components/src/sheet/Sheet.js
+++ b/packages/styled-components/src/sheet/Sheet.js
@@ -21,7 +21,7 @@ type NamesAllocationMap = Map<string, Set<string>>;
 const defaultOptions: SheetOptions = {
   isServer: !IS_BROWSER,
   useCSSOMInjection: !DISABLE_SPEEDY,
-  useMultipleStyles: false
+  useMultipleStyles: false,
 };
 
 /** Contains the main stylesheet logic for stringification and caching */

--- a/packages/styled-components/src/sheet/Sheet.js
+++ b/packages/styled-components/src/sheet/Sheet.js
@@ -4,7 +4,6 @@ import { EMPTY_OBJECT } from '../utils/empties';
 import { makeGroupedTag } from './GroupedTag';
 import { getGroupForId } from './GroupIDAllocator';
 import { outputSheet, rehydrateSheet } from './Rehydration';
-import { makeTag } from './Tag';
 import type { GroupedTag, Sheet, SheetOptions } from './types';
 
 let SHOULD_REHYDRATE = IS_BROWSER;
@@ -12,6 +11,7 @@ let SHOULD_REHYDRATE = IS_BROWSER;
 type SheetConstructorArgs = {
   isServer?: boolean,
   useCSSOMInjection?: boolean,
+  useMultipleStyles?: boolean,
   target?: HTMLElement,
 };
 
@@ -21,6 +21,7 @@ type NamesAllocationMap = Map<string, Set<string>>;
 const defaultOptions: SheetOptions = {
   isServer: !IS_BROWSER,
   useCSSOMInjection: !DISABLE_SPEEDY,
+  useMultipleStyles: false
 };
 
 /** Contains the main stylesheet logic for stringification and caching */
@@ -72,7 +73,7 @@ export default class StyleSheet implements Sheet {
 
   /** Lazily initialises a GroupedTag for when it's actually needed */
   getTag(): GroupedTag {
-    return this.tag || (this.tag = makeGroupedTag(makeTag(this.options)));
+    return this.tag || (this.tag = makeGroupedTag(this.options));
   }
 
   /** Check whether a name is known for caching */

--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -33,7 +33,7 @@ export class CSSOMTag implements Tag {
   }
 
   destroy() {
-    this.element.remove()
+    this.element.remove();
   }
 
   insertRule(index: number, rule: string): boolean {
@@ -77,7 +77,7 @@ export class TextTag implements Tag {
   }
 
   destroy() {
-    this.element.remove()
+    this.element.remove();
   }
 
   insertRule(index: number, rule: string): boolean {

--- a/packages/styled-components/src/sheet/Tag.js
+++ b/packages/styled-components/src/sheet/Tag.js
@@ -32,6 +32,10 @@ export class CSSOMTag implements Tag {
     this.length = 0;
   }
 
+  destroy() {
+    this.element.remove()
+  }
+
   insertRule(index: number, rule: string): boolean {
     try {
       this.sheet.insertRule(rule, index);
@@ -72,6 +76,10 @@ export class TextTag implements Tag {
     this.length = 0;
   }
 
+  destroy() {
+    this.element.remove()
+  }
+
   insertRule(index: number, rule: string): boolean {
     if (index <= this.length && index >= 0) {
       const node = document.createTextNode(rule);
@@ -105,6 +113,11 @@ export class VirtualTag implements Tag {
   length: number;
 
   constructor(_target?: HTMLElement) {
+    this.rules = [];
+    this.length = 0;
+  }
+
+  destroy() {
     this.rules = [];
     this.length = 0;
   }

--- a/packages/styled-components/src/sheet/types.js
+++ b/packages/styled-components/src/sheet/types.js
@@ -7,22 +7,24 @@ export interface Tag {
   deleteRule(index: number): void;
   getRule(index: number): string;
   length: number;
-}
-
-/** Group-aware Tag that sorts rules by indices */
-export interface GroupedTag {
-  constructor(tag: Tag): void;
-  insertRules(group: number, rules: string[]): void;
-  clearGroup(group: number): void;
-  getGroup(group: number): string;
-  length: number;
+  destroy(): void
 }
 
 export type SheetOptions = {
   isServer: boolean,
   target?: HTMLElement,
   useCSSOMInjection: boolean,
+  useMultipleStyles?: boolean
 };
+
+/** Group-aware Tag that sorts rules by indices */
+export interface GroupedTag {
+  constructor(tag: SheetOptions): void;
+  insertRules(group: number, rules: string[]): void;
+  clearGroup(group: number): void;
+  getGroup(group: number): string;
+  length: number;
+}
 
 export interface Sheet {
   allocateGSInstance(id: string): number;

--- a/packages/styled-components/src/sheet/types.js
+++ b/packages/styled-components/src/sheet/types.js
@@ -7,14 +7,14 @@ export interface Tag {
   deleteRule(index: number): void;
   getRule(index: number): string;
   length: number;
-  destroy(): void
+  destroy(): void;
 }
 
 export type SheetOptions = {
   isServer: boolean,
   target?: HTMLElement,
   useCSSOMInjection: boolean,
-  useMultipleStyles?: boolean
+  useMultipleStyles?: boolean,
 };
 
 /** Group-aware Tag that sorts rules by indices */


### PR DESCRIPTION
First of all, huge thanks for an amazing library.

We've encountered the performance issue caused by a Chrome quirk when maintaining the rules inside single style tag is causing unnecessary style recalculations (comparing to adding and removing many granular style tags). This issue is very pronounced on large pages with many nodes.

Hopefully Chrome team would fix an issue some day. But for now it will be great if user would have an option to chose the strategy.

**A small screencast where I explain the problem:**
https://www.youtube.com/watch?v=jxCWDhwG2o0