### PR TITLE
Read from textContent rather than innerHTML during rehydrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Rehydrate stylesheets from `textContent` rather than `innerHTML` to fix issue of selectors sometimes being HTML encoded (see [#3567](https://github.com/styled-components/styled-components/issues/3567)).
+
 - Use `class` instead of `className` for unidentified DOM elements (better support for styling web components)
 
 - Upgrade to stylis v4

--- a/packages/styled-components/src/sheet/Rehydration.ts
+++ b/packages/styled-components/src/sheet/Rehydration.ts
@@ -50,7 +50,7 @@ const rehydrateNamesFromContent = (sheet: Sheet, id: string, content: string) =>
 };
 
 const rehydrateSheetFromTag = (sheet: Sheet, style: HTMLStyleElement) => {
-  const parts = style.innerHTML.split(SPLITTER);
+  const parts = (style.textContent ?? '').split(SPLITTER);
   const rules: string[] = [];
 
   for (let i = 0, l = parts.length; i < l; i++) {


### PR DESCRIPTION
Resolves https://github.com/styled-components/styled-components/issues/3567

Sorry about the lack of tests. I tried adding the following test but it passes even without this change, so it's not particularly useful. I think that `innerHTML` behaves differently in actual browsers compared with the environment where the Jest tests are run (JSDOM?)

**packages/styled-components/src/sheet/test/Rehydration.test.js**

```js
  it('supports > characters in selectors when style is inside another element', () => {
    document.body.innerHTML = `
      <svg>
        <style ${SC_ATTR} ${SC_ATTR_VERSION}="${SC_VERSION}">
          .b > * {}/*!sc*/
          ${SC_ATTR}.g22[id="idB"]{content:"nameB,"}/*!sc*/
        </style>
      </svg>
    `;
    const sheet = new StyleSheet({ isServer: true });
    rehydrateSheet(sheet);
    expect(sheet.getTag().getGroup(22)).toBe('.b > * {}/*!sc*/\n');
  });
```