### PR TITLE
Stabilize style prop for React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 - Rename `masterSheet` in internals to `mainSheet`
 
+- Stabilize the identity of the style prop that is passed into components. This will help in styling PureComponent or React.memo components.
+
 ## [v5.3.0] - 2021-05-04
 
 - Pass `elementToBeCreated` as a third parameter to `shouldForwardProp` so that the user-specified function can decide whether to pass through props based on whether the created element will be a tag or another component. (see [#3436](https://github.com/styled-components/styled-components/pull/3436))

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -1,4 +1,4 @@
-import React, { createElement, Ref, useContext } from 'react';
+import React, { createElement, Ref, useContext, useMemo } from 'react';
 import type {
   Attrs,
   ExtensibleObject,
@@ -79,15 +79,17 @@ function useStyledComponentImpl(
     }
   }
 
-  if (typeof props.style === 'function') {
-    propsForElement.style = (state: any) => {
-      return [generatedStyles].concat(props.style(state));
+  propsForElement.style = useMemo(() => {
+    if (typeof props.style === 'function') {
+      return (state: any) => {
+        return [generatedStyles].concat(props.style(state));
+      }
+    } else if (props.style == null) {
+      return generatedStyles;
+    } else {
+      return [generatedStyles].concat(props.style || []);
     }
-  } else if (props.style == null) {
-    propsForElement.style = generatedStyles;
-  } else {
-    propsForElement.style = [generatedStyles].concat(props.style || []);
-  }
+  }, [props.style, generatedStyles]);
 
   propsForElement.ref = refToForward;
 

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -79,12 +79,15 @@ function useStyledComponentImpl(
     }
   }
 
-  propsForElement.style =
-    typeof props.style === 'function'
-      ? (state: any) => {
-          return [generatedStyles].concat(props.style(state));
-        }
-      : [generatedStyles].concat(props.style || []);
+  if (typeof props.style === 'function') {
+    propsForElement.style = (state: any) => {
+      return [generatedStyles].concat(props.style(state));
+    }
+  } else if (props.style == null) {
+    propsForElement.style = generatedStyles;
+  } else {
+    propsForElement.style = [generatedStyles].concat(props.style || []);
+  }
 
   propsForElement.ref = refToForward;
 

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -31,7 +31,7 @@ describe('native', () => {
     const wrapper = TestRenderer.create(<Comp />);
     const view = wrapper.root.findByType(View);
 
-    expect(view.props.style).toEqual([{}]);
+    expect(view.props.style).toEqual({});
   });
 
   it('should fold successive styled() wrappings', () => {
@@ -46,7 +46,7 @@ describe('native', () => {
     const wrapper = TestRenderer.create(<Comp2 />);
     const view = wrapper.root.findByType(Text);
 
-    expect(view.props.style).toEqual([{ color: 'red', textAlign: 'left' }]);
+    expect(view.props.style).toEqual({ color: 'red', textAlign: 'left' });
   });
 
   it('folds defaultProps', () => {
@@ -154,11 +154,11 @@ describe('native', () => {
 
     const wrapper = TestRenderer.create(<Comp opacity={0.5} />);
 
-    expect(wrapper.root.findByType(View).props.style).toEqual([{ paddingTop: 5, opacity: 0.5 }]);
+    expect(wrapper.root.findByType(View).props.style).toEqual({ paddingTop: 5, opacity: 0.5 });
 
     wrapper.update(<Comp opacity={0.9} />);
 
-    expect(wrapper.root.findByType(View).props.style).toEqual([{ paddingTop: 5, opacity: 0.9 }]);
+    expect(wrapper.root.findByType(View).props.style).toEqual({ paddingTop: 5, opacity: 0.9 });
   });
 
   it('should forward the "as" prop if "forwardedAs" is used', () => {
@@ -182,7 +182,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(View);
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
       });
     });
 
@@ -195,7 +195,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(View);
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         test: true,
       });
     });
@@ -210,7 +210,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(View);
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         copy: test,
         test,
       });
@@ -229,7 +229,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(View);
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         first: 'first',
         second: 'second',
         test: 'test',
@@ -249,7 +249,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(View);
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         first: 'first',
         second: 'second',
         test: 'test',
@@ -269,7 +269,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(View);
 
       expect(view.props).toMatchObject({
-        style: [{}],
+        style: {},
         first: 'first',
         second: 'second',
       });
