### PR TITLE
only minify standalone prod build

### DIFF
--- a/packages/styled-components/rollup.config.js
+++ b/packages/styled-components/rollup.config.js
@@ -122,7 +122,6 @@ const standaloneConfig = {
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),
     }),
-    minifierPlugin
   ),
 };
 
@@ -151,7 +150,6 @@ const serverConfig = {
       window: undefined,
       __SERVER__: JSON.stringify(true),
     }),
-    minifierPlugin
   ),
 };
 
@@ -165,7 +163,6 @@ const browserConfig = {
     replace({
       __SERVER__: JSON.stringify(false),
     }),
-    minifierPlugin
   ),
 };
 
@@ -192,7 +189,6 @@ const macroConfig = Object.assign({}, configBase, {
     replace({
       __SERVER__: JSON.stringify(false),
     }),
-    minifierPlugin
   ),
 });
 


### PR DESCRIPTION
I briefly mentioned this on [twitter](https://twitter.com/henryqdineen/status/1565175665468530688) but we prefer, when possible for third party libraries to distribute unminified source to allow us to minify it ourselves. It seems to me that only the `.min.js` was meant to be minified so I removed the terser plugin from the others. 