### PR TITLE
fix(component-style): classname collision due to static style rules not hashed

### DIFF
--- a/packages/styled-components/src/models/ComponentStyle.js
+++ b/packages/styled-components/src/models/ComponentStyle.js
@@ -64,7 +64,7 @@ export default class ComponentStyle {
         names.push(this.staticRulesId);
       } else {
         const cssStatic = flatten(this.rules, executionContext, styleSheet, stylis).join('');
-        const name = generateName(phash(this.baseHash, cssStatic.length) >>> 0);
+        const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
 
         if (!styleSheet.hasNameForId(componentId, name)) {
           const cssStaticFormatted = stylis(cssStatic, `.${name}`, undefined, componentId);


### PR DESCRIPTION
## Environment
All

## Reproduction
Running the classname generating logic in v5 will produce the same hash even if the ruleset is different.

```
//  const name = generateName(phash(this.baseHash, cssStatic.length) >>> 0);

// component ruleset 1
const name1 = generateName(phash(12345678, "width:100px;") >>> 0);

// component ruleset 2 
const name2 = generateName(phash(12345678, "width:10px;") >>> 0);

expect(name1).not.toEqual(name2);

```

## Steps to reproduce
N/A

## Expected Behavior
Same component id with different ruleset should generate different classNames.

## Actual Behavior
Same component id with different ruleset currently will result in classname collision.
