### PR TITLE
Refactor else blok is unnecesary

### DIFF
--- a/packages/benchmarks/src/app/Benchmark/timing.js
+++ b/packages/benchmarks/src/app/Benchmark/timing.js
@@ -10,7 +10,6 @@ export function now() {
     const secInMS = seconds * MS_PER_S;
     const nSecInMS = nanoseconds / NS_PER_MS;
     return secInMS + nSecInMS;
-  } else {
-    return Date.now();
   }
+  return Date.now();
 }

--- a/packages/benchmarks/src/cases/SierpinskiTriangle.js
+++ b/packages/benchmarks/src/cases/SierpinskiTriangle.js
@@ -1,7 +1,7 @@
-import { BenchmarkType } from '../app/Benchmark';
+import { interpolateBuPu, interpolatePurples, interpolateRdPu } from 'd3-scale-chromatic';
 import { number, object } from 'prop-types';
 import React from 'react';
-import { interpolatePurples, interpolateBuPu, interpolateRdPu } from 'd3-scale-chromatic';
+import { BenchmarkType } from '../app/Benchmark';
 
 const targetSize = 10;
 
@@ -16,12 +16,12 @@ class SierpinskiTriangle extends React.Component {
     renderCount: number,
     s: number,
     x: number,
-    y: number
+    y: number,
   };
 
   static defaultProps = {
     depth: 0,
-    renderCount: 0
+    renderCount: 0,
   };
 
   render() {
@@ -45,7 +45,7 @@ class SierpinskiTriangle extends React.Component {
         }
 
         // introduce randomness to ensure that repeated runs don't produce the same colors
-        const color = fn(renderCount * Math.random() / 20);
+        const color = fn((renderCount * Math.random()) / 20);
         return (
           <Dot color={color} size={targetSize} x={x - targetSize / 2} y={y - targetSize / 2} />
         );

--- a/packages/benchmarks/src/cases/SierpinskiTriangle.js
+++ b/packages/benchmarks/src/cases/SierpinskiTriangle.js
@@ -81,9 +81,9 @@ class SierpinskiTriangle extends React.Component {
           />
         </React.Fragment>
       );
-    } else {
-      return <span style={{ color: 'white' }}>No implementation available</span>;
     }
+
+    return <span style={{ color: 'white' }}>No implementation available</span>;
   }
 }
 

--- a/packages/benchmarks/src/implementations/inline-styles/View.js
+++ b/packages/benchmarks/src/implementations/inline-styles/View.js
@@ -2,11 +2,7 @@
 import React from 'react';
 
 const compose = (s1, s2) => {
-  if (s1 && s2) {
-    return { ...s1, ...s2 };
-  } else {
-    return s1 || s2;
-  }
+  return s1 && s2 ? { ...s1, ...s2 } : s1 || s2;
 };
 
 class View extends React.Component {

--- a/packages/benchmarks/src/implementations/inline-styles/View.js
+++ b/packages/benchmarks/src/implementations/inline-styles/View.js
@@ -26,7 +26,7 @@ const viewStyle = {
   position: 'relative',
   // fix flexbox bugs
   minHeight: 0,
-  minWidth: 0
+  minWidth: 0,
 };
 
 export default View;

--- a/packages/styled-components/src/constructors/test/keyframes.test.tsx
+++ b/packages/styled-components/src/constructors/test/keyframes.test.tsx
@@ -263,11 +263,11 @@ describe('keyframes', () => {
             `,
           ''
         );
-      } else {
-        return css`
-          ${animation === 'slide' ? slideAnimation : opacityAnimation} 1s linear
-        `;
       }
+
+      return css`
+        ${animation === 'slide' ? slideAnimation : opacityAnimation} 1s linear
+      `;
     };
 
     const Foo = styled.div`

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -93,9 +93,9 @@ function useStyledComponentImpl<Target extends NativeTarget, Props extends Exten
       };
     } else if (props.style == null) {
       return generatedStyles;
-    } else {
-      return [generatedStyles].concat(props.style || []);
     }
+
+    return [generatedStyles].concat(props.style || []);
   }, [props.style, generatedStyles]);
 
   propsForElement.ref = refToForward;

