### PR TITLE
fix(types): allow interpolating false

### DIFF
--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -59,6 +59,7 @@ export type Interpolation<Props> =
   | TemplateStringsArray
   | string
   | number
+  | false
   | undefined
   | null
   | Keyframes


### PR DESCRIPTION
Allow `${bool && styles}` instead of requiring `${bool ? styles : null}`