### PR TITLE
[v5] generate more complete sourcemaps

### DIFF
--- a/packages/styled-components/rollup.config.js
+++ b/packages/styled-components/rollup.config.js
@@ -4,9 +4,9 @@ import replace from 'rollup-plugin-replace';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
 import json from 'rollup-plugin-json';
-import flow from 'rollup-plugin-flow';
 import { terser } from 'rollup-plugin-terser';
 import sourceMaps from 'rollup-plugin-sourcemaps';
+import flowRemoveTypes from 'flow-remove-types';
 import pkg from './package.json';
 
 /**
@@ -29,10 +29,12 @@ const getCJS = override => ({ ...cjs, ...override });
 const getESM = override => ({ ...esm, ...override });
 
 const commonPlugins = [
-  flow({
-    // needed for sourcemaps to be properly generated
-    pretty: true,
-  }),
+  {
+    transform: code => ({
+      code: flowRemoveTypes(code).toString(),
+      map: null,
+    }),
+  },
   sourceMaps(),
   json(),
   nodeResolve(),


### PR DESCRIPTION
I noticed that the [sourcemaps](https://unpkg.com/styled-components@5.3.1/dist/styled-components.browser.esm.js.map) for `styled-components` are incomplete and only a portion of the actual bundled sources are included

```
sources": [
"../src/constants.js",
"../src/sheet/Rehydration.js",
"../src/sheet/Tag.js",
"../src/sheet/Sheet.js",
"../src/utils/isStaticRules.js",
"../src/models/Keyframes.js",
"../src/models/StyledComponent.js",
"../src/models/GlobalStyle.js",
"../src/models/ServerStyleSheet.js"
],
```

There are known issues with `rollup-plugin-flow` and source maps and it looks like the `pretty: true` option was used to workaround the issues but it only helped for certain files. My fix was suggest in https://github.com/leebyron/rollup-plugin-flow/issues/5#issuecomment-506926220 and is just to use `flow-remove-types` directly in a custom rollup plugin.

Alternately we could just totally drop `rollup-plugin-flow` since we already have the [flow preset in the Babel configuration](https://github.com/henryqdineen/styled-components/blob/5aa0af34e440f42445a3a07f3f2b36372a58de26/babel-preset.js#L15) and that will strip the types. I tried that out but it actually creates a small bundle size increase because the Babel plugin transforms code differently. 