### PR TITLE
Add withTheme flag to fix folding up for themed components

### DIFF
--- a/packages/styled-components/src/hoc/withTheme.js
+++ b/packages/styled-components/src/hoc/withTheme.js
@@ -35,6 +35,12 @@ export default (Component: AbstractComponent<*, *>) => {
   hoistStatics(WithTheme, Component);
 
   WithTheme.displayName = `WithTheme(${getComponentName(Component)})`;
+  
+  // The underlying component is expected to get a theme as a prop.
+  // However, if the underlying component is folded up (see StyledComponent.js),
+  // we cannot tell that it needs a theme as a prop without a mark.
+  // So we mark WithTheme with withTheme flag.
+  WithTheme.withTheme = true;
 
   return WithTheme;
 };

--- a/packages/styled-components/src/hoc/withTheme.js
+++ b/packages/styled-components/src/hoc/withTheme.js
@@ -5,6 +5,8 @@ import { ThemeContext } from '../models/ThemeProvider';
 import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
 
+type WithThemeComponent = AbstractComponent<*, *> & { withTheme?: boolean };
+
 // NOTE: this would be the correct signature:
 // export default <Config: { theme?: any }, Instance>(
 //  Component: AbstractComponent<Config, Instance>
@@ -40,7 +42,7 @@ export default (Component: AbstractComponent<*, *>) => {
   // However, if the underlying component is folded up (see StyledComponent.js),
   // we cannot tell that it needs a theme as a prop without a mark.
   // So we mark WithTheme with withTheme flag.
-  WithTheme.withTheme = true;
+  ((WithTheme: any): WithThemeComponent).withTheme = true;
 
   return WithTheme;
 };

--- a/packages/styled-components/src/models/StyledComponent.js
+++ b/packages/styled-components/src/models/StyledComponent.js
@@ -110,6 +110,7 @@ function useStyledComponentImpl(
     shouldForwardProp,
     styledComponentId,
     target,
+    withTheme,
   } = forwardedComponent;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -136,6 +137,11 @@ function useStyledComponentImpl(
   const isTargetTag = isTag(elementToBeCreated);
   const computedProps = attrs !== props ? { ...props, ...attrs } : props;
   const propsForElement = {};
+
+  // if the original component was themed via withTheme HOC, pass the theme
+  if (withTheme) {
+    propsForElement.theme = theme;
+  }
 
   // eslint-disable-next-line guard-for-in
   for (const key in computedProps) {
@@ -307,6 +313,8 @@ export default function createStyledComponent(
 
   WrappedStyledComponent.toString = () => `.${WrappedStyledComponent.styledComponentId}`;
 
+  WrappedStyledComponent.withTheme = isTargetStyledComp && ((target: any): IStyledComponent).withTheme;
+
   if (isCompositeComponent) {
     hoist<
       IStyledStatics,
@@ -322,6 +330,7 @@ export default function createStyledComponent(
       styledComponentId: true,
       target: true,
       withComponent: true,
+      withTheme: true,
     });
   }
 

--- a/packages/styled-components/src/types.js
+++ b/packages/styled-components/src/types.js
@@ -51,6 +51,7 @@ export interface IStyledStatics {
   styledComponentId: string;
   warnTooManyClasses?: $Call<typeof createWarnTooManyClasses, string, string>;
   withComponent: (tag: Target) => IStyledComponent;
+  withTheme?: boolean;
 }
 
 export interface IStyledComponent extends Component<*>, IStyledStatics {


### PR DESCRIPTION
Fixes #3659 
I added a flag to detect if a component was themed via withTheme HOC. When styled again, a styled component is folded up and doesn't get a theme from the HOC anymore. I fixed this by using the flag and passing the theme to the folded up component again.
