### PR TITLE
Forces type imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,10 @@
       "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "ignoreRestSiblings": true }
     ],
+    "@typescript-eslint/consistent-type-imports": [
+      "warn",
+      { "prefer": "type-imports", "disallowTypeAnnotations": false }
+    ],
     "react-hooks/rules-of-hooks": "error",
     "class-methods-use-this": 0,
     "curly": [2, "multi-line"],

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Attrs,
   Interpolation,
   IStyledComponent,

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -2,9 +2,10 @@ import React from 'react';
 import { STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheet, useStylis } from '../models/StyleSheetManager';
-import { DefaultTheme, ThemeContext } from '../models/ThemeProvider';
-import StyleSheet from '../sheet';
-import {
+import type { DefaultTheme} from '../models/ThemeProvider';
+import { ThemeContext } from '../models/ThemeProvider';
+import type StyleSheet from '../sheet';
+import type {
   ExecutionContext,
   ExecutionProps,
   Interpolation,

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -1,4 +1,4 @@
-import { Interpolation, StyledObject, StyleFunction, Styles } from '../types';
+import type { Interpolation, StyledObject, StyleFunction, Styles } from '../types';
 import { EMPTY_ARRAY } from '../utils/empties';
 import flatten from '../utils/flatten';
 import interleave from '../utils/interleave';

--- a/packages/styled-components/src/constructors/keyframes.ts
+++ b/packages/styled-components/src/constructors/keyframes.ts
@@ -1,5 +1,5 @@
 import Keyframes from '../models/Keyframes';
-import { Interpolation, Styles } from '../types';
+import type { Interpolation, Styles } from '../types';
 import generateComponentId from '../utils/generateComponentId';
 import css from './css';
 

--- a/packages/styled-components/src/constructors/styled.tsx
+++ b/packages/styled-components/src/constructors/styled.tsx
@@ -1,7 +1,8 @@
 import createStyledComponent from '../models/StyledComponent';
-import { WebTarget } from '../types';
+import type { WebTarget } from '../types';
 import domElements from '../utils/domElements';
-import constructWithOptions, { Styled } from './constructWithOptions';
+import type { Styled } from './constructWithOptions';
+import constructWithOptions from './constructWithOptions';
 
 const baseStyled = <Target extends WebTarget>(tag: Target) =>
   constructWithOptions<'web', Target>(createStyledComponent, tag);

--- a/packages/styled-components/src/global.d.ts
+++ b/packages/styled-components/src/global.d.ts
@@ -1,5 +1,5 @@
 declare module '@babel/helper-module-imports' {
-  import { NodePath, types } from '@babel/core';
+  import type { NodePath, types } from '@babel/core';
 
   export function addDefault(
     program: NodePath,

--- a/packages/styled-components/src/hoc/withTheme.spec.tsx
+++ b/packages/styled-components/src/hoc/withTheme.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import ThemeProvider from '../models/ThemeProvider';
-import { ExecutionContext } from '../types';
+import type { ExecutionContext } from '../types';
 import withTheme from './withTheme';
 
 describe('withTheme', () => {

--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeContext } from '../models/ThemeProvider';
-import { AnyComponent, ExecutionProps } from '../types';
+import type { AnyComponent, ExecutionProps } from '../types';
 import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
 import hoist from '../utils/hoist';

--- a/packages/styled-components/src/hooks/useTheme.ts
+++ b/packages/styled-components/src/hooks/useTheme.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import { DefaultTheme, ThemeContext } from '../models/ThemeProvider';
+import type { DefaultTheme} from '../models/ThemeProvider';
+import { ThemeContext } from '../models/ThemeProvider';
 
 const useTheme = (): DefaultTheme | undefined => useContext(ThemeContext);
 

--- a/packages/styled-components/src/macro/index.ts
+++ b/packages/styled-components/src/macro/index.ts
@@ -1,7 +1,8 @@
-import { types } from '@babel/core';
+import type { types } from '@babel/core';
 import { addDefault, addNamed } from '@babel/helper-module-imports';
 import traverse from '@babel/traverse';
-import { createMacro, MacroParams } from 'babel-plugin-macros';
+import type { MacroParams } from 'babel-plugin-macros';
+import { createMacro } from 'babel-plugin-macros';
 import babelPlugin from 'babel-plugin-styled-components';
 
 function styledComponentsMacro({

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -1,6 +1,6 @@
 import { SC_VERSION } from '../constants';
 import StyleSheet from '../sheet';
-import { RuleSet, Stringifier } from '../types';
+import type { RuleSet, Stringifier } from '../types';
 import flatten from '../utils/flatten';
 import generateName from '../utils/generateAlphabeticName';
 import { hash, phash } from '../utils/hash';

--- a/packages/styled-components/src/models/GlobalStyle.ts
+++ b/packages/styled-components/src/models/GlobalStyle.ts
@@ -1,5 +1,5 @@
 import StyleSheet from '../sheet';
-import { ExecutionContext, FlattenerResult, RuleSet, Stringifier } from '../types';
+import type { ExecutionContext, FlattenerResult, RuleSet, Stringifier } from '../types';
 import flatten from '../utils/flatten';
 import isStaticRules from '../utils/isStaticRules';
 

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -1,6 +1,6 @@
 import transformDeclPairs from 'css-to-react-native';
 import { parse } from 'postcss';
-import {
+import type {
   Dict,
   ExecutionContext,
   IInlineStyle,

--- a/packages/styled-components/src/models/Keyframes.ts
+++ b/packages/styled-components/src/models/Keyframes.ts
@@ -1,5 +1,5 @@
-import StyleSheet from '../sheet';
-import { Keyframes as KeyframesType, Stringifier } from '../types';
+import type StyleSheet from '../sheet';
+import type { Keyframes as KeyframesType, Stringifier } from '../types';
 import styledError from '../utils/error';
 import { mainStylis } from './StyleSheetManager';
 

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import React from 'react';
 import type * as streamInternal from 'stream';
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 import { IS_BROWSER, SC_ATTR, SC_ATTR_VERSION, SC_VERSION } from '../constants';
 import StyleSheet from '../sheet';
 import styledError from '../utils/error';

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import shallowequal from 'shallowequal';
 import StyleSheet from '../sheet';
-import { Stringifier } from '../types';
+import type { Stringifier } from '../types';
 import createStylisInstance from '../utils/stylis';
 
 type Props = {

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -1,4 +1,5 @@
-import React, { createElement, Ref, useContext, useDebugValue } from 'react';
+import type { Ref} from 'react';
+import React, { createElement, useContext, useDebugValue } from 'react';
 import { SC_VERSION } from '../constants';
 import type {
   AnyComponent,

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -1,4 +1,5 @@
-import React, { createElement, Ref, useContext, useMemo } from 'react';
+import type { Ref} from 'react';
+import React, { createElement, useContext, useMemo } from 'react';
 import type {
   Attrs,
   Dict,
@@ -19,7 +20,8 @@ import generateDisplayName from '../utils/generateDisplayName';
 import hoist from '../utils/hoist';
 import isStyledComponent from '../utils/isStyledComponent';
 import merge from '../utils/mixinDeep';
-import { DefaultTheme, ThemeContext } from './ThemeProvider';
+import type { DefaultTheme} from './ThemeProvider';
+import { ThemeContext } from './ThemeProvider';
 
 function useResolvedAttrs<Props extends object>(
   theme: DefaultTheme = EMPTY_OBJECT,

--- a/packages/styled-components/src/native/index.ts
+++ b/packages/styled-components/src/native/index.ts
@@ -1,12 +1,13 @@
-import React from 'react';
-import constructWithOptions, { Styled } from '../constructors/constructWithOptions';
+import type React from 'react';
+import type { Styled } from '../constructors/constructWithOptions';
+import constructWithOptions from '../constructors/constructWithOptions';
 import css from '../constructors/css';
 import withTheme from '../hoc/withTheme';
 import useTheme from '../hooks/useTheme';
 import _InlineStyle from '../models/InlineStyle';
 import _StyledNativeComponent from '../models/StyledNativeComponent';
 import ThemeProvider, { ThemeConsumer, ThemeContext } from '../models/ThemeProvider';
-import { NativeTarget } from '../types';
+import type { NativeTarget } from '../types';
 import isStyledComponent from '../utils/isStyledComponent';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, react/jsx-key, @typescript-eslint/no-empty-function */
-import React, { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
+import React from 'react';
 import { Text, View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import styled, { ThemeProvider } from '../';

--- a/packages/styled-components/src/sheet/GroupedTag.ts
+++ b/packages/styled-components/src/sheet/GroupedTag.ts
@@ -1,6 +1,6 @@
 import { SPLITTER } from '../constants';
 import styledError from '../utils/error';
-import { GroupedTag, Tag } from './types';
+import type { GroupedTag, Tag } from './types';
 
 /** Create a GroupedTag with an underlying Tag implementation */
 export const makeGroupedTag = (tag: Tag) => {

--- a/packages/styled-components/src/sheet/Rehydration.ts
+++ b/packages/styled-components/src/sheet/Rehydration.ts
@@ -1,6 +1,6 @@
 import { SC_ATTR, SC_ATTR_ACTIVE, SC_ATTR_VERSION, SC_VERSION, SPLITTER } from '../constants';
 import { getIdForGroup, setGroupForId } from './GroupIDAllocator';
-import { Sheet } from './types';
+import type { Sheet } from './types';
 
 const SELECTOR = `style[${SC_ATTR}][${SC_ATTR_VERSION}="${SC_VERSION}"]`;
 const MARKER_RE = new RegExp(`^${SC_ATTR}\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)`);

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -4,7 +4,7 @@ import { makeGroupedTag } from './GroupedTag';
 import { getGroupForId } from './GroupIDAllocator';
 import { outputSheet, rehydrateSheet } from './Rehydration';
 import { makeTag } from './Tag';
-import { GroupedTag, Sheet, SheetOptions } from './types';
+import type { GroupedTag, Sheet, SheetOptions } from './types';
 
 let SHOULD_REHYDRATE = IS_BROWSER;
 

--- a/packages/styled-components/src/sheet/Tag.ts
+++ b/packages/styled-components/src/sheet/Tag.ts
@@ -1,5 +1,5 @@
 import { getSheet, makeStyleTag } from './dom';
-import { SheetOptions, Tag } from './types';
+import type { SheetOptions, Tag } from './types';
 
 /** Create a CSSStyleSheet-like tag depending on the environment */
 export const makeTag = ({ isServer, useCSSOMInjection, target }: SheetOptions) => {

--- a/packages/styled-components/src/sheet/test/Tag.test.ts
+++ b/packages/styled-components/src/sheet/test/Tag.test.ts
@@ -1,6 +1,6 @@
-import { Class } from 'utility-types';
+import type { Class } from 'utility-types';
 import { CSSOMTag, TextTag, VirtualTag } from '../Tag';
-import { Tag } from '../types';
+import type { Tag } from '../types';
 
 const describeTag = (TagClass: Class<Tag>) => {
   it('inserts and retrieves rules at indices', () => {

--- a/packages/styled-components/src/test/attrs.test.tsx
+++ b/packages/styled-components/src/test/attrs.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import ThemeProvider from '../models/ThemeProvider';
-import { AnyComponent } from '../types';
+import type { AnyComponent } from '../types';
 import { getRenderedCSS, resetStyled } from './utils';
 
 // Disable isStaticRules optimisation since we're not

--- a/packages/styled-components/src/test/basic.test.tsx
+++ b/packages/styled-components/src/test/basic.test.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
-import React, { Component, CSSProperties, StrictMode } from 'react';
+import type { CSSProperties} from 'react';
+import React, { Component, StrictMode } from 'react';
 import { findDOMNode } from 'react-dom';
 import { findRenderedComponentWithType, renderIntoDocument } from 'react-dom/test-utils';
 import TestRenderer from 'react-test-renderer';
 import { find } from '../../test-utils';
-import { AnyComponent } from '../types';
+import type { AnyComponent } from '../types';
 import hoist from '../utils/hoist';
 import { getRenderedCSS, resetStyled } from './utils';
 

--- a/packages/styled-components/src/test/overriding.test.tsx
+++ b/packages/styled-components/src/test/overriding.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
-import { AnyComponent } from '../types';
+import type { AnyComponent } from '../types';
 import { getRenderedCSS, resetStyled } from './utils';
 
 // Disable isStaticRules optimisation since we're not

--- a/packages/styled-components/src/test/theme.test.tsx
+++ b/packages/styled-components/src/test/theme.test.tsx
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import { renderIntoDocument } from 'react-dom/test-utils';
 import TestRenderer from 'react-test-renderer';
 import withTheme from '../hoc/withTheme';
-import ThemeProvider, { DefaultTheme } from '../models/ThemeProvider';
+import type { DefaultTheme } from '../models/ThemeProvider';
+import ThemeProvider from '../models/ThemeProvider';
 import { getRenderedCSS, resetStyled } from './utils';
 
 let styled: ReturnType<typeof resetStyled>;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import ComponentStyle from './models/ComponentStyle';
+import type React from 'react';
+import type ComponentStyle from './models/ComponentStyle';
 import { DefaultTheme } from './models/ThemeProvider';
-import createWarnTooManyClasses from './utils/createWarnTooManyClasses';
+import type createWarnTooManyClasses from './utils/createWarnTooManyClasses';
 
 interface ExoticComponentWithDisplayName<P = any> extends React.ExoticComponent<P> {
   defaultProps?: Partial<P>;

--- a/packages/styled-components/src/utils/createWarnTooManyClasses.ts
+++ b/packages/styled-components/src/utils/createWarnTooManyClasses.ts
@@ -1,4 +1,4 @@
-import { Dict } from '../types';
+import type { Dict } from '../types';
 
 export const LIMIT = 200;
 

--- a/packages/styled-components/src/utils/determineTheme.ts
+++ b/packages/styled-components/src/utils/determineTheme.ts
@@ -1,4 +1,4 @@
-import { ExecutionProps } from '../types';
+import type { ExecutionProps } from '../types';
 import { EMPTY_OBJECT } from './empties';
 
 export default function determineTheme(

--- a/packages/styled-components/src/utils/empties.ts
+++ b/packages/styled-components/src/utils/empties.ts
@@ -1,4 +1,4 @@
-import { Dict } from '../types';
+import type { Dict } from '../types';
 
 export const EMPTY_ARRAY = Object.freeze([]) as Readonly<any[]>;
 export const EMPTY_OBJECT = Object.freeze({}) as Readonly<Dict<any>>;

--- a/packages/styled-components/src/utils/error.ts
+++ b/packages/styled-components/src/utils/error.ts
@@ -1,4 +1,4 @@
-import { Dict } from '../types';
+import type { Dict } from '../types';
 import errorMap from './errors';
 
 const ERRORS: Dict<any> = process.env.NODE_ENV !== 'production' ? errorMap : {};

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -1,6 +1,6 @@
 import Keyframes from '../models/Keyframes';
-import StyleSheet from '../sheet';
-import {
+import type StyleSheet from '../sheet';
+import type {
   AnyComponent,
   Dict,
   ExecutionContext,

--- a/packages/styled-components/src/utils/generateDisplayName.ts
+++ b/packages/styled-components/src/utils/generateDisplayName.ts
@@ -1,4 +1,4 @@
-import { StyledTarget } from '../types';
+import type { StyledTarget } from '../types';
 import getComponentName from './getComponentName';
 import isTag from './isTag';
 

--- a/packages/styled-components/src/utils/getComponentName.ts
+++ b/packages/styled-components/src/utils/getComponentName.ts
@@ -1,4 +1,4 @@
-import { StyledTarget } from '../types';
+import type { StyledTarget } from '../types';
 
 export default function getComponentName(target: StyledTarget<any>) {
   return (

--- a/packages/styled-components/src/utils/hoist.ts
+++ b/packages/styled-components/src/utils/hoist.ts
@@ -1,5 +1,5 @@
-import React from 'react';
-import { AnyComponent } from '../types';
+import type React from 'react';
+import type { AnyComponent } from '../types';
 
 const hasSymbol = typeof Symbol === 'function' && Symbol.for;
 

--- a/packages/styled-components/src/utils/interleave.ts
+++ b/packages/styled-components/src/utils/interleave.ts
@@ -1,4 +1,4 @@
-import { Interpolation } from '../types';
+import type { Interpolation } from '../types';
 
 export default function interleave<Props extends object>(
   strings: TemplateStringsArray,

--- a/packages/styled-components/src/utils/isStaticRules.ts
+++ b/packages/styled-components/src/utils/isStaticRules.ts
@@ -1,4 +1,4 @@
-import { RuleSet } from '../types';
+import type { RuleSet } from '../types';
 import isFunction from './isFunction';
 import isStyledComponent from './isStyledComponent';
 

--- a/packages/styled-components/src/utils/isStyledComponent.ts
+++ b/packages/styled-components/src/utils/isStyledComponent.ts
@@ -1,4 +1,4 @@
-import { IStyledComponent } from '../types';
+import type { IStyledComponent } from '../types';
 
 export default function isStyledComponent(target: any): target is IStyledComponent<'web', any, any> {
   return typeof target === 'object' && 'styledComponentId' in target;

--- a/packages/styled-components/src/utils/isTag.ts
+++ b/packages/styled-components/src/utils/isTag.ts
@@ -1,4 +1,4 @@
-import { StyledTarget } from '../types';
+import type { StyledTarget } from '../types';
 
 export default function isTag(target: StyledTarget<'web'>): target is string {
   return (

--- a/packages/styled-components/src/utils/mixinDeep.ts
+++ b/packages/styled-components/src/utils/mixinDeep.ts
@@ -1,4 +1,4 @@
-import { ExecutionProps } from '../types';
+import type { ExecutionProps } from '../types';
 import isPlainObject from './isPlainObject'
 
 function mixinRecursively(target: any, source: any, forceMerge = false) {

--- a/packages/styled-components/src/utils/stylis.ts
+++ b/packages/styled-components/src/utils/stylis.ts
@@ -1,5 +1,6 @@
-import { compile, Element, Middleware, middleware, prefixer, RULESET, stringify } from 'stylis';
-import { Stringifier } from '../types';
+import type { Element, Middleware} from 'stylis';
+import { compile, middleware, prefixer, RULESET, stringify } from 'stylis';
+import type { Stringifier } from '../types';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from './empties';
 import throwStyledError from './error';
 import { phash, SEED } from './hash';


### PR DESCRIPTION
Adds `@typescript-eslint/consistent-type-imports` lint rule to use `import type` for all type imports.