### PR TITLE
Fix SSR collisions caused by static style collisions and group ID minimums

### DIFF
--- a/packages/styled-components/src/models/ComponentStyle.js
+++ b/packages/styled-components/src/models/ComponentStyle.js
@@ -64,7 +64,7 @@ export default class ComponentStyle {
         names.push(this.staticRulesId);
       } else {
         const cssStatic = flatten(this.rules, executionContext, styleSheet, stylis).join('');
-        const name = generateName(phash(this.baseHash, cssStatic.length) >>> 0);
+        const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
 
         if (!styleSheet.hasNameForId(componentId, name)) {
           const cssStaticFormatted = stylis(cssStatic, `.${name}`, undefined, componentId);

--- a/packages/styled-components/src/sheet/GroupIDAllocator.js
+++ b/packages/styled-components/src/sheet/GroupIDAllocator.js
@@ -42,6 +42,10 @@ export const getIdForGroup = (group: number): void | string => {
 };
 
 export const setGroupForId = (id: string, group: number) => {
+  if (group >= nextFreeGroup) {
+    nextFreeGroup = group + 1;
+  }
+
   groupIDRegister.set(id, group);
   reverseRegister.set(group, id);
 };


### PR DESCRIPTION
Resolve #3561
Resolve #3482
Resolve #3411
Resolve #3321
Resolve #3094
Resolve #3522

## Summary

Server-side rendering collisions were increasingly common in seemingly random cases, which was caused by a previous change that allowed new groups to have lower specificity and group IDs than all rehydrated groups. (See #3233)

Additionally, the hash was applied incorrectly (compare to `main` branch), where static styles would use `cssStatic.length` rather than `cssStatic`. This was previously broken due to changes in the hashing function. Overall however, this was causing issues when component IDs collided in hashes already, since `cssStatic.length` wouldn't do anything to alter the hash provided. We could still use `cssStatic.length.toString(16)` or an equivalent input, however, I've made this change to align with `main` for now, since the difference didn't make sense anyway.

## Set of changes

- Revert #3233 but preserve change in `getGroupForId`
- Fix typo in `ComponentStyle` relating to `phash(x, cssStatic.length)`