### PR TITLE
Replace mixinDeep with a cycle-safe implementation

### DIFF
--- a/packages/styled-components/src/utils/isPlainObject.ts
+++ b/packages/styled-components/src/utils/isPlainObject.ts
@@ -2,6 +2,9 @@ export default function isPlainObject(x: any): boolean {
   return (
     x !== null &&
     typeof x === 'object' &&
+    /* a check for empty prototype would be more typical, but that
+       doesn't play well with objects created in different vm contexts */
+    (!x.constructor || x.constructor.name === 'Object') &&
     (x.toString ? x.toString() : Object.prototype.toString.call(x)) === '[object Object]' &&
     /* check for reasonable markers that the object isn't an element for react & preact/compat */
     !('props' in x && (x.$$typeof || x.constructor === undefined))

--- a/packages/styled-components/src/utils/mixinDeep.ts
+++ b/packages/styled-components/src/utils/mixinDeep.ts
@@ -1,60 +1,33 @@
 import { ExtensibleObject } from '../types';
+import isPlainObject from './isPlainObject'
 
-/**
-  mixin-deep; https://github.com/jonschlinkert/mixin-deep
-  Inlined such that it will be consistently transpiled to an IE-compatible syntax.
-
-  The MIT License (MIT)
-
-  Copyright (c) 2014-present, Jon Schlinkert.
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  THE SOFTWARE.
-*/
-const isObject = (val: any) => {
-  return (
-    typeof val === 'function' || (typeof val === 'object' && val !== null && !Array.isArray(val))
-  );
-};
-
-const isValidKey = (key: string) => {
-  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
-};
-
-function mixin(target: ExtensibleObject, val: any, key: string) {
-  const obj = target[key];
-  if (isObject(val) && isObject(obj)) {
-    mixinDeep(obj, val);
-  } else {
-    target[key] = val;
-  }
+function isRecursible(obj: any) {
+  return isPlainObject(obj) || Array.isArray(obj);
 }
 
-export default function mixinDeep(target: ExtensibleObject, ...rest: any[]) {
-  for (const obj of rest) {
-    if (isObject(obj)) {
-      for (const key in obj) {
-        if (isValidKey(key)) {
-          mixin(target, obj[key], key);
-        }
-      }
+function mixinRecursively(target: any, source: any) {
+  const isRecursive = isRecursible(target);
+  for (const [key, sourceVal] of Object.entries(source)) {
+    const targetVal = target[key];
+    if (isRecursive && isRecursible(targetVal) && isRecursible(sourceVal)) {
+      target[key] = mixinRecursively(targetVal, sourceVal);
+    } else {
+      target[key] = sourceVal;
     }
-  }
+  };
 
+  return target;
+}
+
+/**
+ * Arrays & POJOs merged recursively, other objects and value types are overridden
+ * Source objects applied left to right.  Mutates & returns target.  Similar to lodash merge.
+ */
+export default function mixinDeep(target: ExtensibleObject = {}, ...sources: any[]) {
+  for (const source of sources) {
+    if (isRecursible(source)) {
+      mixinRecursively(target, source);
+    }
+  };
   return target;
 }

--- a/packages/styled-components/src/utils/test/isPlainObject.test.ts
+++ b/packages/styled-components/src/utils/test/isPlainObject.test.ts
@@ -15,6 +15,12 @@ it('returns false for an instance of a class with its own toString method', () =
   expect(isPlainObject(new SomeClass())).toEqual(false);
 });
 
+it('returns false for an instance of an object with a custom prototype', () => {
+  function SomeObj(): void {
+  }
+  expect(isPlainObject(new SomeObj())).toEqual(false);
+});
+
 it('returns false for a function', () => {
   expect(isPlainObject(() => {})).toEqual(false);
 });

--- a/packages/styled-components/src/utils/test/mixinDeep.test.ts
+++ b/packages/styled-components/src/utils/test/mixinDeep.test.ts
@@ -1,6 +1,14 @@
 /* ported from https://github.com/jonschlinkert/mixin-deep; thanks Jon! */
 import mixinDeep from '../mixinDeep';
 
+const MyObj = function (foo, bar, baz = undefined) {
+  this.foo = foo;
+  this.bar = bar;
+  if (baz) {
+    this.baz = 5;
+  }
+};
+
 it('should deeply mix the properties of object into the first object.', () => {
   expect(mixinDeep({ a: { aa: 'aa' } }, { a: { bb: 'bb' } }, { a: { cc: 'cc' } })).toEqual({
     a: { aa: 'aa', bb: 'bb', cc: 'cc' },
@@ -32,6 +40,31 @@ it('should mixin nested object properties', () => {
   const obj2 = { a: { b: 2, d: { f: 'f' } } };
 
   expect(mixinDeep(obj1, obj2)).toEqual({ a: { b: 2, c: 1, d: { e: 1, f: 'f' } } });
+});
+
+it('should shallow merge properties if target is not a POJO or array', () => {
+  const obj1 = new MyObj(5, 6);
+  const obj2 = { a: { b: 2, d: { f: 'f' } } };
+
+  expect(mixinDeep(obj1, obj2)).toMatchInlineSnapshot(`
+MyObj {
+  "a": Object {
+    "b": 2,
+    "d": Object {
+      "f": "f",
+    },
+  },
+  "bar": 6,
+  "foo": 5,
+}
+`);
+});
+
+it('should NOT shallow merge non-POJO properties of target', () => {
+  const obj1 = { wrapped: new MyObj(5, 6) };
+  const obj2 = { wrapped: { a: { b: 2, d: { f: 'f' } } } };
+
+  expect(mixinDeep(obj1, obj2)).toEqual({ wrapped: { a: { b: 2, d: { f: 'f' } } } });
 });
 
 it('should use the last value defined', () => {
@@ -81,15 +114,55 @@ it('should deep mixin arrays during mixin', () => {
   expect(actual.a).toEqual([1, 2, [3, 4]]);
   expect(actual.a[2]).toEqual([3, 4]);
   expect(actual.b).toEqual(obj2.b);
+
+  expect(
+    mixinDeep(
+      [new MyObj(1, 2), { a: 1 }, new MyObj(4, 5), new MyObj(8, 9)],
+      [{ abc: 345 }, { abc: 456 }, new MyObj(7, 8)]
+    )
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "abc": 345,
+      },
+      Object {
+        "a": 1,
+        "abc": 456,
+      },
+      MyObj {
+        "bar": 8,
+        "foo": 7,
+      },
+      MyObj {
+        "bar": 9,
+        "foo": 8,
+      },
+    ]
+  `);
 });
 
 it('should not modify source properties', () => {
   expect(mixinDeep({ test: true }).test).toEqual(true);
 });
 
-it('should not mixin arrays', () => {
+it('should properly mixin arrays', () => {
   expect(mixinDeep([1, 2, 3])).toEqual([1, 2, 3]);
   expect(mixinDeep([1, 2, 3], {})).toEqual([1, 2, 3]);
+  expect(mixinDeep([1, 2, 3], {})).toEqual([1, 2, 3]);
+  expect(mixinDeep([10, 20, 30, 40, 50, 60], [11, 21, { abc: 123 }, true], [12, 22])).toEqual([
+    12,
+    22,
+    { abc: 123 },
+    true,
+    50,
+    60,
+  ]);
+  expect(mixinDeep([10], [11, 21, { abc: 123 }, true], [12, 22])).toEqual([
+    12,
+    22,
+    { abc: 123 },
+    true,
+  ]);
 });
 
 it('should work with sparse objects:', () => {
@@ -117,7 +190,7 @@ it('should not mixin objects created with custom constructor', () => {
 });
 
 it('should not fail on objects with cyclical prototypes', () => {
-  const Cyclical = function() {}
+  const Cyclical = function () {};
   Cyclical.prototype.cycle = new Cyclical();
 
   const cycle1 = new Cyclical();

--- a/packages/styled-components/src/utils/test/mixinDeep.test.ts
+++ b/packages/styled-components/src/utils/test/mixinDeep.test.ts
@@ -115,3 +115,14 @@ it('should not mixin objects created with custom constructor', () => {
   const actual = mixinDeep(fixture);
   expect(actual).toEqual(fixture);
 });
+
+it('should not fail on objects with cyclical prototypes', () => {
+  const Cyclical = function() {}
+  Cyclical.prototype.cycle = new Cyclical();
+
+  const cycle1 = new Cyclical();
+  const cycle2 = new Cyclical();
+
+  const actual = mixinDeep(cycle1, cycle2, { a: 1 });
+  expect(actual).toEqual(cycle1);
+});


### PR DESCRIPTION
Fixes #3576

Since #2838, styled-components has been using a different (smaller) implementation of deep merge that doesn't play well with cyclical objects & particularly objects with cyclical prototypes.  In particular, this causes styled-components to blow the stack when used with some Function prototype extensions.

This PR replaces the mixinDeep implementation with a custom one that's closer to the [previously used library](https://github.com/mesqueeb/merge-anything) & is most similar in usage to [_.merge](https://lodash.com/docs/4.17.15#merge).  It keeps the tests unchanged, but adds a new one that explicitly ensures that cyclical objects don't blow the stack (try it with the old implementation if you want to see what happens in the current version).

See discussion in #3576 for further detail.