### PR TITLE
update keyframes test with functions 

### DIFF
--- a/packages/styled-components/src/constructors/test/keyframes.test.tsx
+++ b/packages/styled-components/src/constructors/test/keyframes.test.tsx
@@ -191,6 +191,112 @@ describe('keyframes', () => {
     `);
   });
 
+  it('should insert the correct styles for functions', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+    const name = animation.getName();
+
+    getRenderedCSS('');
+
+    const Comp = styled.div(() => ({
+      animation: css`
+        ${animation} 2s linear infinite
+      `,
+    }));
+
+    TestRenderer.create(<Comp />);
+
+    getRenderedCSS(`
+      .a {
+        -webkit-animation: ${name} 2s linear infinite;
+        animation: ${name} 2s linear infinite;
+      }
+      @-webkit-keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+      @keyframes ${name} {
+        0% {
+          opacity:0;
+        }
+        100% {
+          opacity:1;
+        }
+      }
+    `);
+  });
+
+  it('should insert the correct styles for functions with nesting', () => {
+    const rules = `
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    `;
+
+    const animation = keyframes`${rules}`;
+
+    getRenderedCSS('');
+
+    const Comp = styled.div(() => ({
+      '@media(max-width: 700px)': {
+        animation: css`
+          ${animation} 2s linear infinite
+        `,
+        ':hover': {
+          animation: css`
+            ${animation} 10s linear infinite
+          `,
+        },
+      },
+    }));
+
+    TestRenderer.create(<Comp />);
+
+    getRenderedCSS(`
+     @media(max-width: 700px) {
+      .a {
+        -webkit-animation: jgzmJZ 2s linear infinite;
+        animation: jgzmJZ 2s linear infinite;
+       }
+     }
+    .a:hover {
+      -webkit-animation: jgzmJZ 10s linear infinite;
+      animation: jgzmJZ 10s linear infinite;
+    }
+    @-webkit-keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    @keyframes jgzmJZ {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    `);
+  });
+
   it('should insert the correct styles when keyframes in props', () => {
     const rules = `
       0% {


### PR DESCRIPTION
## System:
 - OS: macOS 11.4
 - CPU: (8) x64 Apple M1
 - Memory: 40.66 MB / 16.00 GB
 - Shell: 5.8 - /bin/zsh
## Binaries:
 - Node: 14.17.3 - ~/.nvm/versions/node/v14.17.3/bin/node
 - Yarn: 1.19.0 - ~/.nvm/versions/node/v14.17.3/bin/yarn
 - npm: 6.14.13 - ~/Documents/genially/mono-genially/node_modules/.bin/npm
 
 ## Steps to reproduce

 Hi,
 
This pull request is because I am using the latest version(5.3.1) and although this works:

```js
const animation = keyframes({
  from: { opacity: 0 },
  to: { opacity: 1 }
});

const Animated = styled.div({
  animation: css`
    ${animation} 1s infinite
  `
});
```

this does not:
```js
const Animated2 = styled.div(({time = 1}) => ({
  animation: css`${animation} ${time}s infinite` 
}))
```

## Reproduction
I was trying it here: [Codesandbox example](https://codesandbox.io/s/test-animation-styled-components-ktl31?file=/src/App.tsx:262-363)

I saw this was solved in this [PR](https://github.com/styled-components/styled-components/pull/3497/files) but there are no tests with functions.

 
 