### PR TITLE
fix: copy readme to styled-component package before publishing

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint src",
     "lint:size": "bundlewatch",
     "prettier": "prettier src/** --write",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "cp ../../README.md . && yarn build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR copy the `README.md` from root to the styled-components package before publishing

Closes #3277 