### PR TITLE
chore: update typescript

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -134,7 +134,7 @@
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^7.0.2",
     "stylis-plugin-rtl": "^2.1.1",
-    "typescript": "^4.7.4",
+    "typescript": "^4.8.3",
     "utility-types": "^3.10.0"
   },
   "bundlewatch": {

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -20,7 +20,7 @@ export interface Styled<
   R extends Runtime,
   Target extends StyledTarget<R>,
   DerivedProps = Target extends KnownTarget ? React.ComponentProps<Target> : unknown,
-  OuterProps = unknown,
+  OuterProps extends {} = {},
   OuterStatics = unknown
 > {
   <Props = unknown, Statics = unknown>(
@@ -58,7 +58,7 @@ export default function constructWithOptions<
   }
 
   /* This is callable directly as a template function */
-  const templateFunction = <Props = unknown, Statics = unknown>(
+  const templateFunction = <Props extends {} = {}, Statics = unknown>(
     initialStyles: Styles<DerivedProps & OuterProps & Props>,
     ...interpolations: Interpolation<ExecutionContext & DerivedProps & OuterProps & Props>[]
   ) =>

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -59,7 +59,6 @@ function useResolvedAttrs<Props = unknown>(
   const context: ExecutionContext & Props = { ...props, theme };
 
   attrs.forEach(attrDef => {
-    // @ts-expect-error narrowing isn't working properly for some reason
     const resolvedAttrDef = typeof attrDef === 'function' ? attrDef(context) : attrDef;
     let key;
 
@@ -68,10 +67,13 @@ function useResolvedAttrs<Props = unknown>(
       // @ts-expect-error bad types
       context[key] =
         key === 'className'
-          ? joinStrings(context[key], resolvedAttrDef[key])
+          ? // @ts-expect-error bad types
+            joinStrings(context[key], resolvedAttrDef[key])
           : key === 'style'
-          ? { ...context[key], ...resolvedAttrDef[key] }
-          : resolvedAttrDef[key];
+          ? // @ts-expect-error bad types
+            { ...context[key], ...resolvedAttrDef[key] }
+          : // @ts-expect-error bad types
+            resolvedAttrDef[key];
     }
     /* eslint-enable guard-for-in */
   });
@@ -79,7 +81,7 @@ function useResolvedAttrs<Props = unknown>(
   return context;
 }
 
-function useInjectedStyle<T>(
+function useInjectedStyle<T extends {}>(
   componentStyle: ComponentStyle,
   isStatic: boolean,
   resolvedAttrs: T,
@@ -173,7 +175,7 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Extensib
   return createElement(elementToBeCreated, propsForElement);
 }
 
-function createStyledComponent<Target extends WebTarget, OuterProps = unknown, Statics = unknown>(
+function createStyledComponent<Target extends WebTarget, OuterProps extends {}, Statics = unknown>(
   target: Target,
   options: StyledOptions<'web', OuterProps>,
   rules: RuleSet<OuterProps>

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -33,7 +33,6 @@ function useResolvedAttrs<Props = unknown>(
   const resolvedAttrs: BaseExtensibleObject = {};
 
   attrs.forEach(attrDef => {
-    // @ts-expect-error narrowing isn't working properly for some reason
     let resolvedAttrDef = typeof attrDef === 'function' ? attrDef(context) : attrDef;
     let key;
 

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -100,7 +100,7 @@ export type FlattenerResult<Props> =
   | number
   | string
   | string[]
-  | IStyledComponent<any, any>
+  | IStyledComponent<any, any, any>
   | Keyframes;
 
 export interface Stringifier {
@@ -119,7 +119,7 @@ export interface CommonStatics<R extends Runtime, Props> {
   withComponent: any;
 }
 
-export interface IStyledStatics<R extends Runtime, OuterProps = unknown>
+export interface IStyledStatics<R extends Runtime, OuterProps extends {}>
   extends CommonStatics<R, OuterProps> {
   componentStyle: R extends 'web' ? ComponentStyle : never;
   // this is here because we want the uppermost displayName retained in a folding scenario
@@ -157,8 +157,8 @@ type PolymorphicComponentProps<
 interface PolymorphicComponent<
   R extends Runtime,
   FallbackComponent extends StyledTarget<R>,
-  ExpectedProps = unknown,
-  PropsToBeInjectedIntoActualComponent = unknown
+  ExpectedProps extends {},
+  PropsToBeInjectedIntoActualComponent extends {}
 > extends React.ForwardRefExoticComponent<ExpectedProps> {
   <ActualComponent extends StyledTarget<R> = FallbackComponent>(
     props: PolymorphicComponentProps<
@@ -179,7 +179,7 @@ interface PolymorphicComponent<
 export interface IStyledComponent<
   R extends Runtime,
   Target extends StyledTarget<R>,
-  Props = unknown
+  Props extends {}
 > extends PolymorphicComponent<R, Target, Props, ExecutionContext>,
     IStyledStatics<R, Props> {
   defaultProps?: Partial<
@@ -192,7 +192,7 @@ export interface IStyledComponent<
 export interface IStyledComponentFactory<
   R extends Runtime,
   Target extends StyledTarget<R>,
-  Props = unknown,
+  Props extends {},
   Statics = unknown
 > {
   (target: Target, options: StyledOptions<R, Props>, rules: RuleSet<Props>): IStyledComponent<

--- a/packages/styled-components/src/utils/isStaticRules.ts
+++ b/packages/styled-components/src/utils/isStaticRules.ts
@@ -1,4 +1,4 @@
-import { AnyComponent, IStyledComponent, RuleSet } from '../types';
+import { RuleSet } from '../types';
 import isFunction from './isFunction';
 import isStyledComponent from './isStyledComponent';
 
@@ -6,10 +6,7 @@ export default function isStaticRules<Props = unknown>(rules: RuleSet<Props>) {
   for (let i = 0; i < rules.length; i += 1) {
     const rule = rules[i];
 
-    if (
-      isFunction(rule) &&
-      !isStyledComponent(rule as IStyledComponent<'web', any> | AnyComponent)
-    ) {
+    if (isFunction(rule) && !isStyledComponent(rule)) {
       // functions are allowed to be static if they're just being
       // used to get the classname of a nested styled component
       return false;

--- a/packages/styled-components/src/utils/isStyledComponent.ts
+++ b/packages/styled-components/src/utils/isStyledComponent.ts
@@ -1,5 +1,5 @@
 import { IStyledComponent } from '../types';
 
-export default function isStyledComponent(target: any): target is IStyledComponent<'web', any> {
+export default function isStyledComponent(target: any): target is IStyledComponent<'web', any, any> {
   return typeof target === 'object' && 'styledComponentId' in target;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9600,10 +9600,10 @@ type-fest@^1.0.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"


### PR DESCRIPTION
Updating typescript revealed some issues, see full output at the bottom. This PR includes the fixes so that `tsc` runs clean again.

The most interesting part of this starts with the error:

```
src/types.ts:167:7 - error TS2344: Type 'ExpectedProps & PropsToBeInjectedIntoActualComponent'
    does not satisfy the constraint '{}'.
```

which ends up bubbling upward to force changing various `Props = unknown` to `Props extends {}` or `Props extends {} = {}`. I think this is a good thing, and we should be avoiding defaulting to unknown where we can, since it causes more problems down the line.

---

Full output of `yarn tsc` after upgrade, before fixes:

```
src/models/StyledComponent.ts:62:5 - error TS2578: Unused '@ts-expect-error' directive.

62     // @ts-expect-error narrowing isn't working properly for some reason
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/models/StyledComponent.ts:71:39 - error TS7053: Element implicitly has an 'any' type because expression of type '"className"' can't be used to index type 'Partial<Props>'.
  Property 'className' does not exist on type 'Partial<Props>'.

71           ? joinStrings(context[key], resolvedAttrDef[key])
                                         ~~~~~~~~~~~~~~~~~~~~

src/models/StyledComponent.ts:73:35 - error TS7053: Element implicitly has an 'any' type because expression of type '"style"' can't be used to index type 'Partial<Props>'.
  Property 'style' does not exist on type 'Partial<Props>'.

73           ? { ...context[key], ...resolvedAttrDef[key] }
                                     ~~~~~~~~~~~~~~~~~~~~

src/models/StyledComponent.ts:74:13 - error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Partial<Props>'.
  No index signature with a parameter of type 'string' was found on type 'Partial<Props>'.

74           : resolvedAttrDef[key];
               ~~~~~~~~~~~~~~~~~~~~

src/models/StyledComponent.ts:93:46 - error TS2345: Argument of type 'T' is not assignable to parameter of type 'Object'.

93     : componentStyle.generateAndInjectStyles(resolvedAttrs, styleSheet, stylis);
                                                ~~~~~~~~~~~~~

  src/models/StyledComponent.ts:82:27
    82 function useInjectedStyle<T>(
                                 ~
    This type parameter might need an `extends Object` constraint.

src/models/StyledComponent.ts:230:43 - error TS2344: Type 'OuterProps' does not satisfy the constraint 'ExtensibleObject'.

230     return useStyledComponentImpl<Target, OuterProps>(WrappedStyledComponent, props, ref, isStatic);
                                              ~~~~~~~~~~

  src/models/StyledComponent.ts:176:58
    176 function createStyledComponent<Target extends WebTarget, OuterProps = unknown, Statics = unknown>(
                                                                 ~~~~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends ExtensibleObject` constraint.

src/models/StyledNativeComponent.ts:36:5 - error TS2578: Unused '@ts-expect-error' directive.

36     // @ts-expect-error narrowing isn't working properly for some reason
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/types.ts:167:7 - error TS2344: Type 'ExpectedProps & PropsToBeInjectedIntoActualComponent' does not satisfy the constraint '{}'.

167       ExpectedProps & PropsToBeInjectedIntoActualComponent
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```