### PR TITLE
Fix the return type for `css` tag

### DIFF
--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -4,7 +4,6 @@ import {
   IStyledComponent,
   IStyledComponentFactory,
   KnownTarget,
-  RuleSet,
   Runtime,
   StyledOptions,
   StyledTarget,
@@ -86,12 +85,7 @@ export default function constructWithOptions<
   const templateFunction = <Props extends object = object, Statics extends object = object>(
     initialStyles: Styles<OuterProps & Props>,
     ...interpolations: Interpolation<OuterProps & Props>[]
-  ) =>
-    componentConstructor<Props, Statics>(
-      tag,
-      options,
-      css(initialStyles, ...interpolations) as RuleSet<OuterProps & Props>
-    );
+  ) => componentConstructor<Props, Statics>(tag, options, css(initialStyles, ...interpolations));
 
   /* Modify/inject new props at runtime */
   templateFunction.attrs = <T extends Attrs<object>>(

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -4,14 +4,7 @@ import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheet, useStylis } from '../models/StyleSheetManager';
 import { DefaultTheme, ThemeContext } from '../models/ThemeProvider';
 import StyleSheet from '../sheet';
-import {
-  ExecutionContext,
-  ExecutionProps,
-  Interpolation,
-  RuleSet,
-  Stringifier,
-  Styles,
-} from '../types';
+import { ExecutionContext, ExecutionProps, Interpolation, Stringifier, Styles } from '../types';
 import { checkDynamicCreation } from '../utils/checkDynamicCreation';
 import determineTheme from '../utils/determineTheme';
 import generateComponentId from '../utils/generateComponentId';
