### PR TITLE
Remove: extra dev script for styled components base directory package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "build": "yarn workspace styled-components build",
     "postbuild": "cp README.md packages/styled-components/",
     "postinstall": "yarn workspace styled-components generateErrors",
-    "dev": "yarn workspace styled-components dev",
     "lint": "yarn workspace styled-components lint",
     "size": "yarn workspace styled-components lint:size",
     "test": "yarn workspace styled-components test"


### PR DESCRIPTION
The `package.json` in the base directory contained a `dev` script which in turn was related to the `dev` script of the 'packages/styled-components'. But since there is not associated `dev` script in that part of the repository, the base command fails.

![image](https://user-images.githubusercontent.com/44740407/153419468-db76987b-6558-4cf7-b517-33d3eb57750d.png)


This pull request addresses that small issue.