### PR TITLE
Fix forced server-side mode not triggering global styles

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -51,13 +51,15 @@ export default function createGlobalStyle(
       renderStyles(instance, props, styleSheet, theme, stylis);
     }
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useLayoutEffect(() => {
-      if (!styleSheet.server) {
-        renderStyles(instance, props, styleSheet, theme, stylis);
-        return () => globalStyle.removeStyles(instance, styleSheet);
-      }
-    }, [instance, props, styleSheet, theme, stylis]);
+    if (!__SERVER__) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useLayoutEffect(() => {
+        if (!styleSheet.server) {
+          renderStyles(instance, props, styleSheet, theme, stylis);
+          return () => globalStyle.removeStyles(instance, styleSheet);
+        }
+      }, [instance, props, styleSheet, theme, stylis]);
+    }
 
     return null;
   };

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -10,8 +10,6 @@ import determineTheme from '../utils/determineTheme';
 import generateComponentId from '../utils/generateComponentId';
 import css from './css';
 
-declare const __SERVER__: boolean;
-
 export default function createGlobalStyle(
   strings: Styles,
   ...interpolations: Array<Interpolation>
@@ -49,17 +47,17 @@ export default function createGlobalStyle(
       );
     }
 
-    if (__SERVER__) {
+    if (styleSheet.server) {
       renderStyles(instance, props, styleSheet, theme, stylis);
-    } else {
-      // this conditional is fine because it is compiled away for the relevant builds during minification,
-      // resulting in a single unguarded hook call
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      useLayoutEffect(() => {
+    }
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useLayoutEffect(() => {
+      if (!styleSheet.server) {
         renderStyles(instance, props, styleSheet, theme, stylis);
         return () => globalStyle.removeStyles(instance, styleSheet);
-      }, [instance, props, styleSheet, theme, stylis]);
-    }
+      }
+    }, [instance, props, styleSheet, theme, stylis]);
 
     return null;
   };

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -29,6 +29,7 @@ export default class StyleSheet implements Sheet {
   gs: GlobalStylesAllocationMap;
   names: NamesAllocationMap;
   options: SheetOptions;
+  server: boolean;
   tag?: GroupedTag;
 
   /** Register a group ID to give it an index */
@@ -48,9 +49,10 @@ export default class StyleSheet implements Sheet {
 
     this.gs = globalStyles;
     this.names = new Map(names as NamesAllocationMap);
+    this.server = !!options.isServer;
 
     // We rehydrate only once and use the sheet that is created first
-    if (!this.options.isServer && IS_BROWSER && SHOULD_REHYDRATE) {
+    if (!this.server && IS_BROWSER && SHOULD_REHYDRATE) {
       SHOULD_REHYDRATE = false;
       rehydrateSheet(this);
     }


### PR DESCRIPTION
Resolve #3506
Resolve #3369

`createGlobalStyle` components skip the synchronous insertion of styles
in the browser, which is based on a global variable. However, sheets can
be forced into server-side mode, which means we need to instead adhere
to the client-side sheet's settings.