@@ -285,7 +285,7 @@ describe('native', () => {
 
       expect(text.props).toMatchObject({
         children: 'Probably a bad idea',
-        style: [{}],
+        style: {},
       });
     });
 
@@ -300,7 +300,7 @@ describe('native', () => {
 
       expect(text.props).toMatchObject({
         children: child,
-        style: [{}],
+        style: {},
       });
     });
 
@@ -315,7 +315,7 @@ describe('native', () => {
 
       expect(text.props).toMatchObject({
         children: child,
-        style: [{}],
+        style: {},
       });
     });
 
@@ -330,7 +330,7 @@ describe('native', () => {
 
       expect(text.props).toMatchObject({
         children: child,
-        style: [{}],
+        style: {},
       });
     });
 
@@ -349,7 +349,7 @@ describe('native', () => {
       expect(text.props).toMatchObject({
         children: 'Something else',
         'data-color': 'red',
-        style: [{}],
+        style: {},
       });
     });
 
@@ -361,7 +361,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp theme={{ myColor: 'red' }}>Something else</Comp>);
       const text = wrapper.root.findByType(Text);
 
-      expect(text.props.style).toMatchObject([{ color: 'red' }]);
+      expect(text.props.style).toMatchObject({ color: 'red' });
     });
 
     it('theme in defaultProps works', () => {
@@ -373,7 +373,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp>Something else</Comp>);
       const text = wrapper.root.findByType(Text);
 
-      expect(text.props.style).toMatchObject([{ color: 'red' }]);
+      expect(text.props.style).toMatchObject({ color: 'red' });
     });
   });
 
