### PR TITLE
Fixes issue when using an ampersand (&) to scope css to a parent selector alongside the new namespace feature

### DIFF
--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -600,3 +600,42 @@ describe('StyleSheetManager', () => {
     `);
   });
 });
+
+it('namespaced StyleSheetManager works with ampersand selector and media queries', () => {
+  const Test = styled.div`
+    color: red;
+    .child2 &,
+    .child & {
+      color: green;
+    }
+    @media (min-width: 768px) {
+      color: blue;
+      .child2 &,
+      .child & {
+        color: cyan;
+      }
+    }
+  `;
+
+  TestRenderer.create(
+    <StyleSheetManager namespace=".parent">
+      <div>
+        <Test>Foo</Test>
+        <div className="child">
+          <Test>Foo Bar</Test>
+        </div>
+        <div className="child2">
+          <Test>Foo Bar</Test>
+        </div>
+      </div>
+    </StyleSheetManager>
+  );
+
+  expect(document.head.innerHTML).toMatchInlineSnapshot(`
+    <style data-styled="active"
+           data-styled-version="JEST_MOCK_VERSION"
+    >
+      .parent .b{color:red;}.parent .child2 .sc-a,.parent .child .b{color:green;}.parent .d{color:red;}.parent .child2 .sc-c,.parent .child .d{color:green;}@media (min-width: 768px){.parent .d{color:blue;}.parent .child2 .sc-c,.parent .child .d{color:cyan;}}
+    </style>
+  `);
+});

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -595,7 +595,7 @@ describe('StyleSheetManager', () => {
       <style data-styled="active"
              data-styled-version="JEST_MOCK_VERSION"
       >
-        .parent .b{color:red;}.parent .child2 .sc-a,.parent .child .sc-a{color:green;}
+        .parent .b{color:red;}.parent .child2 .sc-a,.parent .child .b{color:green;}
       </style>
     `);
   });

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -539,4 +539,32 @@ describe('StyleSheetManager', () => {
       </style>
     `);
   });
+
+  it('namespaced StyleSheetManager works with ampersand selector', () => {
+    const Test = styled.div`
+      padding-top: 5px;
+      .bar & {
+        padding-top: 10px;
+      }
+    `;
+
+    TestRenderer.create(
+      <StyleSheetManager namespace="#foo">
+        <div>
+          <Test>Foo</Test>
+          <div className=".bar">
+            <Test>Foo Bar</Test>
+          </div>
+        </div>
+      </StyleSheetManager>
+    );
+
+    expect(document.head.innerHTML).toMatchInlineSnapshot(`
+      <style data-styled="active"
+             data-styled-version="JEST_MOCK_VERSION"
+      >
+        #foo .b{padding-top:5px;}#foo .bar .sc-a{padding-top:10px;}
+      </style>
+    `);
+  });
 });

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -543,16 +543,16 @@ describe('StyleSheetManager', () => {
   it('namespaced StyleSheetManager works with ampersand selector', () => {
     const Test = styled.div`
       padding-top: 5px;
-      .bar & {
+      .child & {
         padding-top: 10px;
       }
     `;
 
     TestRenderer.create(
-      <StyleSheetManager namespace="#foo">
+      <StyleSheetManager namespace=".parent">
         <div>
           <Test>Foo</Test>
-          <div className=".bar">
+          <div className="child">
             <Test>Foo Bar</Test>
           </div>
         </div>
@@ -563,7 +563,39 @@ describe('StyleSheetManager', () => {
       <style data-styled="active"
              data-styled-version="JEST_MOCK_VERSION"
       >
-        #foo .b{padding-top:5px;}#foo .bar .sc-a{padding-top:10px;}
+        .parent .b{padding-top:5px;}.parent .child .sc-a{padding-top:10px;}
+      </style>
+    `);
+  });
+
+  it('namespaced StyleSheetManager works with ampersand selector (complex)', () => {
+    const Test = styled.div`
+      color: red;
+      .child2 &,
+      .child & {
+        color: green;
+      }
+    `;
+
+    TestRenderer.create(
+      <StyleSheetManager namespace=".parent">
+        <div>
+          <Test>Foo</Test>
+          <div className="child">
+            <Test>Foo Bar</Test>
+          </div>
+          <div className="child2">
+            <Test>Foo Bar</Test>
+          </div>
+        </div>
+      </StyleSheetManager>
+    );
+
+    expect(document.head.innerHTML).toMatchInlineSnapshot(`
+      <style data-styled="active"
+             data-styled-version="JEST_MOCK_VERSION"
+      >
+        .parent .b{color:red;}.parent .child2 .sc-a,.parent .child .sc-a{color:green;}
       </style>
     `);
   });

--- a/packages/styled-components/src/utils/stylis.ts
+++ b/packages/styled-components/src/utils/stylis.ts
@@ -91,17 +91,25 @@ export default function createStylisInstance(
     }
 
     middlewares.push(selfReferenceReplacementPlugin, stringify);
+    let compiled = compile(prefix || selector ? `${prefix} ${selector} { ${flatCSS} }` : flatCSS);
 
-    return serialize(
-      compile(
-        options.namespace || prefix || selector
-          ? `${
-              options.namespace ? options.namespace + ' ' : ''
-            }${prefix} ${selector} { ${flatCSS} }`
-          : flatCSS
-      ),
+    if(options.namespace) {
+      compiled = compiled.map(rule=> {
+        // add the namespace to the start
+        rule.value = `${options.namespace} ${rule.value}`;
+        // add the namespace after each comma for subsequent selectors.
+        rule.value = rule.value.replaceAll(',', `,${options.namespace} `)
+        rule.props = rule.props.map(prop => {
+          return `${options.namespace} ${prop}`
+        });
+        return rule;
+      })
+    }
+    const serialized = serialize(
+      compiled,
       middleware(middlewares)
     );
+    return serialized;
   };
 
   stringifyRules.hash = plugins.length

--- a/packages/styled-components/src/utils/stylis.ts
+++ b/packages/styled-components/src/utils/stylis.ts
@@ -93,22 +93,19 @@ export default function createStylisInstance(
     middlewares.push(selfReferenceReplacementPlugin, stringify);
     let compiled = compile(prefix || selector ? `${prefix} ${selector} { ${flatCSS} }` : flatCSS);
 
-    if(options.namespace) {
-      compiled = compiled.map(rule=> {
+    if (options.namespace) {
+      compiled = compiled.map(rule => {
         // add the namespace to the start
         rule.value = `${options.namespace} ${rule.value}`;
         // add the namespace after each comma for subsequent selectors.
-        rule.value = rule.value.replaceAll(',', `,${options.namespace} `)
+        rule.value = rule.value.replaceAll(',', `,${options.namespace} `);
         rule.props = rule.props.map(prop => {
-          return `${options.namespace} ${prop}`
+          return `${options.namespace} ${prop}`;
         });
         return rule;
-      })
+      });
     }
-    const serialized = serialize(
-      compiled,
-      middleware(middlewares)
-    );
+    const serialized = serialize(compiled, middleware(middlewares));
     return serialized;
   };
 


### PR DESCRIPTION
The instructions on raising an issue said to consider making a PR with a failing test so here is one:

The issue this tests for is that when using an ampersand (&) to scope css to a parent selector and also using the new namespace feature added in the latest beta version, the resulting css has the parent selector before the namespace selector.

I took a stab at resolving this but while I was able to get the original issue solved, it breaks down with more complex use cases (as seen in the 2nd test)
