### PR TITLE
fix: Support ESM in Node.js through conditional exports

### DIFF
--- a/packages/styled-components/macro/package.json
+++ b/packages/styled-components/macro/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "types": "../dist/index.d.ts",
   "main": "../dist/styled-components-macro.cjs.js",
-  "module": "../dist/styled-components-macro.esm.js",
-  "jsnext:main": "../dist/styled-components-macro.esm.js"
+  "module": "../dist/styled-components-macro.esm.mjs",
+  "jsnext:main": "../dist/styled-components-macro.esm.mjs"
 }

--- a/packages/styled-components/native/package.json
+++ b/packages/styled-components/native/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "types": "./dist/native/index.d.ts",
   "main": "./dist/styled-components.native.cjs.js",
-  "jsnext:main": "./dist/styled-components.native.esm.js",
-  "module": "./dist/styled-components.native.esm.js"
+  "jsnext:main": "./dist/styled-components.native.esm.mjs",
+  "module": "./dist/styled-components.native.esm.mjs"
 }

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -4,10 +4,16 @@
   "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress",
   "types": "dist/index.d.ts",
   "main": "dist/styled-components.cjs.js",
-  "module": "dist/styled-components.esm.js",
+  "module": "dist/styled-components.esm.mjs",
   "react-native": "native/dist/styled-components.native.cjs.js",
+  "exports": {
+    ".": {
+      "import": "./dist/styled-components.esm.mjs",
+      "require": "./dist/styled-components.cjs.js"
+    }
+  },
   "browser": {
-    "./dist/styled-components.esm.js": "./dist/styled-components.browser.esm.js",
+    "./dist/styled-components.esm.mjs": "./dist/styled-components.browser.esm.mjs",
     "./dist/styled-components.cjs.js": "./dist/styled-components.browser.cjs.js"
   },
   "sideEffects": [

--- a/packages/styled-components/primitives/package.json
+++ b/packages/styled-components/primitives/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "types": "./dist/primitives/index.d.ts",
   "main": "./dist/styled-components-primitives.cjs.js",
-  "module": "./dist/styled-components-primitives.esm.js",
-  "jsnext:main": "./dist/styled-components-primitives.esm.js"
+  "module": "./dist/styled-components-primitives.esm.mjs",
+  "jsnext:main": "./dist/styled-components-primitives.esm.mjs"
 }

--- a/packages/styled-components/rollup.config.js
+++ b/packages/styled-components/rollup.config.js
@@ -104,7 +104,7 @@ const standaloneProdConfig = {
 const serverConfig = {
   ...configBase,
   output: [
-    getESM({ file: 'dist/styled-components.esm.js' }),
+    getESM({ file: 'dist/styled-components.esm.mjs' }),
     getCJS({ file: 'dist/styled-components.cjs.js' }),
   ],
   plugins: configBase.plugins.concat(
@@ -119,7 +119,7 @@ const serverConfig = {
 const browserConfig = {
   ...configBase,
   output: [
-    getESM({ file: 'dist/styled-components.browser.esm.js' }),
+    getESM({ file: 'dist/styled-components.browser.esm.mjs' }),
     getCJS({ file: 'dist/styled-components.browser.cjs.js' }),
   ],
   plugins: configBase.plugins.concat(
@@ -138,7 +138,7 @@ const nativeConfig = {
       file: 'native/dist/styled-components.native.cjs.js',
     }),
     getESM({
-      file: 'native/dist/styled-components.native.esm.js',
+      file: 'native/dist/styled-components.native.esm.mjs',
     }),
   ],
 };
@@ -147,7 +147,7 @@ const primitivesConfig = {
   ...configBase,
   input: './src/primitives/index.ts',
   output: [
-    getESM({ file: 'primitives/dist/styled-components-primitives.esm.js' }),
+    getESM({ file: 'primitives/dist/styled-components-primitives.esm.mjs' }),
     getCJS({
       file: 'primitives/dist/styled-components-primitives.cjs.js',
     }),
@@ -162,7 +162,7 @@ const primitivesConfig = {
 const macroConfig = Object.assign({}, configBase, {
   input: './src/macro/index.ts',
   output: [
-    getESM({ file: 'dist/styled-components-macro.esm.js' }),
+    getESM({ file: 'dist/styled-components-macro.esm.mjs' }),
     getCJS({ file: 'dist/styled-components-macro.cjs.js' }),
   ],
   plugins: configBase.plugins.concat(


### PR DESCRIPTION
This is an attempt to fix #3601. This fix uses [conditional exports](https://nodejs.org/docs/latest-v16.x/api/packages.html#packages_conditional_exports) and is specifically to fix how Node.js, not bundlers, import styled components.

I'm leaving it as a draft for now, because it's not fully tested due to `@emotion/is-prop-valid` possibly suffering from the same issue and needing the same fix:

```
TypeError: i is not a function
    at file:///path/to/repo/node_modules/styled-components/dist/styled-components.esm.mjs:1:20617
    at x (file:///path/to/repo/node_modules/styled-components/dist/styled-components.esm.mjs:1:20841)
    at Wc (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:73:362)
    at Z (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at $c (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:78:98)
    at bd (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:77:404)
    at Z (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:217)
    at $c (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:78:98)
    at Zc (/path/to/repo/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:71:145)
```

`i` is the default export from `@emotion/is-prop-valid`.

Similarly, in my (legacy) v5 backport, I had this issue with `@emotion/stylis`:

```
TypeError: h is not a constructor
    at ae (file:///path/to/repo/node_modules/styled-components/dist/styled-components.esm.mjs:1:12214)
    at file:///path/to/repo/node_modules/styled-components/dist/styled-components.esm.mjs:1:13205
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:385:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:437:15)
```

`h` is the default export from `@emotion/stylis`.

When I get some time later in the week, I'll work my way through the affected Emotion packages and, if that ultimately fixes the problem, create additional PRs to support this one.