### PR TITLE
added new cssWithContext utility

### DIFF
--- a/packages/styled-components/src/base.ts
+++ b/packages/styled-components/src/base.ts
@@ -1,7 +1,7 @@
 /* Import singletons */
 import { SC_VERSION } from './constants';
 import createGlobalStyle from './constructors/createGlobalStyle';
-import css from './constructors/css';
+import css, { cssWithContext } from './constructors/css';
 import keyframes from './constructors/keyframes';
 /* Import Higher Order Components */
 import withTheme from './hoc/withTheme';
@@ -60,6 +60,7 @@ export * from './secretInternals';
 export {
   createGlobalStyle,
   css,
+  cssWithContext,
   isStyledComponent,
   keyframes,
   ServerStyleSheet,

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -10,24 +10,24 @@ export const cssWithContext =
     styles: Styles,
     ...interpolations: Array<Interpolation>
   ): FlattenerResult => {
-    if (isFunction(styles) || isPlainObject(styles)) {
-      const styleFunctionOrObject = styles as Function | ExtensibleObject;
+  if (isFunction(styles) || isPlainObject(styles)) {
+    const styleFunctionOrObject = styles as Function | ExtensibleObject;
 
-      return flatten(interleave(EMPTY_ARRAY as string[], [styleFunctionOrObject, ...interpolations]), executionContext);
-    }
-
-    const styleStringArray = styles as string[];
-
-    if (
-      interpolations.length === 0 &&
-      styleStringArray.length === 1 &&
-      typeof styleStringArray[0] === 'string'
-    ) {
-      return styleStringArray;
-    }
-
-    return flatten(interleave(styleStringArray, interpolations), executionContext);
+    return flatten(interleave(EMPTY_ARRAY as string[], [styleFunctionOrObject, ...interpolations]), executionContext);
   }
+
+  const styleStringArray = styles as string[];
+
+  if (
+    interpolations.length === 0 &&
+    styleStringArray.length === 1 &&
+    typeof styleStringArray[0] === 'string'
+  ) {
+    return styleStringArray;
+  }
+
+  return flatten(interleave(styleStringArray, interpolations), executionContext);
+}
 
 export default function css(
   styles: Styles,

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -5,25 +5,33 @@ import interleave from '../utils/interleave';
 import isFunction from '../utils/isFunction';
 import isPlainObject from '../utils/isPlainObject';
 
+export const cssWithContext =
+  (executionContext?: ExtensibleObject) => (
+    styles: Styles,
+    ...interpolations: Array<Interpolation>
+  ): FlattenerResult => {
+    if (isFunction(styles) || isPlainObject(styles)) {
+      const styleFunctionOrObject = styles as Function | ExtensibleObject;
+
+      return flatten(interleave(EMPTY_ARRAY as string[], [styleFunctionOrObject, ...interpolations]), executionContext);
+    }
+
+    const styleStringArray = styles as string[];
+
+    if (
+      interpolations.length === 0 &&
+      styleStringArray.length === 1 &&
+      typeof styleStringArray[0] === 'string'
+    ) {
+      return styleStringArray;
+    }
+
+    return flatten(interleave(styleStringArray, interpolations), executionContext);
+  }
+
 export default function css(
   styles: Styles,
   ...interpolations: Array<Interpolation>
 ): FlattenerResult {
-  if (isFunction(styles) || isPlainObject(styles)) {
-    const styleFunctionOrObject = styles as Function | ExtensibleObject;
-
-    return flatten(interleave(EMPTY_ARRAY as string[], [styleFunctionOrObject, ...interpolations]));
-  }
-
-  const styleStringArray = styles as string[];
-
-  if (
-    interpolations.length === 0 &&
-    styleStringArray.length === 1 &&
-    typeof styleStringArray[0] === 'string'
-  ) {
-    return styleStringArray;
-  }
-
-  return flatten(interleave(styleStringArray, interpolations));
+  return cssWithContext({})(styles, ...interpolations);
 }


### PR DESCRIPTION
Ahoy hoy!

First time contributing long time utilizing. This is more of an idea with a basic implementation of the possible interface we could expose. Couldn't get the project running locally so I doubt it actually works

I am in the process if trying to make the following API possible:

```js
const background = cssMixin`
  background-color: ${({isDark}) => isDark ? "black" : "white" };
`

const border = cssMixin`
  border: 1px solid black;
  border-radius: ${({curved}) => curved ? 5 : 1};
`

const MyComposedComponent = styled.div`
  display: block;
  ${background({isDark: false})}
  ${border({curved: true})}
`

const CoolContainer = () => (
  <MyComposedComponent isDark /> {/* isDark here will overwrite isDark as defined in the mixin utilization of the component */}
);
```

The code for cssMixin is as follows (its hard to read and probably horridly broken, hens why I'm making this PR)

```js
import { isArray, isFunction } from "lodash";

const enhanceFunction = (interpolation, defaultValues) => {
  const functionWithEnhancedResult = (props) => {
    const functionResult = interpolation({ ...defaultValues, ...props });
    return enhance(functionResult, defaultValues);
  };

  return functionWithEnhancedResult;
};

export const enhance = (interpolation, defaultValues) => {
  if (isArray(interpolation)) {
    return interpolation.map(item => enhance(item, defaultValues));
  }

  if (isFunction(interpolation)) {
    return enhanceFunction(interpolation, defaultValues);
  }

  return interpolation;
};

export const cssMixin = (styles, ...interpolations) => (defaultValues = {}) => {
  return css.apply(null, [styles, ...enhance(interpolations, defaultValues)]);
};
```

Now this mostly works.. However I've been having an issue when I also use this with my cssIf helper:

```js
import { css } from "styled-components";
import { isFunction } from "lodash";

const runConditionCheck = (condition, props) => {
  const isFunctionAndPasses = isFunction(condition) && condition(props);
  const isNotFunctionAndIsTruthy = !isFunction(condition) && !!condition;
  return isFunctionAndPasses || isNotFunctionAndIsTruthy;
};

/* 
yes I've tried to use my cssMixin instead of css.apply to fix the ability to nest, didn't work 
when I try to fix the nesting issue I will likely just need to fix somthing dumb here, but 
I really dislike this code anyway so I would rather this was built into styled-components
*/
export const cssIf = (condition) => (styles, ...interpolations) => (props) => {
  if (runConditionCheck(condition, props)) {
    return css.apply(null, [styles, interpolations]);
  } else {
    return "";
  }
};
```

Now I can probably figure out through some fiddling why it's not a happy chappy and I probably will have to (if I use cssIf I cannot use a cssMixin inside of it) but this got me into the styled-components codebase looking for how you folk do the css function. Of which when I look at it it feels like the cssWithContext function I've build could almost remove any and all need for my horrendous  recursive enhance function and I could instead use: 

```js
export const cssMixin = (styles, ...interpolations) => (defaultValues = {}) => cssWithContext(defaultValues)(styles, ...interpolations);
```

which would be much nicer. However I am looking at the code more and more and I don't think my PR would achieve what I want given I am causing the code to go down a different path that normal as it appears that css the helper doesn't inject any context into the functions inside of my template literals (see line 88 of flatten.ts, no executionContext is passed in when css used, thus it would just return the chunk without adding any of my custom state + there is no code to merge the correct executionContext with my custom context so even if this did work it would kill the context from other sources, as such my isDark attribute wouldn't come through if it even rendered at all)  (Sorry I tried to test but the sandbox project isn't working on my machine (Windows 10)) 

so I was wondering.. 

With my code example above of how I currently am achieving this to somewhat some success AND with my mock up of how I would love to expose this functionality nativly could anyone perhapse shed any light on how I could successfully.

OR

Is there some secret hidden mojo that makes this possible currently as is without a PR? All of the searching I've done has led me to the concision that my mixins either need to have no configurability (full access to the theme/attributes via my template functions like normal, but I cannot allow the implementing styled-compoenent of the mixin to define configuration ON the call to the mixin) OR I have to use a mixin that is a template litteral in itself, but has no access to the styled-compoenents context so I cannot access attribute data for the styled-component the mixin is being used inside of (isDark would stop working).

Cheers 👍 love the project, its a long post so no offense if this is a bit much for yall to handle.