@@ -411,20 +411,12 @@ describe('native', () => {
 
       expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
         <Text
-          style={
-            Array [
-              Object {},
-            ]
-          }
+          style={Object {}}
         />
       `);
       expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchInlineSnapshot(`
         <View
-          style={
-            Array [
-              Object {},
-            ]
-          }
+          style={Object {}}
         />
       `);
     });
@@ -441,7 +433,7 @@ describe('native', () => {
       const view = wrapper.root.findByType(Text);
 
       expect(view.props).toHaveProperty('foo');
-      expect(view.props.style).toEqual([{ color: 'red' }]);
+      expect(view.props.style).toEqual({ color: 'red' });
     });
 
     it('should omit transient props', () => {
@@ -452,11 +444,9 @@ describe('native', () => {
       expect(TestRenderer.create(<Comp $color="red" />).toJSON()).toMatchInlineSnapshot(`
         <Text
           style={
-            Array [
-              Object {
-                "color": "red",
-              },
-            ]
+            Object {
+              "color": "red",
+            }
           }
         />
       `);
@@ -471,7 +461,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp filterThis="abc" passThru="def" />);
       // @ts-expect-error bs error
       const { props } = wrapper.root.findByType('View');
-      expect(props.style).toEqual([{ color: 'red' }]);
+      expect(props.style).toEqual({ color: 'red' });
       expect(props.passThru).toBe('def');
       expect(props.filterThis).toBeUndefined();
     });
@@ -486,7 +476,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp filterThis="abc" passThru="def" />);
       // @ts-expect-error bs error
       const { props } = wrapper.root.findByType('View');
-      expect(props.style).toEqual([{ color: 'red' }]);
+      expect(props.style).toEqual({ color: 'red' });
       expect(props.passThru).toBe('def');
       expect(props.filterThis).toBeUndefined();
     });
@@ -541,7 +531,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp as={AsComp} filterThis="abc" passThru="def" />);
       const { props } = wrapper.root.findByType(AsComp);
 
-      expect(props.style).toEqual([{ color: 'red' }]);
+      expect(props.style).toEqual({ color: 'red' });
       expect(props.passThru).toBe('def');
       expect(props.filterThis).toBeUndefined();
     });
@@ -556,7 +546,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp as={AsComp} filterThis="abc" passThru="def" />);
       const { props } = wrapper.root.findByType(AsComp);
 
-      expect(props.style).toEqual([{ color: 'red' }]);
+      expect(props.style).toEqual({ color: 'red' });
       expect(props.passThru).toBe('def');
       expect(props.filterThis).toBeUndefined();
     });
@@ -570,7 +560,7 @@ describe('native', () => {
       const wrapper = TestRenderer.create(<Comp as="a" filterThis="abc" passThru="def" />);
       const { props } = wrapper.root.findByType('a');
 
-      expect(props.style).toEqual([{ color: 'red' }]);
+      expect(props.style).toEqual({ color: 'red' });
       expect(props.passThru).toBe('def');
       expect(props.filterThis).toBeUndefined();
     });
@@ -586,7 +576,7 @@ describe('native', () => {
       // @ts-expect-error bs error
       const view = wrapper.root.findByType('View');
 
-      expect(view.props.style).toEqual([{ color: 'red' }]);
+      expect(view.props.style).toEqual({ color: 'red' });
       expect(() => wrapper.root.findByType(Text)).toThrowError();
     });
   });

--- a/packages/styled-components/src/primitives/test/__snapshots__/primitives.test.tsx.snap
+++ b/packages/styled-components/src/primitives/test/__snapshots__/primitives.test.tsx.snap
@@ -2,20 +2,12 @@
 
 exports[`primitives expanded API withComponent should work 1`] = `
 <Text
-  style={
-    Array [
-      Object {},
-    ]
-  }
+  style={Object {}}
 />
 `;
 
 exports[`primitives expanded API withComponent should work 2`] = `
 <View
-  style={
-    Array [
-      Object {},
-    ]
-  }
+  style={Object {}}
 />
 `;

--- a/packages/styled-components/src/primitives/test/primitives.test.tsx
+++ b/packages/styled-components/src/primitives/test/primitives.test.tsx
@@ -31,7 +31,7 @@ describe('primitives', () => {
     // @ts-expect-error valid input
     const view = wrapper.root.findByType('View');
 
-    expect(view.props.style).toEqual([{}]);
+    expect(view.props.style).toEqual({});
   });
 
   it('should fold successive styled() wrappings', () => {
@@ -47,7 +47,7 @@ describe('primitives', () => {
     // @ts-expect-error valid input
     const view = wrapper.root.findByType('Text');
 
-    expect(view.props.style).toEqual([{ color: 'red', textAlign: 'left' }]);
+    expect(view.props.style).toEqual({ color: 'red', textAlign: 'left' });
   });
 
   it('should combine inline styles and the style prop', () => {
@@ -71,7 +71,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('View');
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
       });
     });
 
@@ -85,7 +85,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('View');
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         test: true,
       });
     });
@@ -103,7 +103,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('View');
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         copy: test,
         test,
       });
@@ -123,7 +123,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('View');
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         first: 'first',
         second: 'second',
         test: 'test',
@@ -144,7 +144,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('View');
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         first: 'first',
         second: 'second',
         test: 'test',
@@ -165,7 +165,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('View');
 
       expect(view.props).toEqual({
-        style: [{}],
+        style: {},
         first: 'first',
         second: 'second',
       });
@@ -182,7 +182,7 @@ describe('primitives', () => {
 
       expect(text.props).toMatchObject({
         children: 'Probably a bad idea',
-        style: [{}],
+        style: {},
       });
     });
 
@@ -198,7 +198,7 @@ describe('primitives', () => {
 
       expect(text.props).toMatchObject({
         children: child,
-        style: [{}],
+        style: {},
       });
     });
 
@@ -214,7 +214,7 @@ describe('primitives', () => {
 
       expect(text.props).toMatchObject({
         children: child,
-        style: [{}],
+        style: {},
       });
     });
 
@@ -230,7 +230,7 @@ describe('primitives', () => {
 
       expect(text.props).toMatchObject({
         children: child,
-        style: [{}],
+        style: {},
       });
     });
 
@@ -251,7 +251,7 @@ describe('primitives', () => {
       expect(text.props).toMatchObject({
         children: 'Something else',
         'data-color': 'red',
-        style: [{}],
+        style: {},
       });
     });
   });
@@ -288,7 +288,7 @@ describe('primitives', () => {
       const view = wrapper.root.findByType('Text');
 
       expect(view.props).toHaveProperty('foo');
-      expect(view.props.style).toEqual([{ color: 'red' }]);
+      expect(view.props.style).toEqual({ color: 'red' });
     });
 
     it('withComponent should work', () => {


### PR DESCRIPTION
This is somewhat similar to https://github.com/styled-components/styled-components/pull/3602 but I took a different take.

Since `generatedStyles` already seems stable, I just allow it to be passed directly to the `propsForElement` object.

The style prop will still be unstable in the case that the caller passes in some inline stables, but I think this should cover most use cases.