### PR TITLE
Appending classnames

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -12,7 +12,7 @@ import type {
   OmitNever,
   RuleSet,
   StyledOptions,
-  WebTarget,
+  WebTarget
 } from '../types';
 import { checkDynamicCreation } from '../utils/checkDynamicCreation';
 import createWarnTooManyClasses from '../utils/createWarnTooManyClasses';
@@ -150,7 +150,7 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Executio
       ? 'class'
       : 'className'
   ] = foldedComponentIds
-    .concat(styledComponentId, generatedClassName, context.className)
+    .concat(styledComponentId, context.className, generatedClassName)
     .filter(Boolean)
     .join(' ');
 

--- a/packages/styled-components/src/test/attrs.test.tsx
+++ b/packages/styled-components/src/test/attrs.test.tsx
@@ -304,7 +304,7 @@ describe('attrs', () => {
     `);
     expect(rendered.toJSON()).toMatchInlineSnapshot(`
       <p
-        className="sc-a d sc-b c"
+        className="sc-a sc-b c d"
         style={
           {
             "color": "blue",

--- a/packages/styled-components/src/test/basic.test.tsx
+++ b/packages/styled-components/src/test/basic.test.tsx
@@ -379,7 +379,7 @@ describe('basic', () => {
       `);
       expect(rendered.toJSON()).toMatchInlineSnapshot(`
         <div
-          className="sc-a d sc-b c"
+          className="sc-a sc-b c d"
         />
       `);
     });


### PR DESCRIPTION
When using tailwind to generate pre-defined components with some classes,  there is this unexpected behavior where instance className is prepended instead of appended. This prevents from overriding the css. This solves #3912 . Fixed by changing the order of concat and some tests.