### PR TITLE
Use regex for topLevelImportPaths option

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -68,7 +68,7 @@
     "@emotion/is-prop-valid": "^1.1.0",
     "@emotion/stylis": "^0.8.4",
     "@emotion/unitless": "^0.7.4",
-    "babel-plugin-styled-components": ">= 1.12.0",
+    "babel-plugin-styled-components": ">= 2.0.0",
     "css-to-react-native": "^3.0.0",
     "hoist-non-react-statics": "^3.0.0",
     "shallowequal": "^1.1.0",

--- a/packages/styled-components/src/macro/index.js
+++ b/packages/styled-components/src/macro/index.js
@@ -3,6 +3,7 @@ import { addDefault, addNamed } from '@babel/helper-module-imports';
 import traverse from '@babel/traverse';
 import { createMacro } from 'babel-plugin-macros';
 import babelPlugin from 'babel-plugin-styled-components';
+import escapeRegExp from 'lodash/escapeRegExp';
 
 function styledComponentsMacro({
   references,
@@ -38,7 +39,7 @@ function styledComponentsMacro({
     ...state,
     opts: {
       ...config,
-      topLevelImportPaths: (config.topLevelImportPaths || []).concat(importModuleName),
+      topLevelImportPaths: (config.topLevelImportPaths || []).concat(`$${escapeRegExp(importModuleName)}^`),
     },
     customImportName,
   };

--- a/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
+++ b/packages/styled-components/src/macro/test/__snapshots__/macro.test.js.snap
@@ -111,8 +111,9 @@ css\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { css as _css } from \\"styled-components\\";
-
-_css([\\"color:\\", \\";\\"], props => props.whiteColor ? 'white' : 'black');
+_css\`
+  color: \${props => props.whiteColor ? 'white' : 'black'};
+\`;
 "
 `;
 
@@ -128,8 +129,10 @@ keyframes\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { keyframes as _keyframes } from \\"styled-components\\";
-
-_keyframes([\\"0%{opacity:0;}100%{opacity:1;}\\"]);
+_keyframes\`
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+\`;
 "
 `;
 
@@ -250,14 +253,14 @@ import _styled2 from \\"styled-components\\";
 import _styled from \\"styled-components\\";
 import React from 'react';
 
+function Foo() {
+  return /*#__PURE__*/React.createElement(_StyledDiv, null);
+}
+
 var _StyledDiv = _styled(\\"div\\").withConfig({
   displayName: \\"macrotest___StyledDiv\\",
   componentId: \\"sc-11gvsec-0\\"
 })([\\"color:red;\\"]);
-
-function Foo() {
-  return /*#__PURE__*/React.createElement(_StyledDiv, null);
-}
 "
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,13 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-annotate-as-pure@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz#9a1f0ebcda53d9a2d00108c4ceace6a5d5f1f08d"
+  integrity sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz#c84097a427a061ac56a1c30ebf54b7b22d241503"
@@ -234,6 +241,13 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-module-imports@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
+  integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-module-transforms@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
@@ -335,6 +349,11 @@
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
+"@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/helper-validator-identifier@^7.9.0":
   version "7.9.0"
@@ -1127,6 +1146,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
+  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -2509,13 +2536,13 @@ babel-plugin-react-native-web@^0.11.4:
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
 
-"babel-plugin-styled-components@>= 1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
-  integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
+"babel-plugin-styled-components@>= 2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz#0fac11402dc9db73698b55847ab1dc73f5197c54"
+  integrity sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
-    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-module-imports" "^7.16.0"
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
 
@@ -10719,7 +10746,7 @@ style-loader@^0.23.1:
     "@emotion/is-prop-valid" "^1.1.0"
     "@emotion/stylis" "^0.8.4"
     "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
+    babel-plugin-styled-components ">= 2.0.0"
     css-to-react-native "^3.0.0"
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"


### PR DESCRIPTION
In the 2.x.x version of babel-plugin-styled-components, topLevelImportPath requires a regex, so we escape the literal here.
