### PR TITLE
fix: missing polymorphic props

### DIFF
--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -148,11 +148,17 @@ type PolymorphicComponentProps<R extends Runtime, E extends StyledTarget<R>, P e
 } & P &
   (E extends KnownTarget ? Omit<React.ComponentProps<E>, keyof P | 'as'> : object);
 
+/**
+ * Remove the function call signature, keeping the additional properties.
+ * https://stackoverflow.com/a/62502740/347386
+ */
+type OmitSignatures<T> = Pick<T, keyof T>;
+
 interface PolymorphicComponent<
   R extends Runtime,
   P extends object,
   FallbackComponent extends StyledTarget<R>
-> extends React.ForwardRefExoticComponent<P> {
+> extends OmitSignatures<React.ForwardRefExoticComponent<P>> {
   <E extends StyledTarget<R> = FallbackComponent>(
     props: PolymorphicComponentProps<R, E, P>
   ): React.ReactElement | null;


### PR DESCRIPTION
This fixes the problem where `ZProps` is missing `as` in the example below:

```
const Z = styled.div``
type ZProps = ComponentProps<typeof Z>
```

See https://github.com/styled-components/styled-components/issues/3800#issuecomment-1268523022 for the original report against beta.3