### PR TITLE
Support use of css tagged template inside style objects (v6)

### DIFF
--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -5,6 +5,18 @@ import interleave from '../utils/interleave';
 import isFunction from '../utils/isFunction';
 import isPlainObject from '../utils/isPlainObject';
 
+/**
+ * Used when flattening object styles to determine if we should
+ * expand an array of styles.
+ */
+const addTag = (arg: ReturnType<typeof flatten> & { isCss?: boolean }) => {
+  if (Array.isArray(arg)) {
+    // eslint-disable-next-line no-param-reassign
+    arg.isCss = true;
+  }
+  return arg;
+};
+
 export default function css(
   styles: Styles,
   ...interpolations: Array<Interpolation>
@@ -12,7 +24,9 @@ export default function css(
   if (isFunction(styles) || isPlainObject(styles)) {
     const styleFunctionOrObject = styles as Function | ExtensibleObject;
 
-    return flatten(interleave(EMPTY_ARRAY as string[], [styleFunctionOrObject, ...interpolations]));
+    return addTag(
+      flatten(interleave(EMPTY_ARRAY as string[], [styleFunctionOrObject, ...interpolations]))
+    );
   }
 
   const styleStringArray = styles as string[];
@@ -25,5 +39,5 @@ export default function css(
     return styleStringArray;
   }
 
-  return flatten(interleave(styleStringArray, interpolations));
+  return addTag(flatten(interleave(styleStringArray, interpolations)));
 }

--- a/packages/styled-components/src/constructors/test/keyframes.test.tsx
+++ b/packages/styled-components/src/constructors/test/keyframes.test.tsx
@@ -85,6 +85,112 @@ describe('keyframes', () => {
     `);
   });
 
+  it('should insert the correct styles for objects', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    getRenderedCSS('');
+
+    const Comp = styled.div({
+      animation: css`
+        ${animation} 2s linear infinite
+      `,
+    });
+
+    TestRenderer.create(<Comp />);
+
+    getRenderedCSS(`
+      .a {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+      @-webkit-keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+      @keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+    `);
+  });
+
+  it('should insert the correct styles for objects with nesting', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+
+    getRenderedCSS('');
+
+    const Comp = styled.div({
+      '@media(max-width: 700px)': {
+        animation: css`
+          ${animation} 2s linear infinite
+        `,
+        ':hover': {
+          animation: css`
+            ${animation} 10s linear infinite
+          `,
+        },
+      },
+    });
+
+    TestRenderer.create(<Comp />);
+
+    getRenderedCSS(`
+     @media(max-width: 700px) {
+      .a {
+        -webkit-animation: jgzmJZ 2s linear infinite;
+        animation: jgzmJZ 2s linear infinite;
+       }
+     }
+    .a:hover {
+      -webkit-animation: jgzmJZ 10s linear infinite;
+      animation: jgzmJZ 10s linear infinite;
+    }
+    @-webkit-keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    @keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    `);
+  });
+
   it('should insert the correct styles when keyframes in props', () => {
     const rules = `
       0% {

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -21,10 +21,10 @@ export const objToCssArray = (obj: ExtensibleObject, prevKey?: string): string[]
   for (const key in obj) {
     if (!obj.hasOwnProperty(key) || isFalsish(obj[key])) continue;
 
-    if (isPlainObject(obj[key])) {
-      rules.push(...objToCssArray(obj[key], key));
-    } else if (isFunction(obj[key])) {
+    if ((Array.isArray(obj[key]) && obj[key].isCss) || isFunction(obj[key])) {
       rules.push(`${hyphenate(key)}:`, obj[key], ';');
+    } else if (isPlainObject(obj[key])) {
+      rules.push(...objToCssArray(obj[key], key));
     } else {
       rules.push(`${hyphenate(key)}: ${addUnitIfNeeded(key, obj[key])};`);
     }


### PR DESCRIPTION
See #3469 for v5.

Reimplementation of #3080. Tests pass, and I was able to recreate the intended behavior in the sandbox app.

Adds support for the following syntax:

```js
const animation = keyframes({
  from: { opacity: 0 },
  to: { opacity: 1 }
})

const Animated = styled.div({ animation: css`${animation} 3s` })

const Animated2 = styled.div(({time = 1}) => ({
  animation: css`${animation} ${time}s infinite` 
}))
```

This addresses issue:
#2561

Note on implementation: adding the `isCss` property isn't entirely necessary. Doing a check for whether the value is an Array is sufficient. But it does seem worthwhile to refine that condition with this `isCss` check to account for other array values (perhaps someday down the road supporting fallback values with the object syntax)