### PR TITLE
Bump stylis to version 4.1.3

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -72,7 +72,7 @@
     "@emotion/unitless": "^0.7.4",
     "css-to-react-native": "^3.0.0",
     "shallowequal": "^1.1.0",
-    "stylis": "^4.1.2"
+    "stylis": "^4.1.3"
   },
   "peerDependencies": {
     "babel-plugin-styled-components": ">= 2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9249,7 +9249,7 @@ style-loader@^3.3.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "6.0.0-beta.4"
+  version "6.0.0-beta.5"
   dependencies:
     "@babel/cli" "^7.18.6"
     "@babel/core" "^7.18.6"
@@ -9264,7 +9264,7 @@ style-loader@^3.3.1:
     "@emotion/unitless" "^0.7.4"
     css-to-react-native "^3.0.0"
     shallowequal "^1.1.0"
-    stylis "^4.1.2"
+    stylis "^4.1.3"
 
 styled-jsx@5.0.4:
   version "5.0.4"
@@ -9313,10 +9313,10 @@ stylis@4.0.13:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
   integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
-stylis@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.2.tgz#870b3c1c2275f51b702bb3da9e94eedad87bba41"
-  integrity sha512-Nn2CCrG2ZaFziDxaZPN43CXqn+j7tcdjPFCkRBkFue8QYXC2HdEwnw5TCBo4yQZ2WxKYeSi0fdoOrtEqgDrXbA==
+stylis@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
 
 sudo-prompt@^9.0.0:
   version "9.2.1"


### PR DESCRIPTION
This should enable `styled-components` to take advantage of the new support for container queries (`@container`).