### PR TITLE
feat: move style injection from render to useInsetionEffect

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -62,6 +62,19 @@ function useInjectedStyle<T extends object>(
     ssc.stylis
   );
 
+  if (ssc.styleSheet.server) {
+    componentStyle.flushStyles(ssc.styleSheet, ssc.stylis);
+  }
+
+  if (!__SERVER__) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    // @ts-expect-error still using React 17 types for the time being
+    (React.useInsertionEffect || React.useLayoutEffect)(() => {
+      componentStyle.flushStyles(ssc.styleSheet, ssc.stylis);
+    });
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   if (process.env.NODE_ENV !== 'production') useDebugValue(className);
 
   return className;


### PR DESCRIPTION
Atm this is just a quick experiment if we can utilize `useInsertionEffect` instead of injecting styles in render which isn't the best for performance. E.g. following the guidelines described in https://github.com/reactwg/react-18/discussions/110


From my limited and quick testing this seems to work fine, is there anything I'm missing and does this sound like a good idea to you? If that is the case I'll clean up the PR a little more, e.g. renaming `generateAndInjectStyles` to something more fitting