### PR TITLE
Fix missing typeof window check in src/base.js (v5)

### DIFF
--- a/packages/styled-components/src/base.js
+++ b/packages/styled-components/src/base.js
@@ -38,7 +38,7 @@ if (
 }
 
 /* Warning if there are several instances of styled-components */
-if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test' && !__SERVER__) {
+if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test' && typeof window !== 'undefined') {
   window['__styled-components-init__'] = window['__styled-components-init__'] || 0;
 
   if (window['__styled-components-init__'] === 1) {


### PR DESCRIPTION
Fix #3284
Fix #3374