### PR TITLE
Bump is-prop-valid to forward translate attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+- Add support for the `translate` attribute as a valid prop by [@ay4toh5i](https://github.com/ay4toh5i) (See [#3619](https://github.com/styled-components/styled-components/pull/3619))
+
 ## [v5.3.3] - 2021-10-19
 
 - Backport #3568 (Read from textContent rather than innerHTML during rehydrate) by [@keeganstreet](https://github.com/keeganstreet) (See [#3591](https://github.com/styled-components/styled-components/pull/3591))

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0",
     "@babel/traverse": "^7.4.5",
-    "@emotion/is-prop-valid": "^0.8.8",
+    "@emotion/is-prop-valid": "^1.1.0",
     "@emotion/stylis": "^0.8.4",
     "@emotion/unitless": "^0.7.4",
     "babel-plugin-styled-components": ">= 1.12.0",

--- a/packages/styled-components/src/utils/test/validAttr.test.js
+++ b/packages/styled-components/src/utils/test/validAttr.test.js
@@ -134,6 +134,7 @@ describe('validAttr', () => {
     expect(validAttr('tabIndex')).toEqual(true);
     expect(validAttr('target')).toEqual(true);
     expect(validAttr('title')).toEqual(true);
+    expect(validAttr('translate')).toEqual(true);
     expect(validAttr('type')).toEqual(true);
     expect(validAttr('useMap')).toEqual(true);
     expect(validAttr('value')).toEqual(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,10 +1180,22 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz#29ef6be1e946fb4739f9707def860f316f668cde"
+  integrity sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
@@ -10700,11 +10712,11 @@ style-loader@^0.23.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "5.2.1"
+  version "5.3.3"
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/is-prop-valid" "^1.1.0"
     "@emotion/stylis" "^0.8.4"
     "@emotion/unitless" "^0.7.4"
     babel-plugin-styled-components ">= 1.12.0"


### PR DESCRIPTION
`translate` attribute is html global attribute, but it is not forwarded in v5.
It is added in `is-prop-valid` 1.0.0.
https://github.com/emotion-js/emotion/blob/main/packages/is-prop-valid/CHANGELOG.md