### PR TITLE
Remove reference to Spectrum support channel

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,6 @@ Thank you for contributing and please follow this guide before creating an issue
 - Look for prior or closed issues (but please avoid replying to them if they're old)
 - Check the docs: https://www.styled-components.com/docs
 - Look for/ask questions on stack overflow: https://stackoverflow.com/questions/ask?tags=styled-components
-- Start a thread on our Spectrum help channel: https://spectrum.chat/styled-components/help
 - Is this about Typescript? TS types are provided by DefinitelyTyped, all issues opened about TS will be closed and referred there.
 
 2. Think you found a bug?


### PR DESCRIPTION
After Github purchased Spectrum all forums are now read-only, including [SC's](https://spectrum.chat/styled-components?tab=posts). Let's remove the reference to starting threads on this closed forum :smile: 

P.S. I was looking for a forum to _discuss_ pros/cons on importing theme vs getting it from the provider, which is a non-definitive question type that is out of scope for StackOverflow (i.e. will be closed). Having a new forum for such things would be great. I suggest enabling Github Discussions (which is probably povered by Spectrum code anyway).h