### PR TITLE
[v6] Types: add overloads without props generic

### DIFF
--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -51,9 +51,9 @@ export interface Styled<
   OuterStatics extends object = object
 > {
   (
-    initialStyles: Styles<OuterProps & OuterProps>,
-    ...interpolations: Interpolation<OuterProps & OuterProps>[]
-  ): IStyledComponent<R, Target, OuterProps & OuterProps> & OuterStatics;
+    initialStyles: Styles<OuterProps>,
+    ...interpolations: Interpolation<OuterProps>[]
+  ): IStyledComponent<R, Target, OuterProps> & OuterStatics;
   <Props extends object = object, Statics extends object = object>(
     initialStyles: Styles<OuterProps & Props>,
     ...interpolations: Interpolation<OuterProps & Props>[]

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -8,7 +8,7 @@ import {
   Runtime,
   StyledOptions,
   StyledTarget,
-  Styles,
+  Styles
 } from '../types';
 import { EMPTY_OBJECT } from '../utils/empties';
 import styledError from '../utils/error';
@@ -50,6 +50,10 @@ export interface Styled<
     : object,
   OuterStatics extends object = object
 > {
+  (
+    initialStyles: Styles<OuterProps & OuterProps>,
+    ...interpolations: Interpolation<OuterProps & OuterProps>[]
+  ): IStyledComponent<R, Target, OuterProps & OuterProps> & OuterStatics;
   <Props extends object = object, Statics extends object = object>(
     initialStyles: Styles<OuterProps & Props>,
     ...interpolations: Interpolation<OuterProps & Props>[]

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -10,7 +10,7 @@ import {
   Interpolation,
   RuleSet,
   Stringifier,
-  Styles,
+  Styles
 } from '../types';
 import { checkDynamicCreation } from '../utils/checkDynamicCreation';
 import determineTheme from '../utils/determineTheme';
@@ -21,7 +21,7 @@ export default function createGlobalStyle<Props extends object>(
   strings: Styles<Props>,
   ...interpolations: Array<Interpolation<Props>>
 ) {
-  const rules = css(strings, ...interpolations) as RuleSet<Props>;
+  const rules = css<Props>(strings, ...interpolations) as RuleSet<Props>;
   const styledComponentId = `sc-global-${generateComponentId(JSON.stringify(rules))}`;
   const globalStyle = new GlobalStyle<Props>(rules, styledComponentId);
 
@@ -29,7 +29,7 @@ export default function createGlobalStyle<Props extends object>(
     checkDynamicCreation(styledComponentId);
   }
 
-  const GlobalStyleComponent: React.ComponentType<ExecutionProps> = props => {
+  const GlobalStyleComponent: React.ComponentType<ExecutionProps & Props> = props => {
     const styleSheet = useStyleSheet();
     const stylis = useStylis();
     const theme = React.useContext(ThemeContext);

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -9,7 +9,7 @@ import isPlainObject from '../utils/isPlainObject';
  * Used when flattening object styles to determine if we should
  * expand an array of styles.
  */
-const addTag = <T>(arg: T extends any[] ? T & { isCss?: boolean } : T) => {
+const addTag = <T>(arg: T extends any[] ? T & { isCss?: boolean } : T): T => {
   if (Array.isArray(arg)) {
     // eslint-disable-next-line no-param-reassign
     (arg as any[] & { isCss?: boolean }).isCss = true;
@@ -18,10 +18,18 @@ const addTag = <T>(arg: T extends any[] ? T & { isCss?: boolean } : T) => {
   return arg;
 };
 
-export default function css<Props extends object>(
+function css(
+  styles: Styles<{}>,
+  ...interpolations: Interpolation<{}>[]
+): Interpolation<{}>;
+function css<Props extends object>(
   styles: Styles<Props>,
   ...interpolations: Interpolation<Props>[]
-) {
+): Interpolation<Props>;
+function css<Props extends {} = {}>(
+  styles: Styles<Props>,
+  ...interpolations: Interpolation<Props>[]
+): Interpolation<Props> {
   if (isFunction(styles) || isPlainObject(styles)) {
     const styleFunctionOrObject = styles as StyleFunction<Props> | StyledObject;
 
@@ -47,3 +55,5 @@ export default function css<Props extends object>(
 
   return addTag(flatten<Props>(interleave<Props>(styleStringArray, interpolations)));
 }
+
+export default css;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -77,7 +77,7 @@ export type Attrs<Props extends object> =
   | (ExecutionProps & Props)
   | ((props: ExecutionContext & Props) => Partial<Props>);
 
-export type RuleSet<Props extends object> = Interpolation<ExecutionContext & Props>[];
+export type RuleSet<Props extends object> = Interpolation<Props>[];
 
 export type Styles<Props extends object> =
   | TemplateStringsArray


### PR DESCRIPTION
Fixes issues from this comment: https://github.com/styled-components/styled-components/issues/3800#issuecomment-1247256052