### PR TITLE
fix: interpolation functions returning null should not console.error

### DIFF
--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -82,7 +82,8 @@ export default function flatten<Props extends object>(
         typeof result === 'object' &&
         !Array.isArray(result) &&
         !(result instanceof Keyframes) &&
-        !isPlainObject(result)
+        !isPlainObject(result) &&
+        result !== null
       ) {
         // eslint-disable-next-line no-console
         console.error(

--- a/packages/styled-components/src/utils/test/flatten.test.tsx
+++ b/packages/styled-components/src/utils/test/flatten.test.tsx
@@ -168,3 +168,15 @@ describe('flatten', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 });
+
+it('does not error for functions that return null', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  const Bar = styled.div`
+    ${() => null}
+  `;
+
+  expect(() => TestRenderer.create(<Bar />)).not.toThrowError();
+
+  expect(console.error).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
We are in the process of migrating our codebase to SC v6 and we have this case in many places:

```tsx
const StyledDiv = styled.div<{
  $color: string;
}>`
  ${(p) => {
    if (p.$color) return `color: ${p.$color}`
    return null
  }
`;
```

With v6, this results in the following runtime error:
```sh
Component is not a styled component and cannot be referred to via component selector. See https://www.styled-components.com/docs/advanced#referring-to-other-components for more details.
```

Realizing that the appropriate solve for this issue to remove the `return null` or to return something else instead, this error is confusing. Because `typeof null === 'object'`, the logic in `flatten.ts` incorrectly interprets the `null` as a nameless React component.

Since `null` is dropped in flatten anyway ([as demonstrated in this test case](https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/utils/test/flatten.test.tsx#L11)), this change avoids calling `console.error` when an interpolation function returns `null`.