### PR TITLE
feat(StyleSheetManager): add ability to provide default shouldForwardProp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,38 @@ permissions:
   contents: read #  to fetch code (actions/checkout)
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "yarn"
+
+      - run: yarn --pure-lockfile
+
+      - name: Build
+        run: yarn build
+        env:
+          BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "yarn"
+
+      - run: yarn --pure-lockfile
+
+      - name: Lint
+        run: yarn lint
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -23,19 +55,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          cache: "yarn"
 
       - run: yarn --pure-lockfile
 
-      - name: Lint
-        run: yarn lint
-        if: matrix.node == '16'
-
       - name: Jest
         run: yarn test
-
-      - name: Build
-        run: yarn build
-        if: matrix.node == '16'
-        env:
-          BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -28,7 +28,7 @@ import isTag from '../utils/isTag';
 import joinStrings from '../utils/joinStrings';
 import merge from '../utils/mixinDeep';
 import ComponentStyle from './ComponentStyle';
-import { useStyleSheet, useStylis } from './StyleSheetManager';
+import { useShouldForwardProp, useStyleSheet, useStylis } from './StyleSheetManager';
 import { ThemeContext } from './ThemeProvider';
 
 const identifiers: { [key: string]: number } = {};
@@ -84,10 +84,12 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Executio
     componentStyle,
     defaultProps,
     foldedComponentIds,
-    shouldForwardProp,
     styledComponentId,
     target,
   } = forwardedComponent;
+
+  const defaultShouldForwardProp = useShouldForwardProp();
+  const shouldForwardProp = forwardedComponent.shouldForwardProp || defaultShouldForwardProp;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   if (process.env.NODE_ENV !== 'production') useDebugValue(styledComponentId);

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -299,6 +299,29 @@ describe('StyleSheetManager', () => {
     `);
   });
 
+  it('passing default shouldForwardProp via StyleSheetManager works', () => {
+    const Test = styled.div<{ foo?: boolean; bar?: boolean }>`
+      padding-left: 5px;
+    `;
+
+    const result = TestRenderer.create(
+      <StyleSheetManager shouldForwardProp={p => (p === 'foo' ? false : true)}>
+        <Test foo bar>
+          Foo
+        </Test>
+      </StyleSheetManager>
+    );
+
+    expect(result.toJSON()).toMatchInlineSnapshot(`
+      <div
+        bar={true}
+        className="sc-a b"
+      >
+        Foo
+      </div>
+    `);
+  });
+
   it('passing stylis plugins via StyleSheetManager works', () => {
     const Test = styled.div`
       padding-left: 5px;


### PR DESCRIPTION
This allows for an easy upgrade path to v6 if transient props were not previously in use.