### PR TITLE
feat(StyleSheetManager): add optional namespacing

### DIFF
--- a/packages/styled-components/src/base.ts
+++ b/packages/styled-components/src/base.ts
@@ -8,9 +8,13 @@ import withTheme from './hoc/withTheme';
 /* Import hooks */
 import useTheme from './hooks/useTheme';
 import ServerStyleSheet from './models/ServerStyleSheet';
-import StyleSheetManager, {
+import {
+  IStyleSheetContext,
+  IStyleSheetManager,
+  IStylisContext,
   StyleSheetConsumer,
   StyleSheetContext,
+  StyleSheetManager,
 } from './models/StyleSheetManager';
 /* Import components */
 import ThemeProvider, { ThemeConsumer, ThemeContext } from './models/ThemeProvider';
@@ -66,6 +70,9 @@ export {
   createGlobalStyle,
   css,
   isStyledComponent,
+  IStyleSheetManager,
+  IStyleSheetContext,
+  IStylisContext,
   keyframes,
   ServerStyleSheet,
   StyleSheetConsumer,

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { act, Simulate } from 'react-dom/test-utils';
 import ReactTestRenderer from 'react-test-renderer';
 import * as constants from '../../constants';
-import StyleSheetManager from '../../models/StyleSheetManager';
+import { StyleSheetManager } from '../../models/StyleSheetManager';
 import ThemeProvider from '../../models/ThemeProvider';
 import StyleSheet from '../../sheet';
 import { getRenderedCSS, resetStyled } from '../../test/utils';

--- a/packages/styled-components/src/constructors/test/keyframes.test.tsx
+++ b/packages/styled-components/src/constructors/test/keyframes.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import Keyframes from '../../models/Keyframes';
-import StyleSheetManager from '../../models/StyleSheetManager';
+import { StyleSheetManager } from '../../models/StyleSheetManager';
 import { getRenderedCSS, resetStyled } from '../../test/utils';
 import css from '../css';
 import keyframes from '../keyframes';

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -6,7 +6,7 @@ import { IS_BROWSER, SC_ATTR, SC_ATTR_VERSION, SC_VERSION } from '../constants';
 import StyleSheet from '../sheet';
 import styledError from '../utils/error';
 import getNonce from '../utils/nonce';
-import StyleSheetManager from './StyleSheetManager';
+import { StyleSheetManager } from './StyleSheetManager';
 
 declare const __SERVER__: boolean;
 

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -4,18 +4,12 @@ import StyleSheet from '../sheet';
 import { Stringifier } from '../types';
 import createStylisInstance from '../utils/stylis';
 
-type Props = {
-  children?: React.ReactChild;
-  disableCSSOMInjection?: boolean;
-  disableVendorPrefixes?: boolean;
-  sheet?: StyleSheet;
-  stylisPlugins?: stylis.Middleware[];
-  target?: HTMLElement;
-};
-
-export const StyleSheetContext = React.createContext<StyleSheet | void>(undefined);
+export type IStyleSheetContext = StyleSheet | void;
+export const StyleSheetContext = React.createContext<IStyleSheetContext>(undefined);
 export const StyleSheetConsumer = StyleSheetContext.Consumer;
-export const StylisContext = React.createContext<Stringifier | void>(undefined);
+
+export type IStylisContext = Stringifier | void;
+export const StylisContext = React.createContext<IStylisContext>(undefined);
 export const StylisConsumer = StylisContext.Consumer;
 
 export const mainSheet: StyleSheet = new StyleSheet();
@@ -29,7 +23,36 @@ export function useStylis(): Stringifier {
   return useContext(StylisContext) || mainStylis;
 }
 
-export default function StyleSheetManager(props: Props): JSX.Element {
+export type IStyleSheetManager = React.PropsWithChildren<{
+  /**
+   * If desired, you can pass this prop to disable "speedy" insertion mode, which
+   * uses the browser [CSSOM APIs](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).
+   * When disabled, rules are inserted as simple text into style blocks.
+   */
+  disableCSSOMInjection?: boolean;
+  /**
+   * If you are working exclusively with modern browsers, vendor prefixes can often be omitted
+   * to reduce the weight of CSS on the page.
+   */
+  disableVendorPrefixes?: boolean;
+  /**
+   * Create and provide your own `StyleSheet` if necessary for advanced SSR scenarios.
+   */
+  sheet?: StyleSheet;
+  /**
+   * An array of plugins to be run by stylis (style processor) during compilation.
+   * Check out [what's available on npm*](https://www.npmjs.com/search?q=keywords%3Astylis).
+   *
+   * \* The plugin(s) must be compatible with stylis v4 or above.
+   */
+  stylisPlugins?: stylis.Middleware[];
+  /**
+   * Provide an alternate DOM node to host generated styles; useful for iframes.
+   */
+  target?: HTMLElement;
+}>;
+
+export function StyleSheetManager(props: IStyleSheetManager): JSX.Element {
   const [plugins, setPlugins] = useState(props.stylisPlugins);
   const contextStyleSheet = useStyleSheet();
 

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -36,6 +36,10 @@ export type IStyleSheetManager = React.PropsWithChildren<{
    */
   disableVendorPrefixes?: boolean;
   /**
+   * Provide an optional selector to be prepended to all generated style rules.
+   */
+  namespace?: string;
+  /**
    * Create and provide your own `StyleSheet` if necessary for advanced SSR scenarios.
    */
   sheet?: StyleSheet;
@@ -76,10 +80,10 @@ export function StyleSheetManager(props: IStyleSheetManager): JSX.Element {
   const stylis = useMemo(
     () =>
       createStylisInstance({
-        options: { prefix: !props.disableVendorPrefixes },
+        options: { namespace: props.namespace, prefix: !props.disableVendorPrefixes },
         plugins,
       }),
-    [props.disableVendorPrefixes, plugins]
+    [props.disableVendorPrefixes, props.namespace, plugins]
   );
 
   useEffect(() => {

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -490,4 +490,53 @@ describe('StyleSheetManager', () => {
       </style>
     `);
   });
+
+  it('passing a namespace to StyleSheetManager works', () => {
+    const Test = styled.div`
+      display: flex;
+    `;
+
+    TestRenderer.create(
+      <StyleSheetManager namespace="#foo">
+        <Test>Foo</Test>
+      </StyleSheetManager>
+    );
+
+    expect(document.head.innerHTML).toMatchInlineSnapshot(`
+      <style data-styled="active"
+             data-styled-version="JEST_MOCK_VERSION"
+      >
+        #foo .b{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}
+      </style>
+    `);
+  });
+
+  it('nested StyleSheetManager with different namespaces works', () => {
+    const Test = styled.div`
+      padding-left: 5px;
+    `;
+
+    const Test2 = styled.div`
+      background: red;
+    `;
+
+    TestRenderer.create(
+      <StyleSheetManager namespace="#foo">
+        <div>
+          <Test>Foo</Test>
+          <StyleSheetManager namespace="#bar">
+            <Test2>Bar</Test2>
+          </StyleSheetManager>
+        </div>
+      </StyleSheetManager>
+    );
+
+    expect(document.head.innerHTML).toMatchInlineSnapshot(`
+      <style data-styled="active"
+             data-styled-version="JEST_MOCK_VERSION"
+      >
+        #foo .c{padding-left:5px;}#bar .d{background:red;}
+      </style>
+    `);
+  });
 });

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -7,7 +7,7 @@ import stylisRTLPlugin from 'stylis-plugin-rtl';
 import StyleSheet from '../../sheet';
 import { resetStyled } from '../../test/utils';
 import ServerStyleSheet from '../ServerStyleSheet';
-import StyleSheetManager from '../StyleSheetManager';
+import { StyleSheetManager } from '../StyleSheetManager';
 
 let styled: ReturnType<typeof resetStyled>;
 

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -9,7 +9,7 @@ import { renderToNodeStream, renderToString } from 'react-dom/server';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import createGlobalStyle from '../constructors/createGlobalStyle';
 import ServerStyleSheet from '../models/ServerStyleSheet';
-import StyleSheetManager from '../models/StyleSheetManager';
+import { StyleSheetManager } from '../models/StyleSheetManager';
 
 jest.mock('../utils/nonce');
 


### PR DESCRIPTION
This obviates the corresponding babel feature and allows for namespacing in compiler environments that don't support babel.