### PR TITLE
refactor: replace `git.io` within error message

### DIFF
--- a/packages/styled-components/src/utils/error.ts
+++ b/packages/styled-components/src/utils/error.ts
@@ -31,8 +31,7 @@ export default function throwStyledComponentsError(
 ) {
   if (process.env.NODE_ENV === 'production') {
     return new Error(
-      `An error occurred. See https://git.io/JUIaE#${code} for more information.${
-        interpolations.length > 0 ? ` Args: ${interpolations.join(', ')}` : ''
+      `An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#${code} for more information.${interpolations.length > 0 ? ` Args: ${interpolations.join(', ')}` : ''
       }`
     );
   } else {

--- a/packages/styled-components/src/utils/test/error.test.ts
+++ b/packages/styled-components/src/utils/test/error.test.ts
@@ -28,7 +28,7 @@ describe('production', () => {
     expect(() => {
       throw styledError(2);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred. See https://git.io/JUIaE#2 for more information."`
+      `"An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#2 for more information."`
     );
   });
 
@@ -36,7 +36,7 @@ describe('production', () => {
     expect(() => {
       throw styledError(1, 'foo');
     }).toThrowErrorMatchingInlineSnapshot(
-      `"An error occurred. See https://git.io/JUIaE#1 for more information. Args: foo"`
+      `"An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#1 for more information. Args: foo"`
     );
   });
 });


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/, replace all `git.io` usage with the original URL.

----

Alternative solution: use `https://styled-components.com/error#${code}` for the redirection.