### PR TITLE
namespace option on StyleSheetManager better match babel-plugin-styled-components-css-namespace

### DIFF
--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
@@ -561,4 +561,28 @@ describe(`createGlobalStyle`, () => {
       }"
     `);
   });
+
+  it(`namespaced StyleSheetManager does not namespace global styles`, () => {
+    const { render } = context;
+    const GlobalStyle = createGlobalStyle`
+    .blue {
+      color: lightblue;
+    }
+  `;
+
+    render(
+      <StyleSheetManager namespace=".parent">
+        <div>
+          <GlobalStyle />
+          <div className="blue">Im blue dabadee</div>
+        </div>
+      </StyleSheetManager>
+    );
+
+    expect(getRenderedCSS()).toMatchInlineSnapshot(`
+      ".blue {
+        color: lightblue;
+      }"
+    `);
+  });
 });

--- a/packages/styled-components/src/models/GlobalStyle.ts
+++ b/packages/styled-components/src/models/GlobalStyle.ts
@@ -25,7 +25,7 @@ export default class GlobalStyle<Props extends object> {
     stylis: Stringifier
   ): void {
     const flatCSS = flatten(this.rules, executionContext, styleSheet, stylis) as string[];
-    const css = stylis(flatCSS.join(''), '');
+    const css = stylis(flatCSS.join(''), '', undefined, undefined, true);
     const id = this.componentId + instance;
 
     // NOTE: We use the id as a name as well, since these rules never change

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -123,7 +123,13 @@ export type FlattenerResult<Props extends object> =
   | Keyframes;
 
 export interface Stringifier {
-  (css: string, selector?: string, prefix?: string, componentId?: string): string[];
+  (
+    css: string,
+    selector?: string,
+    prefix?: string,
+    componentId?: string,
+    isGlobal?: boolean
+  ): string[];
   hash: string;
 }
 

--- a/packages/styled-components/src/utils/stylis.ts
+++ b/packages/styled-components/src/utils/stylis.ts
@@ -93,7 +93,8 @@ export default function createStylisInstance(
      * This "prefix" referes to a _selector_ prefix.
      */
     prefix = '',
-    componentId = '&'
+    componentId = '&',
+    isGlobal = false
   ) => {
     let flatCSS = css.replace(COMMENT_REGEX, '');
 
@@ -117,7 +118,7 @@ export default function createStylisInstance(
     middlewares.push(selfReferenceReplacementPlugin, stringify);
     let compiled = compile(prefix || selector ? `${prefix} ${selector} { ${flatCSS} }` : flatCSS);
 
-    if (options.namespace) {
+    if (options.namespace && !isGlobal) {
       compiled = recursivelySetNamepace(compiled, options.namespace);
     }
     return serialize(compiled, middleware(middlewares));


### PR DESCRIPTION
I've modified the behaviour of the namespace option on StyleSheetManager so that it doesn't prefix global stye rules added via createGlobalStyle.

This more closely matches the behaviour in the `babel-plugin-styled-components-css-namespace` which was the previous way to namespace/isolate styles.

I think it's better to do things this way around rather than providing some option to stop the global styles getting prefixed. This way they are never prefixed and if you want to prefix them it would just be a case of manually adding your prefix to any global styles you write.