### PR TITLE
collected fixes for v6 typescript

### DIFF
--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -23,16 +23,16 @@ export interface Styled<
   OuterProps extends object = object,
   OuterStatics = unknown
 > {
-  <Props = unknown, Statics = unknown>(
+  <Props extends object = object, Statics = unknown>(
     initialStyles: Styles<DerivedProps & OuterProps & Props>,
     ...interpolations: Interpolation<ExecutionContext & DerivedProps & OuterProps & Props>[]
   ): IStyledComponent<R, Target, DerivedProps & OuterProps & Props> & OuterStatics & Statics;
-  attrs(
-    attrs: Attrs<ExecutionProps & DerivedProps & OuterProps>
-  ): Styled<R, Target, DerivedProps, OuterProps, OuterStatics>;
-  withConfig(
+  attrs: <Props extends object = object>(
+    attrs: Attrs<ExecutionProps & DerivedProps & OuterProps & Props>
+  ) => Styled<R, Target, DerivedProps, OuterProps & Partial<Props>, OuterStatics>;
+  withConfig: (
     config: StyledOptions<R, DerivedProps & OuterProps>
-  ): Styled<R, Target, DerivedProps, OuterProps, OuterStatics>;
+  ) => Styled<R, Target, DerivedProps, OuterProps, OuterStatics>;
 }
 
 export default function constructWithOptions<
@@ -44,11 +44,8 @@ export default function constructWithOptions<
 >(
   componentConstructor: IStyledComponentFactory<R, any, any, any>,
   tag: Target,
-  options: StyledOptions<R, DerivedProps & OuterProps> = EMPTY_OBJECT as StyledOptions<
-    R,
-    DerivedProps & OuterProps
-  >
-) {
+  options: StyledOptions<R, DerivedProps & OuterProps> = EMPTY_OBJECT
+): Styled<R, Target, DerivedProps, OuterProps, OuterStatics> {
   // We trust that the tag is a valid component as long as it isn't falsish
   // Typically the tag here is a string or function (i.e. class or pure function component)
   // However a component may also be an object if it uses another utility, e.g. React.memo
@@ -74,8 +71,10 @@ export default function constructWithOptions<
     >;
 
   /* Modify/inject new props at runtime */
-  templateFunction.attrs = (attrs: Attrs<ExecutionProps & DerivedProps & OuterProps>) =>
-    constructWithOptions<R, Target, DerivedProps, OuterProps, OuterStatics>(
+  templateFunction.attrs = <Props extends object = object>(
+    attrs: Attrs<ExecutionProps & DerivedProps & OuterProps & Props>
+  ) =>
+    constructWithOptions<R, Target, DerivedProps, OuterProps & Partial<Props>, OuterStatics>(
       componentConstructor,
       tag,
       {

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -1,7 +1,7 @@
 import {
   Attrs,
   ExecutionContext,
-  ExtensibleObject,
+  ExecutionProps,
   Interpolation,
   IStyledComponent,
   IStyledComponentFactory,
@@ -28,7 +28,7 @@ export interface Styled<
     ...interpolations: Interpolation<ExecutionContext & DerivedProps & OuterProps & Props>[]
   ): IStyledComponent<R, Target, DerivedProps & OuterProps & Props> & OuterStatics & Statics;
   attrs(
-    attrs: Attrs<ExtensibleObject & DerivedProps & OuterProps>
+    attrs: Attrs<ExecutionProps & DerivedProps & OuterProps>
   ): Styled<R, Target, DerivedProps, OuterProps, OuterStatics>;
   withConfig(
     config: StyledOptions<R, DerivedProps & OuterProps>
@@ -74,7 +74,7 @@ export default function constructWithOptions<
     >;
 
   /* Modify/inject new props at runtime */
-  templateFunction.attrs = (attrs: Attrs<ExtensibleObject & DerivedProps & OuterProps>) =>
+  templateFunction.attrs = (attrs: Attrs<ExecutionProps & DerivedProps & OuterProps>) =>
     constructWithOptions<R, Target, DerivedProps, OuterProps, OuterStatics>(
       componentConstructor,
       tag,

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -20,7 +20,7 @@ export interface Styled<
   R extends Runtime,
   Target extends StyledTarget<R>,
   DerivedProps = Target extends KnownTarget ? React.ComponentProps<Target> : unknown,
-  OuterProps extends {} = {},
+  OuterProps extends object = object,
   OuterStatics = unknown
 > {
   <Props = unknown, Statics = unknown>(
@@ -58,7 +58,7 @@ export default function constructWithOptions<
   }
 
   /* This is callable directly as a template function */
-  const templateFunction = <Props extends {} = {}, Statics = unknown>(
+  const templateFunction = <Props extends object = object, Statics = unknown>(
     initialStyles: Styles<DerivedProps & OuterProps & Props>,
     ...interpolations: Interpolation<ExecutionContext & DerivedProps & OuterProps & Props>[]
   ) =>

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -39,7 +39,7 @@ export default function constructWithOptions<
   R extends Runtime,
   Target extends StyledTarget<R>,
   DerivedProps = Target extends KnownTarget ? React.ComponentProps<Target> : unknown,
-  OuterProps = unknown, // used for styled<{}>().attrs() so attrs() gets the generic prop context
+  OuterProps extends object = object, // used for styled<{}>().attrs() so attrs() gets the generic prop context
   OuterStatics = unknown
 >(
   componentConstructor: IStyledComponentFactory<R, any, any, any>,

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -6,7 +6,7 @@ import { DefaultTheme, ThemeContext } from '../models/ThemeProvider';
 import StyleSheet from '../sheet';
 import {
   ExecutionContext,
-  ExtensibleObject,
+  ExecutionProps,
   Interpolation,
   RuleSet,
   Stringifier,
@@ -29,7 +29,7 @@ export default function createGlobalStyle<Props extends object>(
     checkDynamicCreation(styledComponentId);
   }
 
-  const GlobalStyleComponent: React.ComponentType<ExtensibleObject> = props => {
+  const GlobalStyleComponent: React.ComponentType<ExecutionProps> = props => {
     const styleSheet = useStyleSheet();
     const stylis = useStylis();
     const theme = React.useContext(ThemeContext);
@@ -74,7 +74,7 @@ export default function createGlobalStyle<Props extends object>(
 
   function renderStyles(
     instance: number,
-    props: ExtensibleObject,
+    props: ExecutionProps,
     styleSheet: StyleSheet,
     theme: DefaultTheme | undefined,
     stylis: Stringifier

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -17,7 +17,7 @@ import determineTheme from '../utils/determineTheme';
 import generateComponentId from '../utils/generateComponentId';
 import css from './css';
 
-export default function createGlobalStyle<Props = unknown>(
+export default function createGlobalStyle<Props extends object>(
   strings: Styles<Props>,
   ...interpolations: Array<Interpolation<Props>>
 ) {

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -18,7 +18,7 @@ const addTag = <T>(arg: T extends any[] ? T & { isCss?: boolean } : T) => {
   return arg;
 };
 
-export default function css<Props>(
+export default function css<Props extends object>(
   styles: Styles<Props>,
   ...interpolations: Interpolation<Props>[]
 ) {

--- a/packages/styled-components/src/constructors/keyframes.ts
+++ b/packages/styled-components/src/constructors/keyframes.ts
@@ -3,7 +3,7 @@ import { Interpolation, Styles } from '../types';
 import generateComponentId from '../utils/generateComponentId';
 import css from './css';
 
-export default function keyframes<Props = unknown>(
+export default function keyframes<Props extends object = object>(
   strings: Styles<Props>,
   ...interpolations: Array<Interpolation<Props>>
 ): Keyframes {

--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { ThemeContext } from '../models/ThemeProvider';
-import { AnyComponent, ExecutionContext } from '../types';
+import { AnyComponent, ExtensibleObject } from '../types';
 import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
 import hoist from '../utils/hoist';
 
 export default function withTheme<T extends AnyComponent>(Component: T) {
-  const WithTheme = React.forwardRef<T, JSX.LibraryManagedAttributes<T, ExecutionContext>>(
+  const WithTheme = React.forwardRef<T, JSX.LibraryManagedAttributes<T, ExtensibleObject>>(
     (props, ref) => {
       const theme = React.useContext(ThemeContext);
       const themeProp = determineTheme(props, theme, Component.defaultProps);

--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { ThemeContext } from '../models/ThemeProvider';
-import { AnyComponent, ExtensibleObject } from '../types';
+import { AnyComponent, ExecutionProps } from '../types';
 import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
 import hoist from '../utils/hoist';
 
 export default function withTheme<T extends AnyComponent>(Component: T) {
-  const WithTheme = React.forwardRef<T, JSX.LibraryManagedAttributes<T, ExtensibleObject>>(
+  const WithTheme = React.forwardRef<T, JSX.LibraryManagedAttributes<T, ExecutionProps>>(
     (props, ref) => {
       const theme = React.useContext(ThemeContext);
       const themeProp = determineTheme(props, theme, Component.defaultProps);

--- a/packages/styled-components/src/models/GlobalStyle.ts
+++ b/packages/styled-components/src/models/GlobalStyle.ts
@@ -3,7 +3,7 @@ import { ExecutionContext, FlattenerResult, RuleSet, Stringifier } from '../type
 import flatten from '../utils/flatten';
 import isStaticRules from '../utils/isStaticRules';
 
-export default class GlobalStyle<Props = unknown> {
+export default class GlobalStyle<Props extends object> {
   componentId: string;
   isStatic: boolean;
   rules: FlattenerResult<Props>;

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -1,8 +1,8 @@
 import transformDeclPairs from 'css-to-react-native';
 import { parse } from 'postcss';
 import {
+  Dict,
   ExecutionContext,
-  ExtensibleObject,
   IInlineStyle,
   IInlineStyleConstructor,
   RuleSet,
@@ -11,7 +11,7 @@ import {
 import flatten from '../utils/flatten';
 import generateComponentId from '../utils/generateComponentId';
 
-let generated: ExtensibleObject = {};
+let generated: Dict<any> = {};
 
 export const resetStyleCache = (): void => {
   generated = {};
@@ -20,7 +20,7 @@ export const resetStyleCache = (): void => {
 /**
  * InlineStyle takes arbitrary CSS and generates a flat object
  */
-export default function makeInlineStyleClass<Props = unknown>(styleSheet: StyleSheet) {
+export default function makeInlineStyleClass<Props extends object>(styleSheet: StyleSheet) {
   const InlineStyle: IInlineStyleConstructor<Props> = class InlineStyle
     implements IInlineStyle<Props>
   {

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -4,7 +4,7 @@ import type {
   AnyComponent,
   Attrs,
   ExecutionContext,
-  ExtensibleObject,
+  ExecutionProps,
   IStyledComponent,
   IStyledComponentFactory,
   IStyledStatics,
@@ -73,7 +73,7 @@ function useInjectedStyle<T extends object>(
   return className;
 }
 
-function useStyledComponentImpl<Target extends WebTarget, Props extends ExtensibleObject>(
+function useStyledComponentImpl<Target extends WebTarget, Props extends ExecutionProps>(
   forwardedComponent: IStyledComponent<'web', Target, Props>,
   props: Props,
   forwardedRef: Ref<Element>,
@@ -228,7 +228,7 @@ function createStyledComponent<
   // statically styled-components don't need to build an execution context object,
   // and shouldn't be increasing the number of class names
   const isStatic = componentStyle.isStatic && attrs.length === 0;
-  function forwardRef(props: ExtensibleObject & OuterProps, ref: Ref<Element>) {
+  function forwardRef(props: ExecutionProps & OuterProps, ref: Ref<Element>) {
     // eslint-disable-next-line
     return useStyledComponentImpl<Target, OuterProps>(WrappedStyledComponent, props, ref, isStatic);
   }

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -48,7 +48,7 @@ function generateId(displayName?: string, parentComponentId?: string): string {
   return parentComponentId ? `${parentComponentId}-${componentId}` : componentId;
 }
 
-function useInjectedStyle<T extends {}>(
+function useInjectedStyle<T extends object>(
   componentStyle: ComponentStyle,
   isStatic: boolean,
   resolvedAttrs: T,
@@ -169,7 +169,11 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Extensib
   return createElement(elementToBeCreated, context);
 }
 
-function createStyledComponent<Target extends WebTarget, OuterProps extends {}, Statics = unknown>(
+function createStyledComponent<
+  Target extends WebTarget,
+  OuterProps extends object,
+  Statics = unknown
+>(
   target: Target,
   options: StyledOptions<'web', OuterProps>,
   rules: RuleSet<OuterProps>

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -154,11 +154,11 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Extensib
     domElements.indexOf(elementToBeCreated as unknown as Extract<typeof domElements, string>) === -1
       ? 'class'
       : 'className'
-  ] = (foldedComponentIds as Array<string | undefined>)
+  ] = foldedComponentIds
     .concat(
       styledComponentId,
-      (generatedClassName !== styledComponentId ? generatedClassName : null) as string,
-      context.className
+      generatedClassName !== styledComponentId ? generatedClassName : '',
+      context.className || ''
     )
     .filter(Boolean)
     .join(' ');

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -109,10 +109,13 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Extensib
         // @ts-expect-error bad types
         p[key] =
           key === 'className'
-            ? joinStrings(p[key], resolvedAttrDef[key])
+            ? // @ts-expect-error bad types
+              joinStrings(p[key], resolvedAttrDef[key])
             : key === 'style'
-            ? { ...p[key], ...resolvedAttrDef[key] }
-            : resolvedAttrDef[key];
+            ? // @ts-expect-error bad types
+              { ...p[key], ...resolvedAttrDef[key] }
+            : // @ts-expect-error bad types
+              resolvedAttrDef[key];
       }
       /* eslint-enable guard-for-in */
 

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -3,7 +3,7 @@ import type {
   Attrs,
   Dict,
   ExecutionContext,
-  ExtensibleObject,
+  ExecutionProps,
   IInlineStyleConstructor,
   IStyledComponent,
   IStyledComponentFactory,
@@ -47,7 +47,7 @@ function useResolvedAttrs<Props extends object>(
   return [context, resolvedAttrs];
 }
 
-interface StyledComponentImplProps extends ExtensibleObject {
+interface StyledComponentImplProps extends ExecutionProps {
   style?: any;
 }
 
@@ -111,7 +111,7 @@ function useStyledComponentImpl<
 export default (InlineStyle: IInlineStyleConstructor<any>) => {
   const createStyledNativeComponent = <
     Target extends NativeTarget,
-    OuterProps extends ExtensibleObject,
+    OuterProps extends ExecutionProps,
     Statics = unknown
   >(
     target: Target,
@@ -148,7 +148,7 @@ export default (InlineStyle: IInlineStyleConstructor<any>) => {
       }
     }
 
-    const forwardRef = (props: ExtensibleObject & OuterProps, ref: React.Ref<any>) =>
+    const forwardRef = (props: ExecutionProps & OuterProps, ref: React.Ref<any>) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useStyledComponentImpl<Target, OuterProps>(WrappedStyledComponent, props, ref);
 

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -1,7 +1,7 @@
 import React, { createElement, Ref, useContext, useMemo } from 'react';
 import type {
   Attrs,
-  BaseExtensibleObject,
+  Dict,
   ExecutionContext,
   ExtensibleObject,
   IInlineStyleConstructor,
@@ -21,7 +21,7 @@ import isStyledComponent from '../utils/isStyledComponent';
 import merge from '../utils/mixinDeep';
 import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
-function useResolvedAttrs<Props = unknown>(
+function useResolvedAttrs<Props extends object>(
   theme: DefaultTheme = EMPTY_OBJECT,
   props: Props,
   attrs: Attrs<Props>[]
@@ -30,7 +30,7 @@ function useResolvedAttrs<Props = unknown>(
   // returns [context, resolvedAttrs]
   // where resolvedAttrs is only the things injected by the attrs themselves
   const context: ExecutionContext & Props = { ...props, theme };
-  const resolvedAttrs: BaseExtensibleObject = {};
+  const resolvedAttrs: Dict<any> = {};
 
   attrs.forEach(attrDef => {
     let resolvedAttrDef = typeof attrDef === 'function' ? attrDef(context) : attrDef;
@@ -47,7 +47,14 @@ function useResolvedAttrs<Props = unknown>(
   return [context, resolvedAttrs];
 }
 
-function useStyledComponentImpl<Target extends NativeTarget, Props extends ExtensibleObject>(
+interface StyledComponentImplProps extends ExtensibleObject {
+  style?: any;
+}
+
+function useStyledComponentImpl<
+  Target extends NativeTarget,
+  Props extends StyledComponentImplProps
+>(
   forwardedComponent: IStyledComponent<'native', Target, Props>,
   props: Props,
   forwardedRef: Ref<any>
@@ -73,8 +80,8 @@ function useStyledComponentImpl<Target extends NativeTarget, Props extends Exten
 
   const elementToBeCreated: NativeTarget = attrs.$as || props.$as || attrs.as || props.as || target;
 
-  const computedProps: ExtensibleObject = attrs !== props ? { ...props, ...attrs } : props;
-  const propsForElement: ExtensibleObject = {};
+  const computedProps: Dict<any> = attrs !== props ? { ...props, ...attrs } : props;
+  const propsForElement: Dict<any> = {};
 
   // eslint-disable-next-line guard-for-in
   for (const key in computedProps) {

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -86,17 +86,15 @@ function useStyledComponentImpl<Target extends NativeTarget, Props extends Exten
     }
   }
 
-  propsForElement.style = useMemo(() => {
-    if (typeof props.style === 'function') {
-      return (state: any) => {
-        return [generatedStyles].concat(props.style(state));
-      };
-    } else if (props.style == null) {
-      return generatedStyles;
-    } else {
-      return [generatedStyles].concat(props.style || []);
-    }
-  }, [props.style, generatedStyles]);
+  propsForElement.style = useMemo(
+    () =>
+      typeof props.style === 'function'
+        ? (state: any) => [generatedStyles].concat(props.style(state))
+        : props.style
+        ? [generatedStyles].concat(props.style)
+        : generatedStyles,
+    [props.style, generatedStyles]
+  );
 
   propsForElement.ref = refToForward;
 

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -119,7 +119,7 @@ export interface CommonStatics<R extends Runtime, Props> {
   withComponent: any;
 }
 
-export interface IStyledStatics<R extends Runtime, OuterProps extends {}>
+export interface IStyledStatics<R extends Runtime, OuterProps extends object>
   extends CommonStatics<R, OuterProps> {
   componentStyle: R extends 'web' ? ComponentStyle : never;
   // this is here because we want the uppermost displayName retained in a folding scenario
@@ -136,7 +136,7 @@ export interface IStyledStatics<R extends Runtime, OuterProps extends {}>
 type PolymorphicComponentProps<
   R extends Runtime,
   ActualComponent extends StyledTarget<R>,
-  PropsToBeInjectedIntoActualComponent extends {},
+  PropsToBeInjectedIntoActualComponent extends object,
   ActualComponentProps = ActualComponent extends KnownTarget
     ? React.ComponentPropsWithRef<ActualComponent>
     : {}
@@ -160,8 +160,8 @@ type PolymorphicComponentProps<
 interface PolymorphicComponent<
   R extends Runtime,
   FallbackComponent extends StyledTarget<R>,
-  ExpectedProps extends {},
-  PropsToBeInjectedIntoActualComponent extends {}
+  ExpectedProps extends object,
+  PropsToBeInjectedIntoActualComponent extends object
 > extends React.ForwardRefExoticComponent<ExpectedProps> {
   <ActualComponent extends StyledTarget<R> = FallbackComponent>(
     props: PolymorphicComponentProps<
@@ -182,7 +182,7 @@ interface PolymorphicComponent<
 export interface IStyledComponent<
   R extends Runtime,
   Target extends StyledTarget<R>,
-  Props extends {}
+  Props extends object
 > extends PolymorphicComponent<R, Target, Props, ExecutionContext>,
     IStyledStatics<R, Props> {
   defaultProps?: Partial<
@@ -195,7 +195,7 @@ export interface IStyledComponent<
 export interface IStyledComponentFactory<
   R extends Runtime,
   Target extends StyledTarget<R>,
-  Props extends {},
+  Props extends object,
   Statics = unknown
 > {
   (target: Target, options: StyledOptions<R, Props>, rules: RuleSet<Props>): IStyledComponent<

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -110,7 +110,7 @@ export interface Stringifier {
 }
 
 export interface ShouldForwardProp<R extends Runtime> {
-  (prop: string, elementToBeCreated?: StyledTarget<R>): boolean;
+  (prop: string, elementToBeCreated: StyledTarget<R>): boolean;
 }
 
 export interface CommonStatics<R extends Runtime, Props extends object> {

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -17,7 +17,7 @@ export { DefaultTheme };
 
 export type AnyComponent<P = any> = ExoticComponentWithDisplayName<P> | React.ComponentType<P>;
 
-export interface StyledOptions<R extends Runtime, Props> {
+export interface StyledOptions<R extends Runtime, Props extends object> {
   attrs?: Attrs<Props>[];
   componentId?: R extends 'web' ? string : never;
   displayName?: string;
@@ -33,11 +33,9 @@ export type WebTarget =
 
 export type NativeTarget = AnyComponent;
 
-export interface BaseExtensibleObject {
-  [key: string]: any;
-}
+export type Dict<T> = { [key: string]: T };
 
-export interface ExtensibleObject extends BaseExtensibleObject {
+export interface ExtensibleObject {
   $as?: KnownTarget;
   $forwardedAs?: KnownTarget;
   as?: KnownTarget;
@@ -49,11 +47,11 @@ export interface ExecutionContext extends ExtensibleObject {
   theme: DefaultTheme;
 }
 
-export interface StyleFunction<Props = BaseExtensibleObject> {
+export interface StyleFunction<Props extends object> {
   (executionContext: ExecutionContext & Props): Interpolation<Props>;
 }
 
-export type Interpolation<Props> =
+export type Interpolation<Props extends object> =
   | StyleFunction<Props>
   | StyledObject<Props>
   | TemplateStringsArray
@@ -67,13 +65,16 @@ export type Interpolation<Props> =
   | IStyledComponent<'web', any, any>
   | Interpolation<Props>[];
 
-export type Attrs<Props> =
+export type Attrs<Props extends object> =
   | (ExtensibleObject & Props)
   | ((props: ExecutionContext & Props) => Partial<Props>);
 
-export type RuleSet<Props> = Interpolation<Props>[];
+export type RuleSet<Props extends object> = Interpolation<Props>[];
 
-export type Styles<Props> = TemplateStringsArray | StyledObject<Props> | StyleFunction<Props>;
+export type Styles<Props extends object> =
+  | TemplateStringsArray
+  | StyledObject<Props>
+  | StyleFunction<Props>;
 
 export type NameGenerator = (hash: number) => string;
 
@@ -87,7 +88,7 @@ export interface Keyframes {
   rules: string;
 }
 
-export interface Flattener<Props> {
+export interface Flattener<Props extends object> {
   (
     chunks: Interpolation<Props>[],
     executionContext: Object | null | undefined,
@@ -95,7 +96,7 @@ export interface Flattener<Props> {
   ): Interpolation<Props>[];
 }
 
-export type FlattenerResult<Props> =
+export type FlattenerResult<Props extends object> =
   | RuleSet<Props>
   | number
   | string
@@ -112,7 +113,7 @@ export interface ShouldForwardProp<R extends Runtime> {
   (prop: string, elementToBeCreated?: StyledTarget<R>): boolean;
 }
 
-export interface CommonStatics<R extends Runtime, Props> {
+export interface CommonStatics<R extends Runtime, Props extends object> {
   attrs: Attrs<Props>[];
   target: StyledTarget<R>;
   shouldForwardProp?: ShouldForwardProp<R>;
@@ -143,11 +144,9 @@ type PolymorphicComponentProps<
 > = React.HTMLAttributes<ActualComponent> &
   Omit<PropsToBeInjectedIntoActualComponent, keyof ActualComponentProps | 'as' | '$as'> &
   ActualComponentProps &
-  (
-    // Only one of "$as" or "as" is allowed. This used to take "$as" in
-    // preference over "as" if both were present, but it's less confusing to be
-    // strict.
-    | {
+  // Only one of "$as" or "as" is allowed. This used to take "$as" in preference
+  // over "as" if both were present, but it's less confusing to be strict.
+  (| {
         $as: ActualComponent;
         as?: never;
       }
@@ -206,19 +205,19 @@ export interface IStyledComponentFactory<
     Statics;
 }
 
-export interface IInlineStyleConstructor<Props = unknown> {
+export interface IInlineStyleConstructor<Props extends object> {
   new (rules: RuleSet<Props>): IInlineStyle<Props>;
 }
 
-export interface IInlineStyle<Props = unknown> {
+export interface IInlineStyle<Props extends object> {
   rules: RuleSet<Props>;
   generateStyleObject(executionContext: Object): Object;
 }
 
 export type StyledTarget<R extends Runtime> = R extends 'web' ? WebTarget : NativeTarget;
 
-export interface StyledObject<Props = ExecutionContext> {
-  [key: string]: BaseExtensibleObject | string | number | StyleFunction<Props>;
+export interface StyledObject<Props extends object = ExecutionContext> {
+  [key: string]: Dict<any> | string | number | StyleFunction<Props>;
 }
 // uncomment when we can eventually override index signatures with more specific types
 // [K in keyof CSS.Properties]: CSS.Properties[K] | ((...any: any[]) => CSS.Properties[K]);
@@ -245,4 +244,4 @@ export interface StyledObject<Props = ExecutionContext> {
  * }
  * ```
  */
-export type CSSProp = string | StyledObject | StyleFunction;
+export type CSSProp = string | StyledObject | StyleFunction<any>;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -35,7 +35,7 @@ export type NativeTarget = AnyComponent;
 
 export type Dict<T> = { [key: string]: T };
 
-export interface ExtensibleObject {
+export interface ExecutionProps {
   $as?: KnownTarget;
   $forwardedAs?: KnownTarget;
   as?: KnownTarget;
@@ -43,7 +43,7 @@ export interface ExtensibleObject {
   theme?: DefaultTheme;
 }
 
-export interface ExecutionContext extends ExtensibleObject {
+export interface ExecutionContext extends ExecutionProps {
   theme: DefaultTheme;
 }
 
@@ -66,7 +66,7 @@ export type Interpolation<Props extends object> =
   | Interpolation<Props>[];
 
 export type Attrs<Props extends object> =
-  | (ExtensibleObject & Props)
+  | (ExecutionProps & Props)
   | ((props: ExecutionContext & Props) => Partial<Props>);
 
 export type RuleSet<Props extends object> = Interpolation<Props>[];
@@ -185,7 +185,7 @@ export interface IStyledComponent<
 > extends PolymorphicComponent<R, Target, Props, ExecutionContext>,
     IStyledStatics<R, Props> {
   defaultProps?: Partial<
-    ExtensibleObject & (Target extends KnownTarget ? React.ComponentProps<Target> : {}) & Props
+    ExecutionProps & (Target extends KnownTarget ? React.ComponentProps<Target> : {}) & Props
   >;
   toString: () => string;
 }

--- a/packages/styled-components/src/utils/createWarnTooManyClasses.ts
+++ b/packages/styled-components/src/utils/createWarnTooManyClasses.ts
@@ -1,9 +1,9 @@
-import { ExtensibleObject } from '../types';
+import { Dict } from '../types';
 
 export const LIMIT = 200;
 
 export default (displayName: string, componentId: string) => {
-  let generatedClasses: ExtensibleObject = {};
+  let generatedClasses: Dict<any> = {};
   let warningSeen = false;
 
   return (className: string) => {

--- a/packages/styled-components/src/utils/determineTheme.ts
+++ b/packages/styled-components/src/utils/determineTheme.ts
@@ -1,8 +1,8 @@
-import { ExtensibleObject } from '../types';
+import { ExecutionProps } from '../types';
 import { EMPTY_OBJECT } from './empties';
 
 export default function determineTheme(
-  props: ExtensibleObject,
+  props: ExecutionProps,
   providedTheme: any,
   defaultProps: any = EMPTY_OBJECT
 ) {

--- a/packages/styled-components/src/utils/empties.ts
+++ b/packages/styled-components/src/utils/empties.ts
@@ -1,4 +1,4 @@
-import { ExtensibleObject } from '../types';
+import { Dict } from '../types';
 
-export const EMPTY_ARRAY = Object.freeze([]) as unknown as Readonly<any[]>;
-export const EMPTY_OBJECT = Object.freeze({}) as Readonly<ExtensibleObject>;
+export const EMPTY_ARRAY = Object.freeze([]) as Readonly<any[]>;
+export const EMPTY_OBJECT = Object.freeze({}) as Readonly<Dict<any>>;

--- a/packages/styled-components/src/utils/error.ts
+++ b/packages/styled-components/src/utils/error.ts
@@ -1,7 +1,7 @@
-import { ExtensibleObject } from '../types';
+import { Dict } from '../types';
 import errorMap from './errors';
 
-const ERRORS: ExtensibleObject = process.env.NODE_ENV !== 'production' ? errorMap : {};
+const ERRORS: Dict<any> = process.env.NODE_ENV !== 'production' ? errorMap : {};
 
 /**
  * super basic version of sprintf

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -2,8 +2,8 @@ import Keyframes from '../models/Keyframes';
 import StyleSheet from '../sheet';
 import {
   AnyComponent,
+  Dict,
   ExecutionContext,
-  ExtensibleObject,
   Interpolation,
   IStyledComponent,
   RuleSet,
@@ -24,7 +24,7 @@ import isStyledComponent from './isStyledComponent';
 const isFalsish = (chunk: any): chunk is undefined | null | false | '' =>
   chunk === undefined || chunk === null || chunk === false || chunk === '';
 
-export const objToCssArray = (obj: ExtensibleObject, prevKey?: string): string[] => {
+export const objToCssArray = (obj: Dict<any>, prevKey?: string): string[] => {
   const rules = [];
 
   for (const key in obj) {
@@ -42,7 +42,7 @@ export const objToCssArray = (obj: ExtensibleObject, prevKey?: string): string[]
   return prevKey ? [`${prevKey} {`, ...rules, '}'] : rules;
 };
 
-export default function flatten<Props = unknown>(
+export default function flatten<Props extends object>(
   chunk: Interpolation<Props>,
   executionContext?: ExecutionContext & Props,
   styleSheet?: StyleSheet,

--- a/packages/styled-components/src/utils/interleave.ts
+++ b/packages/styled-components/src/utils/interleave.ts
@@ -1,6 +1,6 @@
 import { Interpolation } from '../types';
 
-export default function interleave<Props = unknown>(
+export default function interleave<Props extends object>(
   strings: TemplateStringsArray,
   interpolations: Interpolation<Props>[]
 ): Interpolation<Props>[] {

--- a/packages/styled-components/src/utils/isStaticRules.ts
+++ b/packages/styled-components/src/utils/isStaticRules.ts
@@ -2,7 +2,7 @@ import { RuleSet } from '../types';
 import isFunction from './isFunction';
 import isStyledComponent from './isStyledComponent';
 
-export default function isStaticRules<Props = unknown>(rules: RuleSet<Props>) {
+export default function isStaticRules<Props extends object>(rules: RuleSet<Props>) {
   for (let i = 0; i < rules.length; i += 1) {
     const rule = rules[i];
 

--- a/packages/styled-components/src/utils/mixinDeep.ts
+++ b/packages/styled-components/src/utils/mixinDeep.ts
@@ -1,4 +1,4 @@
-import { ExtensibleObject } from '../types';
+import { ExecutionProps } from '../types';
 import isPlainObject from './isPlainObject'
 
 function mixinRecursively(target: any, source: any, forceMerge = false) {
@@ -26,7 +26,7 @@ function mixinRecursively(target: any, source: any, forceMerge = false) {
  * If target is not a POJO or an Array, it will get source properties injected via shallow merge
  * Source objects applied left to right.  Mutates & returns target.  Similar to lodash merge.
  */
-export default function mixinDeep(target: ExtensibleObject = {}, ...sources: any[]) {
+export default function mixinDeep(target: ExecutionProps = {}, ...sources: any[]) {
   for (const source of sources) {
     mixinRecursively(target, source, true);
   }


### PR DESCRIPTION
This fixes a bunch, but not all, of the problems reported in #3800 

The problems fixed:

- [styled components don't emit an error on missing props](https://github.com/styled-components/styled-components/issues/3800#issuecomment-1242746314)
- [`styled(Custom).attrs()` breaks typing of properties](https://github.com/styled-components/styled-components/issues/3800#issuecomment-1242760145)

The changes:

- kill `BaseExtensibleObject` (and use `Dict<any>` explicitly in places that need that kind of thing, where `type Dict<T> = {[k: string]: T}`)
- rename `ExtensibleObject` to `ExecutionProps` since it's essentially a partial `ExecutionContext`
- change lots of `<Props = unknown>` to `<Props extends object>` which allows TS to check and infer a bit more
- allow the `attrs` call to infer or optionally be explicitly typed:

```ts
// infers {device: string}
const X = styled.div.attrs({device: 'mobile'})``

// explicit constraint
const Y = styled.div.attrs<{device: 'desktop' | 'mobile'}>(props => ({
  device: 'mobile',
  ...props,
}))``
```

- improve typing on `shouldForwardProp` since it always receives `elementToBeCreated`

I'm confident these changes don't solve all the problems, but I think it's a good stepping stone. With this merged, I think we should be able to muddle through the remaining issues.