### PR TITLE
feat: Add prefix to all hash class to avoid collision when needed

### DIFF
--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -7,6 +7,10 @@ export const SC_ATTR: string =
   (typeof process !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
   'data-styled';
 
+export const SC_CLASS_PREFIX: string =
+  (typeof process !== 'undefined' && (process.env.REACT_APP_SC_CLASS_PREFIX || process.env.SC_CLASS_PREFIX)) ||
+  '';
+
 export const SC_ATTR_ACTIVE = 'active';
 export const SC_ATTR_VERSION = 'data-styled-version';
 export const SC_VERSION = __VERSION__;

--- a/packages/styled-components/src/test/constants.test.js
+++ b/packages/styled-components/src/test/constants.test.js
@@ -34,7 +34,6 @@ describe('constants', () => {
     it('should work with custom SC_ATTR', () => {
       const CUSTOM_SC_ATTR = 'data-custom-styled-components';
       process.env.SC_ATTR = CUSTOM_SC_ATTR;
-      jest.resetModules();
 
       renderAndExpect(CUSTOM_SC_ATTR);
 
@@ -44,11 +43,52 @@ describe('constants', () => {
     it('should work with REACT_APP_SC_ATTR', () => {
       const REACT_APP_CUSTOM_SC_ATTR = 'data-custom-react_app-styled-components';
       process.env.REACT_APP_SC_ATTR = REACT_APP_CUSTOM_SC_ATTR;
-      jest.resetModules();
 
       renderAndExpect(REACT_APP_CUSTOM_SC_ATTR);
 
       delete process.env.REACT_APP_SC_ATTR;
+    });
+  });
+
+  describe('SC_CLASS_PREFIX', () => {
+    function renderAndExpect(expectedValue) {
+      const React = require('react');
+      const TestRenderer = require('react-test-renderer');
+      const { SC_CLASS_PREFIX } = require('../constants');
+      const styled = require('./utils').resetStyled();
+
+      const Comp = styled.div`
+        color: blue;
+      `;
+
+      TestRenderer.create(<Comp />);
+
+      expectCSSMatches('.b { color:blue; }');
+
+      expect(SC_CLASS_PREFIX).toEqual(expectedValue);
+    }
+
+    afterEach(() => {
+      delete process.env.SC_CLASS_PREFIX;
+      delete process.env.REACT_APP_SC_CLASS_PREFIX;
+    });
+
+    it('should be an empty string by default', () => {
+      renderAndExpect('');
+    });
+
+    it('should work with custom SC_CLASS_PREFIX', () => {
+      const customValue = 'custom_prefix_';
+      process.env.SC_CLASS_PREFIX = customValue;
+
+      renderAndExpect(customValue);
+    });
+
+    it('should work with REACT_APP_SC_CLASS_PREFIX', () => {
+      const customValue = 'react_custom_prefix_';
+      process.env.REACT_APP_SC_CLASS_PREFIX = customValue;
+
+      renderAndExpect(customValue);
     });
   });
 

--- a/packages/styled-components/src/utils/generateAlphabeticName.js
+++ b/packages/styled-components/src/utils/generateAlphabeticName.js
@@ -23,5 +23,7 @@ export default function generateAlphabeticName(code: number): string {
     name = getAlphabeticChar(x % charsLength) + name;
   }
 
-  return SC_CLASS_PREFIX + ((getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2'));
+  const prefix = SC_CLASS_PREFIX ? `${SC_CLASS_PREFIX}_` : '';
+
+  return prefix + ((getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2'));
 }

--- a/packages/styled-components/src/utils/generateAlphabeticName.js
+++ b/packages/styled-components/src/utils/generateAlphabeticName.js
@@ -1,6 +1,8 @@
 // @flow
 /* eslint-disable no-bitwise */
 
+import { SC_CLASS_PREFIX } from "../constants";
+
 const AD_REPLACER_R = /(a)(d)/gi;
 
 /* This is the "capacity" of our alphabet i.e. 2x26 for all letters plus their capitalised
@@ -21,5 +23,5 @@ export default function generateAlphabeticName(code: number): string {
     name = getAlphabeticChar(x % charsLength) + name;
   }
 
-  return (getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2');
+  return SC_CLASS_PREFIX + ((getAlphabeticChar(x % charsLength) + name).replace(AD_REPLACER_R, '$1-$2'));
 }

--- a/packages/styled-components/src/utils/test/generateAlphabeticName.test.js
+++ b/packages/styled-components/src/utils/test/generateAlphabeticName.test.js
@@ -24,7 +24,7 @@ describe('generateAlphabeticName', () => {
       jest.resetModules();
     });
 
-    it.only('should concat SC_CLASS_PREFIX with generated alphabetic names', () => {
+    it('should concat SC_CLASS_PREFIX with generated alphabetic names', () => {
       jest.doMock('../../constants', () => ({ SC_CLASS_PREFIX: 'custom-class-prefix_' }))
       const generateAlphabeticName = require('../generateAlphabeticName');
 

--- a/packages/styled-components/src/utils/test/generateAlphabeticName.test.js
+++ b/packages/styled-components/src/utils/test/generateAlphabeticName.test.js
@@ -25,7 +25,7 @@ describe('generateAlphabeticName', () => {
     });
 
     it('should concat SC_CLASS_PREFIX with generated alphabetic names', () => {
-      jest.doMock('../../constants', () => ({ SC_CLASS_PREFIX: 'custom-class-prefix_' }))
+      jest.doMock('../../constants', () => ({ SC_CLASS_PREFIX: 'custom-class-prefix' }))
       const generateAlphabeticName = require('../generateAlphabeticName');
 
       expect(generateAlphabeticName(1000000000)).toEqual('custom-class-prefix_cGNYzm');

--- a/packages/styled-components/src/utils/test/generateAlphabeticName.test.js
+++ b/packages/styled-components/src/utils/test/generateAlphabeticName.test.js
@@ -18,4 +18,18 @@ describe('generateAlphabeticName', () => {
     expect(generateAlphabeticName(2733)).toMatchInlineSnapshot(`"a-D"`);
     expect(generateAlphabeticName(7390035)).toMatchInlineSnapshot(`"a-Da-d"`);
   });
+
+  describe('with SC_CLASS_PREFIX', () => {
+    beforeEach(() => {
+      jest.resetModules();
+    });
+
+    it.only('should concat SC_CLASS_PREFIX with generated alphabetic names', () => {
+      jest.doMock('../../constants', () => ({ SC_CLASS_PREFIX: 'custom-class-prefix_' }))
+      const generateAlphabeticName = require('../generateAlphabeticName');
+
+      expect(generateAlphabeticName(1000000000)).toEqual('custom-class-prefix_cGNYzm');
+      expect(generateAlphabeticName(2000000000)).toEqual('custom-class-prefix_fnBWYy');
+    });
+  })
 });


### PR DESCRIPTION
## What?
Created an environment variable `SC_CLASS_PREFIX` to add a prefix to all hash classes generated, including the ones that contain the style itself to avoid unexpected class collision.

## Why?
To avoid classes collision when we have multiple styled-components loaded at the same time, usually it happens when working with a micro-frontend structure and we have 2 micro-frontend loading the styled-components.

There is the option to use the offical babel plugin to add the [namespace option](https://styled-components.com/docs/tooling#namespace), but as the plugin only add the prefix in the `sc-???` class, it will not shield us from class collision between libraries used in common by multiple micro-frontends because usually the other classes (the ones with the style itself) are the ones that collides.

Based on the description above and the issue described here: https://github.com/styled-components/babel-plugin-styled-components/issues/308, I would like to propose an option to add a prefix to those classes that contain the css and with that shield the styled-components generated classes from colliding with something external when we set this variable.

## How?
Update the function responsible to generate all the class hashes and concatenate the env variable, this variable would be possible to be set by `REACT_APP_SC_CLASS_PREFIX` or `SC_CLASS_PREFIX`, if they aren't set we will use and empty string which will not affect anything.

## Testing
Change the file `packages/sandbox/server/webpack.config.js` by adding the option `SC_CLASS_PREFIX: 'custom-class-prefix_',` inside the webpack EnvironmentPlugin.

## Demo
### Before
![image](https://user-images.githubusercontent.com/83079637/119682878-9e0c5400-be19-11eb-8ede-53a1e08b649b.png)

### After
By adding the environment variable:
```javascript
new webpack.EnvironmentPlugin({
  // This will provide default value for NODE_ENV, unless defined otherwise
  // more info: https://webpack.js.org/plugins/environment-plugin/#usage-with-default-values
  NODE_ENV: 'development',
  SC_CLASS_PREFIX: 'custom-class-prefix_',
}),
```

And running the sandbox, we can see the hash classes with the prefix provided in the env variable:
![image](https://user-images.githubusercontent.com/83079637/119682579-600f3000-be19-11eb-9a0c-1e0b4f45a31d.png)

## References
Special thanks to @justnewbee for contributing it in https://github.com/styled-components/styled-components/pull/3225, I'm trying to reopen this issue with more tests and talking about why the babel plugin isn't working for us.