### PR TITLE
Disallow mix of $as and as

### DIFF
--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -144,12 +144,15 @@ type PolymorphicComponentProps<
   Omit<PropsToBeInjectedIntoActualComponent, keyof ActualComponentProps | 'as' | '$as'> &
   ActualComponentProps &
   (
+    // Only one of "$as" or "as" is allowed. This used to take "$as" in
+    // preference over "as" if both were present, but it's less confusing to be
+    // strict.
     | {
-        // if "$as" is passed it takes precendence over "as"
         $as: ActualComponent;
-        as?: AnyComponent;
+        as?: never;
       }
     | {
+        $as?: never;
         as?: ActualComponent;
       }
   );


### PR DESCRIPTION
This is a bit opinionated, but I think there's no reason anybody should be passing both, and one benefit we get from types is avoiding those kinds of mistakes.