### PR TITLE
fix: css vars mangled by hyphenateStyleName

### DIFF
--- a/packages/styled-components/src/utils/hyphenateStyleName.ts
+++ b/packages/styled-components/src/utils/hyphenateStyleName.ts
@@ -2,8 +2,8 @@
  * inlined version of
  * https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/core/hyphenateStyleName.js
  */
-const uppercaseCheck = /([A-Z])/;
-const uppercasePattern = /([A-Z])/g;
+const uppercaseCheck = /[A-Z]/;
+const uppercasePattern = /[A-Z]/g;
 const msPattern = /^ms-/;
 const prefixAndLowerCase = (char: string): string => `-${char.toLowerCase()}`;
 
@@ -21,7 +21,7 @@ const prefixAndLowerCase = (char: string): string => `-${char.toLowerCase()}`;
  * is converted to `-ms-`.
  */
 export default function hyphenateStyleName(string: string) {
-  return uppercaseCheck.test(string)
+  return uppercaseCheck.test(string) && !string.startsWith('--')
     ? string.replace(uppercasePattern, prefixAndLowerCase).replace(msPattern, '-ms-')
     : string;
 }

--- a/packages/styled-components/src/utils/test/hyphenateStyleName.test.ts
+++ b/packages/styled-components/src/utils/test/hyphenateStyleName.test.ts
@@ -1,0 +1,9 @@
+import hyphenateStyleName from '../hyphenateStyleName';
+
+test('hyphenateStyleName', () => {
+  expect(hyphenateStyleName('backgroundColor')).toEqual('background-color')
+  expect(hyphenateStyleName('MozTransition')).toEqual('-moz-transition')
+  expect(hyphenateStyleName('msTransition')).toEqual('-ms-transition')
+  // https://github.com/styled-components/styled-components/issues/3810
+  expect(hyphenateStyleName('--MyColor')).toEqual('--MyColor')
+})


### PR DESCRIPTION
Fixes #3810. Along with not mangling, CSS vars are case sensitive so the caps need to be preserved.