### PR TITLE
Fix speedy rule insertion when css contains multiple rules

### DIFF
--- a/packages/styled-components/src/hoc/withTheme.spec.tsx
+++ b/packages/styled-components/src/hoc/withTheme.spec.tsx
@@ -49,9 +49,9 @@ describe('withTheme', () => {
       </ThemeProvider>
     );
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
-<span>
-  {"color":"red"}
-</span>
-`);
+      <span>
+        {"color":"red"}
+      </span>
+    `);
   });
 });

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -101,7 +101,7 @@ export type FlattenerResult<Props> =
   | Keyframes;
 
 export interface Stringifier {
-  (css: string, selector?: string, prefix?: string, componentId?: string): string;
+  (css: string, selector?: string, prefix?: string, componentId?: string): string[];
   hash: string;
 }
 

--- a/packages/styled-components/src/utils/test/stylis.test.ts
+++ b/packages/styled-components/src/utils/test/stylis.test.ts
@@ -1,0 +1,37 @@
+import createStylisInstance from '../stylis';
+
+function stylisTest(css: string): string[] {
+  const stylis = createStylisInstance();
+  const componentId = 'a';
+  return stylis(css, `.${componentId}`, undefined, componentId);
+}
+
+describe('stylis', () => {
+  it('handles simple rules', () => {
+    const css = stylisTest(`
+      background: yellow;
+      color: red;
+    `);
+    expect(css).toMatchInlineSnapshot(`
+      Array [
+        ".a{background:yellow;color:red;}",
+      ]
+    `);
+  });
+
+  it('splits css with multiple rules', () => {
+    const css = stylisTest(`
+      background: yellow;
+      color: red;
+      @media (min-width: 500px) {
+        color: blue;
+      }
+    `);
+    expect(css).toMatchInlineSnapshot(`
+      Array [
+        ".a{background:yellow;color:red;}",
+        "@media (min-width: 500px){.a{color:blue;}}",
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
When using CSSOM insertion any css that contains more than one rule will cause it to fail. This is because the `insertRule` api requires only one rule. To fix this we can have a custom stylis serializer that returns an array of rules instead of the default that concatenate them together.

For example this will break:

```js
styled.div`
  color: red;
  @media (min-height: 200px) {
    color: blue;
  }
`
```

since it will try to insert the following rule, which is actually 2 rules:

```
.a {color: red;} @media (min-height: 200px) {.a {color:blue;}}
```

This can be easily reproduced in the sandbox example. To make sure CSSOM is used change `DISABLE_SPEEDY` to false in `constants.ts` and run the sandbox example. You can see some styles are missing, for example the font.

Without speedy (ok):

![image](https://user-images.githubusercontent.com/2677334/184984737-964d056d-a829-40ae-ae2b-06ff96cdd6e2.png)

With speedy (broken):

![image](https://user-images.githubusercontent.com/2677334/184984678-0990a91e-1ed0-4bad-95d9-ba61e84b0b40.png)

After this fix, it renders the same with and without speedy.