### PR TITLE
fix: prevent crash when process.env is not defined

### DIFF
--- a/packages/styled-components/src/constants.ts
+++ b/packages/styled-components/src/constants.ts
@@ -2,7 +2,7 @@ declare let SC_DISABLE_SPEEDY: boolean | null | undefined;
 declare let __VERSION__: string;
 
 export const SC_ATTR: string =
-  (typeof process !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
+  (typeof process !== 'undefined' && typeof process.env !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
   'data-styled';
 
 export const SC_ATTR_ACTIVE = 'active';
@@ -16,18 +16,20 @@ export const DISABLE_SPEEDY = Boolean(
   typeof SC_DISABLE_SPEEDY === 'boolean'
     ? SC_DISABLE_SPEEDY
     : typeof process !== 'undefined' &&
+      typeof process.env !== 'undefined' &&
       typeof process.env.REACT_APP_SC_DISABLE_SPEEDY !== 'undefined' &&
       process.env.REACT_APP_SC_DISABLE_SPEEDY !== ''
-    ? process.env.REACT_APP_SC_DISABLE_SPEEDY === 'false'
-      ? false
-      : process.env.REACT_APP_SC_DISABLE_SPEEDY
-    : typeof process !== 'undefined' &&
-      typeof process.env.SC_DISABLE_SPEEDY !== 'undefined' &&
-      process.env.SC_DISABLE_SPEEDY !== ''
-    ? process.env.SC_DISABLE_SPEEDY === 'false'
-      ? false
-      : process.env.SC_DISABLE_SPEEDY
-    : process.env.NODE_ENV !== 'production'
+      ? process.env.REACT_APP_SC_DISABLE_SPEEDY === 'false'
+        ? false
+        : process.env.REACT_APP_SC_DISABLE_SPEEDY
+      : typeof process !== 'undefined' &&
+        typeof process.env !== 'undefined' &&
+        typeof process.env.SC_DISABLE_SPEEDY !== 'undefined' &&
+        process.env.SC_DISABLE_SPEEDY !== ''
+        ? process.env.SC_DISABLE_SPEEDY === 'false'
+          ? false
+          : process.env.SC_DISABLE_SPEEDY
+        : process.env.NODE_ENV !== 'production'
 );
 
 // Shared empty execution context when generating static styles


### PR DESCRIPTION
there are times when process.env is not defined, 

let's prevent breaking at least...

related to https://github.com/cypress-io/cypress/issues/21434 