### PR TITLE
Fix determineTheme & add typing

### DIFF
--- a/packages/styled-components/src/utils/determineTheme.ts
+++ b/packages/styled-components/src/utils/determineTheme.ts
@@ -1,10 +1,10 @@
-import { ExecutionProps } from '../types';
+import { DefaultTheme, ExecutionProps } from '../types';
 import { EMPTY_OBJECT } from './empties';
 
 export default function determineTheme(
   props: ExecutionProps,
-  providedTheme: any,
-  defaultProps: any = EMPTY_OBJECT
-) {
-  return (props.theme && props.theme !== defaultProps.theme) || providedTheme || defaultProps.theme;
+  providedTheme?: DefaultTheme,
+  defaultProps: { theme?: DefaultTheme } = EMPTY_OBJECT
+): DefaultTheme | undefined {
+  return (props.theme !== defaultProps.theme && props.theme) || providedTheme || defaultProps.theme;
 }


### PR DESCRIPTION
It was broken by [this](https://github.com/styled-components/styled-components/commit/75d492c68caf0f1c2a7f705e734db3e41395f866#diff-36d077e5df21437167bd0eb44ec4445d43399d7aec2761bc11937d3d3a4a36deR9) change, which causes `determineTheme` to return a boolean as the right-hand side of `(props.theme && props.theme !== defaultProps.theme)` will now be a boolean, while with `(props.theme !== defaultProps.theme && props.theme)` it would be `props.theme`.