### PR TITLE
fix: (React Native) passing testID as attrs property

### DIFF
--- a/packages/styled-components/src/models/StyledNativeComponent.js
+++ b/packages/styled-components/src/models/StyledNativeComponent.js
@@ -69,7 +69,7 @@ class StyledNativeComponent extends Component<*, *> {
             return [generatedStyles].concat(style(state))
           }
           : [generatedStyles].concat(style);
-          propsForElement.testID = testID;
+          propsForElement.testID = testID || propsForElement.testID;
 
           if (forwardedRef) propsForElement.ref = forwardedRef;
           if (forwardedAs) propsForElement.as = forwardedAs;


### PR DESCRIPTION
PR that broke down the logic: https://github.com/styled-components/styled-components/pull/3365/files

Currently, adding testID as an attribute in `attrs` does not work, because testID is always overwritten with regular prop as `undefined`.

This change adds the ability to specify testID with `.attrs()`, as was possible before version 5.2.2

```
const MyComponent = styled.View.attrs({ testID: 'something' })`` // such code does not work
```