### PR TITLE
Pass ExpectedProps to PolymorphicComponentProps (v6)

### DIFF
--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -164,13 +164,15 @@ interface PolymorphicComponent<
     props: PolymorphicComponentProps<
       R,
       ActualComponent,
-      ExpectedProps & PropsToBeInjectedIntoActualComponent
+      ExpectedProps & PropsToBeInjectedIntoActualComponent,
+      ExpectedProps
     >
   ): React.ReactElement<
     PolymorphicComponentProps<
       R,
       ActualComponent,
-      ExecutionContext & ExpectedProps & PropsToBeInjectedIntoActualComponent
+      ExecutionContext & ExpectedProps & PropsToBeInjectedIntoActualComponent,
+      ExpectedProps
     >,
     ActualComponent
   >;


### PR DESCRIPTION
Passes `ExpectedProps` to `PolymorphicComponent` as last argument to fix type inference with `react-docgen` and probably other tools. There is probably some problem with the inference from `ActualComponent`. Keeps inference from `styled(Component)` notation.