### PR TITLE
Fix/nonce in ssr

### DIFF
--- a/packages/benchmarks/src/implementations/styled-components-v4/styled-components-v4.esm.js
+++ b/packages/benchmarks/src/implementations/styled-components-v4/styled-components-v4.esm.js
@@ -397,7 +397,7 @@ function stringifyRules(rules, selector, prefix) {
 /* eslint-disable camelcase, no-undef */
 
 var getNonce = function() {
-  return typeof window.__webpack_nonce__ !== 'undefined' ? window.__webpack_nonce__ : null;
+  return typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : null;
 };
 
 //

--- a/packages/styled-components/src/utils/nonce.js
+++ b/packages/styled-components/src/utils/nonce.js
@@ -1,10 +1,10 @@
 // @flow
 /* eslint-disable camelcase, no-undef */
 
-declare var window: { __webpack_nonce__: string };
+declare var __webpack_nonce__: string;
 
 const getNonce = () => {
-  return typeof window.__webpack_nonce__ !== 'undefined' ? window.__webpack_nonce__ : null;
+  return typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : null;
 };
 
 export default getNonce;

--- a/packages/styled-components/src/utils/nonce.js
+++ b/packages/styled-components/src/utils/nonce.js
@@ -4,12 +4,7 @@
 declare var window: { __webpack_nonce__: string };
 
 const getNonce = () => {
-
-  return typeof window !== 'undefined'
-    ? typeof window.__webpack_nonce__ !== 'undefined'
-      ? window.__webpack_nonce__
-      : null
-    : null;
+  return typeof window.__webpack_nonce__ !== 'undefined' ? window.__webpack_nonce__ : null;
 };
 
 export default getNonce;

--- a/scripts/jest/config.main.js
+++ b/scripts/jest/config.main.js
@@ -7,7 +7,4 @@ module.exports = Object.assign({}, baseConfig, {
   setupFiles: ['raf/polyfill', '<rootDir>/src/test/globals.js'],
   setupFilesAfterEnv: ['<rootDir>/test-utils/setupTestFramework.js'],
   testPathIgnorePatterns: ['<rootDir>/src/native', '<rootDir>/src/primitives'],
-  globals: {
-    window: { __webpack_nonce__: 'test' },
-  },
 });


### PR DESCRIPTION
Fixes #3571
Reverts #3415 and #3446

#3415 was a fix for issue #3414 but I believe the issue wasn't in styled-components but maybe just lack of documentation on how `__webpack_nonce__` should be used. And #3446 was just a fix on top of #3415.

`__webpack_nonce__` is a magic variable and webpack does some special handling for it. To my understanding it should be set at the beginning of entry point and used directly like `__webpack_nonce__ = 'secret'` instead of through window (which doesn't even exist on server).
