### PR TITLE
Prevent ServerStyleSheet from emitting empty tags 

### DIFF
--- a/packages/styled-components/src/models/ServerStyleSheet.js
+++ b/packages/styled-components/src/models/ServerStyleSheet.js
@@ -25,6 +25,8 @@ export default class ServerStyleSheet {
 
   _emitSheetCSS = (): string => {
     const css = this.instance.toString();
+    if (!css) return '';
+
     const nonce = getNonce();
     const attrs = [nonce && `nonce="${nonce}"`, `${SC_ATTR}="true"`, `${SC_ATTR_VERSION}="${SC_VERSION}"`];
     const htmlAttr = attrs.filter(Boolean).join(' ');

--- a/packages/styled-components/src/sheet/Rehydration.js
+++ b/packages/styled-components/src/sheet/Rehydration.js
@@ -18,7 +18,7 @@ export const outputSheet = (sheet: Sheet) => {
 
     const names = sheet.names.get(id);
     const rules = tag.getGroup(group);
-    if (names === undefined || rules.length === 0) continue;
+    if (!names || !rules || !names.size) continue;
 
     const selector = `${SC_ATTR}.g${group}[id="${id}"]`;
 

--- a/packages/styled-components/src/sheet/Rehydration.js
+++ b/packages/styled-components/src/sheet/Rehydration.js
@@ -52,7 +52,7 @@ const rehydrateNamesFromContent = (sheet: Sheet, id: string, content: string) =>
 };
 
 const rehydrateSheetFromTag = (sheet: Sheet, style: HTMLStyleElement) => {
-  const parts = style.innerHTML.split(SPLITTER);
+  const parts = (style.innerHTML || '').split(SPLITTER);
   const rules: string[] = [];
 
   for (let i = 0, l = parts.length; i < l; i++) {

--- a/packages/styled-components/src/test/ssr.test.js
+++ b/packages/styled-components/src/test/ssr.test.js
@@ -37,6 +37,18 @@ describe('ssr', () => {
     expect(css).toMatchSnapshot();
   });
 
+  it('should emit nothing when no styles were generated', () => {
+    styled.h1`
+      color: red;
+    `;
+
+    const sheet = new ServerStyleSheet();
+    renderToString(sheet.collectStyles(<div />));
+
+    const css = sheet.getStyleTags();
+    expect(css).toBe('');
+  });
+
   it('should extract both global and local CSS', () => {
     const Component = createGlobalStyle`
       body { background: papayawhip; }


### PR DESCRIPTION
Resolve #3291

_Note:_ There's no need to port this to `main` i.e. v6, as we won't be supporting IE11 for it as discussed a while ago
(For anyone following along, check #3333)