@@ -21,7 +14,7 @@ export default function createGlobalStyle<Props extends object>(
   strings: Styles<Props>,
   ...interpolations: Array<Interpolation<Props>>
 ) {
-  const rules = css(strings, ...interpolations) as RuleSet<Props>;
+  const rules = css(strings, ...interpolations);
   const styledComponentId = `sc-global-${generateComponentId(JSON.stringify(rules))}`;
   const globalStyle = new GlobalStyle<Props>(rules, styledComponentId);
 

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -1,4 +1,4 @@
-import { Interpolation, StyledObject, StyleFunction, Styles } from '../types';
+import { Interpolation, RuleSet, StyledObject, StyleFunction, Styles } from '../types';
 import { EMPTY_ARRAY } from '../utils/empties';
 import flatten from '../utils/flatten';
 import interleave from '../utils/interleave';
@@ -9,11 +9,9 @@ import isPlainObject from '../utils/isPlainObject';
  * Used when flattening object styles to determine if we should
  * expand an array of styles.
  */
-const addTag = <T>(arg: T extends any[] ? T & { isCss?: boolean } : T) => {
-  if (Array.isArray(arg)) {
-    // eslint-disable-next-line no-param-reassign
-    (arg as any[] & { isCss?: boolean }).isCss = true;
-  }
+const addTag = <T extends RuleSet<any>>(arg: T): T => {
+  // eslint-disable-next-line no-param-reassign
+  (arg as any[] & { isCss?: boolean }).isCss = true;
 
   return arg;
 };
@@ -21,7 +19,7 @@ const addTag = <T>(arg: T extends any[] ? T & { isCss?: boolean } : T) => {
 export default function css<Props extends object>(
   styles: Styles<Props>,
   ...interpolations: Interpolation<Props>[]
-) {
+): RuleSet<Props> {
   if (isFunction(styles) || isPlainObject(styles)) {
     const styleFunctionOrObject = styles as StyleFunction<Props> | StyledObject;
 
@@ -42,7 +40,7 @@ export default function css<Props extends object>(
     styleStringArray.length === 1 &&
     typeof styleStringArray[0] === 'string'
   ) {
-    return styleStringArray;
+    return flatten<Props>(styleStringArray);
   }
 
   return addTag(flatten<Props>(interleave<Props>(styleStringArray, interpolations)));

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -277,11 +277,7 @@ function createStyledComponent<
       componentId: newComponentId,
     } as StyledOptions<'web', OuterProps & Props>;
 
-    return createStyledComponent<Target, OuterProps & Props, Statics>(
-      tag,
-      newOptions,
-      rules as RuleSet<OuterProps & Props>
-    );
+    return createStyledComponent<Target, OuterProps & Props, Statics>(tag, newOptions, rules);
   };
 
   Object.defineProperty(WrappedStyledComponent, 'defaultProps', {

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -190,7 +190,7 @@ export default (InlineStyle: IInlineStyleConstructor<any>) => {
       return createStyledNativeComponent<Target, OuterProps & Props, Statics>(
         tag,
         newOptions,
-        rules as RuleSet<OuterProps & Props>
+        rules
       );
     };
 

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -47,28 +47,28 @@ export default function flatten<Props extends object>(
   executionContext?: ExecutionContext & Props,
   styleSheet?: StyleSheet,
   stylisInstance?: Stringifier
-): Interpolation<Props> | RuleSet<Props> {
+): RuleSet<Props> {
   if (Array.isArray(chunk)) {
     const ruleSet: RuleSet<Props> = [];
 
     for (let i = 0, len = chunk.length, result; i < len; i += 1) {
       result = flatten<Props>(chunk[i], executionContext, styleSheet, stylisInstance);
 
-      if (result === '') continue;
-      else if (Array.isArray(result)) ruleSet.push(...result);
-      else ruleSet.push(result);
+      if (result.length === 0) continue;
+
+      ruleSet.push(...result);
     }
 
     return ruleSet;
   }
 
   if (isFalsish(chunk)) {
-    return '';
+    return [];
   }
 
   /* Handle other components */
   if (isStyledComponent(chunk)) {
-    return `.${(chunk as unknown as IStyledComponent<'web', 'div', any>).styledComponentId}`;
+    return [`.${(chunk as unknown as IStyledComponent<'web', 'div', any>).styledComponentId}`];
   }
 
   /* Either execute or defer the function */
@@ -93,16 +93,20 @@ export default function flatten<Props extends object>(
       }
 
       return flatten(result, executionContext, styleSheet, stylisInstance);
-    } else return chunk as unknown as IStyledComponent<'web', 'div', any>;
+    } else {
+      return [chunk as unknown as IStyledComponent<'web', 'div', any>];
+    }
   }
 
   if (chunk instanceof Keyframes) {
     if (styleSheet) {
       chunk.inject(styleSheet, stylisInstance);
-      return chunk.getName(stylisInstance);
-    } else return chunk;
+      return [chunk.getName(stylisInstance)];
+    } else {
+      return [chunk];
+    }
   }
 
   /* Handle objects */
-  return isPlainObject(chunk) ? objToCssArray(chunk as StyledObject) : chunk.toString();
+  return isPlainObject(chunk) ? objToCssArray(chunk as StyledObject) : [chunk.toString()];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9249,7 +9249,7 @@ style-loader@^3.3.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "6.0.0-beta.2"
+  version "6.0.0-beta.3"
   dependencies:
     "@babel/cli" "^7.18.6"
     "@babel/core" "^7.18.6"


### PR DESCRIPTION
At present the following yields a type error because the return type of `css` is inferred weirdly from a composition of several functions.

```ts
import { css } from 'styled-components';

const child = css``;
const parent = css`
  ${child}
`;
```

In the above, the type of `child` is the following which is unable to be nested inside of another css string (i.e. `parent`).

```ts
string | number | false | Keyframes | IStyledComponent<"web", any, any> | TemplateStringsArray | StyledObject<Props> | StyleFunction<Props> | RuleSet<Props> & { isCss?: boolean | undefined; }) | null | undefined;
```

This PR fixes the problem by:
- Explicitly defining the return type of `css` as `RuleSet<Props>` and then...
- Updating the `flatten` function to always return a `RuleSet`.

It seems like this might be what is already desired internally as I was able to remove type casting of `css(...) as RuleSet<X>` in several places.