--- a/packages/styled-components/src/sheet/Tag.ts
+++ b/packages/styled-components/src/sheet/Tag.ts
@@ -7,9 +7,9 @@ export const makeTag = ({ isServer, useCSSOMInjection, target }: SheetOptions) =
     return new VirtualTag(target);
   } else if (useCSSOMInjection) {
     return new CSSOMTag(target);
-  } else {
-    return new TextTag(target);
   }
+
+  return new TextTag(target);
 };
 
 export const CSSOMTag = class CSSOMTag implements Tag {
@@ -47,11 +47,7 @@ export const CSSOMTag = class CSSOMTag implements Tag {
   getRule(index: number): string {
     const rule = this.sheet.cssRules[index];
     // Avoid IE11 quirk where cssText is inaccessible on some invalid rules
-    if (rule !== undefined && typeof rule.cssText === 'string') {
-      return rule.cssText;
-    } else {
-      return '';
-    }
+    return rule !== undefined && typeof rule.cssText === 'string' ? rule.cssText : '';
   }
 };
 
@@ -74,9 +70,9 @@ export const TextTag = class TextTag implements Tag {
       this.element.insertBefore(node, refNode || null);
       this.length++;
       return true;
-    } else {
-      return false;
     }
+
+    return false;
   }
 
   deleteRule(index: number) {
@@ -85,11 +81,7 @@ export const TextTag = class TextTag implements Tag {
   }
 
   getRule(index: number) {
-    if (index < this.length) {
-      return this.nodes[index].textContent as string;
-    } else {
-      return '';
-    }
+    return index < this.length ? (this.nodes[index].textContent as string) : '';
   }
 };
 
@@ -109,9 +101,9 @@ export const VirtualTag = class VirtualTag implements Tag {
       this.rules.splice(index, 0, rule);
       this.length++;
       return true;
-    } else {
-      return false;
     }
+
+    return false;
   }
 
   deleteRule(index: number) {
@@ -120,10 +112,6 @@ export const VirtualTag = class VirtualTag implements Tag {
   }
 
   getRule(index: number) {
-    if (index < this.length) {
-      return this.rules[index];
-    } else {
-      return '';
-    }
+    return index < this.length ? this.rules[index] : '';
   }
 };

--- a/packages/styled-components/src/test/utils.ts
+++ b/packages/styled-components/src/test/utils.ts
@@ -91,10 +91,10 @@ export const expectCSSMatches = (
     const stripped = stripWhitespace(stripComments(css));
     expect(stripped).toEqual(stripWhitespace(expectation));
     return stripped;
-  } else {
-    expect(css).toEqual(expectation);
-    return css;
   }
+
+  expect(css).toEqual(expectation);
+  return css;
 };
 
 export const getRenderedCSS = () => {

--- a/packages/styled-components/src/utils/error.ts
+++ b/packages/styled-components/src/utils/error.ts
@@ -31,10 +31,11 @@ export default function throwStyledComponentsError(
 ) {
   if (process.env.NODE_ENV === 'production') {
     return new Error(
-      `An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#${code} for more information.${interpolations.length > 0 ? ` Args: ${interpolations.join(', ')}` : ''
+      `An error occurred. See https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/errors.md#${code} for more information.${
+        interpolations.length > 0 ? ` Args: ${interpolations.join(', ')}` : ''
       }`
     );
-  } else {
-    return new Error(format(ERRORS[code], ...interpolations).trim());
   }
+
+  return new Error(format(ERRORS[code], ...interpolations).trim());
 }


### PR DESCRIPTION
## Summary
Some codes do not need else block because it has been returned ahead in if block.
It is able to eliminate the complexity of the code (although it is slightly).

> If an if block always executes a return statement, the subsequent else block is unnecessary.

## How did you test this change?
I run all test cases and confirmed NOT change the logic of code execution.