### PR TITLE
fix: prevent crash when process.env is not defined

### DIFF
--- a/packages/styled-components/src/constants.js
+++ b/packages/styled-components/src/constants.js
@@ -4,7 +4,7 @@ declare var SC_DISABLE_SPEEDY: ?boolean;
 declare var __VERSION__: string;
 
 export const SC_ATTR: string =
-  (typeof process !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
+  (typeof process !== 'undefined' && typeof process.env !== 'undefined' && (process.env.REACT_APP_SC_ATTR || process.env.SC_ATTR)) ||
   'data-styled';
 
 export const SC_ATTR_ACTIVE = 'active';
@@ -17,11 +17,11 @@ export const IS_BROWSER = typeof window !== 'undefined' && 'HTMLElement' in wind
 export const DISABLE_SPEEDY =
   Boolean(typeof SC_DISABLE_SPEEDY === 'boolean'
     ? SC_DISABLE_SPEEDY
-    : (typeof process !== 'undefined' && typeof process.env.REACT_APP_SC_DISABLE_SPEEDY !== 'undefined' && process.env.REACT_APP_SC_DISABLE_SPEEDY !== ''
+    : (typeof process !== 'undefined' && typeof process.env !== 'undefined' && typeof process.env.REACT_APP_SC_DISABLE_SPEEDY !== 'undefined' && process.env.REACT_APP_SC_DISABLE_SPEEDY !== ''
       ? process.env.REACT_APP_SC_DISABLE_SPEEDY === 'false' ? false : process.env.REACT_APP_SC_DISABLE_SPEEDY
-      : (typeof process !== 'undefined' && typeof process.env.SC_DISABLE_SPEEDY !== 'undefined' && process.env.SC_DISABLE_SPEEDY !== ''
+      : (typeof process !== 'undefined' && typeof process.env !== 'undefined' && typeof process.env.SC_DISABLE_SPEEDY !== 'undefined' && process.env.SC_DISABLE_SPEEDY !== ''
         ? process.env.SC_DISABLE_SPEEDY === 'false' ? false : process.env.SC_DISABLE_SPEEDY
-        : process.env.NODE_ENV !== 'production'
+        : process.env && process.env.NODE_ENV !== 'production'
       )
     ));
 


### PR DESCRIPTION
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/13535734/222085264-ffda9c4e-9067-4ab1-a2fc-f9b6d8584f74.png">
Was Getting error when process.env was tried to access. So have provided a null check.
Note that these changes are intentionally targeted for legacy-v5 branch since these fixes were already merged to ongoing beta v6 branch. reference - https://github.com/styled-components/styled-components/pull/3907

All tests are passing locally when done **yarn test**

PS : above reference link is not properly formatted, but still it would work.