### PR TITLE
Optimization of hot paths

### DIFF
--- a/packages/styled-components/src/constructors/keyframes.ts
+++ b/packages/styled-components/src/constructors/keyframes.ts
@@ -1,6 +1,7 @@
 import Keyframes from '../models/Keyframes';
 import { Interpolation, Styles } from '../types';
 import generateComponentId from '../utils/generateComponentId';
+import { joinStringArray } from '../utils/joinStrings';
 import css from './css';
 
 export default function keyframes<Props extends object = object>(
@@ -18,7 +19,7 @@ export default function keyframes<Props extends object = object>(
     );
   }
 
-  const rules = (css(strings, ...interpolations) as string[]).join('');
+  const rules = joinStringArray(css(strings, ...interpolations) as string[]);
   const name = generateComponentId(rules);
   return new Keyframes(name, rules);
 }

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -53,9 +53,7 @@ export default class ComponentStyle {
       if (this.staticRulesId && styleSheet.hasNameForId(this.componentId, this.staticRulesId)) {
         this.names.push(this.staticRulesId);
       } else {
-        const cssStatic = (
-          flatten(this.rules, executionContext, styleSheet, stylis) as string[]
-        ).join('');
+        const cssStatic = flatten(this.rules, executionContext, styleSheet, stylis).join('');
         const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
 
         if (!styleSheet.hasNameForId(this.componentId, name)) {
@@ -78,10 +76,7 @@ export default class ComponentStyle {
 
           if (process.env.NODE_ENV !== 'production') dynamicHash = phash(dynamicHash, partRule);
         } else if (partRule) {
-          const partChunk = flatten(partRule, executionContext, styleSheet, stylis) as
-            | string
-            | string[];
-          const partString = Array.isArray(partChunk) ? partChunk.join('') : partChunk;
+          const partString = flatten(partRule, executionContext, styleSheet, stylis).join('');
           dynamicHash = phash(dynamicHash, partString);
           css += partString;
         }

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -5,6 +5,7 @@ import flatten from '../utils/flatten';
 import generateName from '../utils/generateAlphabeticName';
 import { hash, phash } from '../utils/hash';
 import isStaticRules from '../utils/isStaticRules';
+import joinStrings from '../utils/joinStrings';
 
 const SEED = hash(SC_VERSION);
 
@@ -40,16 +41,14 @@ export default class ComponentStyle {
     styleSheet: StyleSheet,
     stylis: Stringifier
   ): string {
-    let names = [];
-
-    if (this.baseStyle) {
-      names.push(this.baseStyle.generateAndInjectStyles(executionContext, styleSheet, stylis));
-    }
+    let names = this.baseStyle
+      ? this.baseStyle.generateAndInjectStyles(executionContext, styleSheet, stylis)
+      : '';
 
     // force dynamic classnames if user-supplied stylis plugins are in use
     if (this.isStatic && !stylis.hash) {
       if (this.staticRulesId && styleSheet.hasNameForId(this.componentId, this.staticRulesId)) {
-        names.push(this.staticRulesId);
+        names = joinStrings(names, this.staticRulesId);
       } else {
         const cssStatic = flatten(this.rules, executionContext, styleSheet, stylis).join('');
         const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
@@ -59,7 +58,7 @@ export default class ComponentStyle {
           styleSheet.insertRules(this.componentId, name, cssStaticFormatted);
         }
 
-        names.push(name);
+        names = joinStrings(names, name);
         this.staticRulesId = name;
       }
     } else {
@@ -91,10 +90,10 @@ export default class ComponentStyle {
           );
         }
 
-        names.push(name);
+        names = joinStrings(names, name);
       }
     }
 
-    return names.join(' ');
+    return names;
   }
 }

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -16,12 +16,10 @@ export default class ComponentStyle {
   baseStyle: ComponentStyle | null | undefined;
   componentId: string;
   isStatic: boolean;
-  names: string[];
   rules: RuleSet<any>;
   staticRulesId: string;
 
   constructor(rules: RuleSet<any>, componentId: string, baseStyle?: ComponentStyle) {
-    this.names = [];
     this.rules = rules;
     this.staticRulesId = '';
     this.isStatic =
@@ -42,16 +40,16 @@ export default class ComponentStyle {
     styleSheet: StyleSheet,
     stylis: Stringifier
   ): string {
-    this.names.length = 0;
+    let names = [];
 
     if (this.baseStyle) {
-      this.names.push(this.baseStyle.generateAndInjectStyles(executionContext, styleSheet, stylis));
+      names.push(this.baseStyle.generateAndInjectStyles(executionContext, styleSheet, stylis));
     }
 
     // force dynamic classnames if user-supplied stylis plugins are in use
     if (this.isStatic && !stylis.hash) {
       if (this.staticRulesId && styleSheet.hasNameForId(this.componentId, this.staticRulesId)) {
-        this.names.push(this.staticRulesId);
+        names.push(this.staticRulesId);
       } else {
         const cssStatic = flatten(this.rules, executionContext, styleSheet, stylis).join('');
         const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
@@ -61,7 +59,7 @@ export default class ComponentStyle {
           styleSheet.insertRules(this.componentId, name, cssStaticFormatted);
         }
 
-        this.names.push(name);
+        names.push(name);
         this.staticRulesId = name;
       }
     } else {
@@ -93,10 +91,10 @@ export default class ComponentStyle {
           );
         }
 
-        this.names.push(name);
+        names.push(name);
       }
     }
 
-    return this.names.join(' ');
+    return names.join(' ');
   }
 }

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -5,7 +5,7 @@ import flatten from '../utils/flatten';
 import generateName from '../utils/generateAlphabeticName';
 import { hash, phash } from '../utils/hash';
 import isStaticRules from '../utils/isStaticRules';
-import joinStrings from '../utils/joinStrings';
+import { joinStringArray, joinStrings } from '../utils/joinStrings';
 
 const SEED = hash(SC_VERSION);
 
@@ -50,7 +50,9 @@ export default class ComponentStyle {
       if (this.staticRulesId && styleSheet.hasNameForId(this.componentId, this.staticRulesId)) {
         names = joinStrings(names, this.staticRulesId);
       } else {
-        const cssStatic = flatten(this.rules, executionContext, styleSheet, stylis).join('');
+        const cssStatic = joinStringArray(
+          flatten(this.rules, executionContext, styleSheet, stylis) as string[]
+        );
         const name = generateName(phash(this.baseHash, cssStatic) >>> 0);
 
         if (!styleSheet.hasNameForId(this.componentId, name)) {
@@ -73,7 +75,9 @@ export default class ComponentStyle {
 
           if (process.env.NODE_ENV !== 'production') dynamicHash = phash(dynamicHash, partRule);
         } else if (partRule) {
-          const partString = flatten(partRule, executionContext, styleSheet, stylis).join('');
+          const partString = joinStringArray(
+            flatten(partRule, executionContext, styleSheet, stylis) as string[]
+          );
           dynamicHash = phash(dynamicHash, partString);
           css += partString;
         }

--- a/packages/styled-components/src/models/GlobalStyle.ts
+++ b/packages/styled-components/src/models/GlobalStyle.ts
@@ -2,6 +2,7 @@ import StyleSheet from '../sheet';
 import { ExecutionContext, FlattenerResult, RuleSet, Stringifier } from '../types';
 import flatten from '../utils/flatten';
 import isStaticRules from '../utils/isStaticRules';
+import { joinStringArray } from '../utils/joinStrings';
 
 export default class GlobalStyle<Props extends object> {
   componentId: string;
@@ -24,7 +25,9 @@ export default class GlobalStyle<Props extends object> {
     styleSheet: StyleSheet,
     stylis: Stringifier
   ): void {
-    const flatCSS = flatten(this.rules, executionContext, styleSheet, stylis).join('');
+    const flatCSS = joinStringArray(
+      flatten(this.rules, executionContext, styleSheet, stylis) as string[]
+    );
     const css = stylis(flatCSS, '');
     const id = this.componentId + instance;
 

--- a/packages/styled-components/src/models/GlobalStyle.ts
+++ b/packages/styled-components/src/models/GlobalStyle.ts
@@ -24,8 +24,8 @@ export default class GlobalStyle<Props extends object> {
     styleSheet: StyleSheet,
     stylis: Stringifier
   ): void {
-    const flatCSS = flatten(this.rules, executionContext, styleSheet, stylis) as string[];
-    const css = stylis(flatCSS.join(''), '');
+    const flatCSS = flatten(this.rules, executionContext, styleSheet, stylis).join('');
+    const css = stylis(flatCSS, '');
     const id = this.componentId + instance;
 
     // NOTE: We use the id as a name as well, since these rules never change

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -32,7 +32,7 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
 
     generateStyleObject(executionContext: ExecutionContext & Props) {
       // keyframes, functions, and component selectors are not allowed for React Native
-      const flatCSS = (flatten(this.rules, executionContext) as string[]).join('');
+      const flatCSS = flatten(this.rules, executionContext).join('');
       const hash = generateComponentId(flatCSS);
 
       if (!generated[hash]) {

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -10,6 +10,7 @@ import {
 } from '../types';
 import flatten from '../utils/flatten';
 import generateComponentId from '../utils/generateComponentId';
+import { joinStringArray } from '../utils/joinStrings';
 
 let generated: Dict<any> = {};
 
@@ -32,7 +33,7 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
 
     generateStyleObject(executionContext: ExecutionContext & Props) {
       // keyframes, functions, and component selectors are not allowed for React Native
-      const flatCSS = flatten(this.rules, executionContext).join('');
+      const flatCSS = joinStringArray(flatten(this.rules, executionContext) as string[]);
       const hash = generateComponentId(flatCSS);
 
       if (!generated[hash]) {

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -4,6 +4,7 @@ import { Readable } from 'stream';
 import { IS_BROWSER, SC_ATTR, SC_ATTR_VERSION, SC_VERSION } from '../constants';
 import StyleSheet from '../sheet';
 import styledError from '../utils/error';
+import { joinStringArray } from '../utils/joinStrings';
 import getNonce from '../utils/nonce';
 import { StyleSheetManager } from './StyleSheetManager';
 
@@ -28,7 +29,7 @@ export default class ServerStyleSheet {
       `${SC_ATTR}="true"`,
       `${SC_ATTR_VERSION}="${SC_VERSION}"`,
     ];
-    const htmlAttr = attrs.filter(Boolean).join(' ');
+    const htmlAttr = joinStringArray(attrs.filter(Boolean) as string[], ' ');
 
     return `<style ${htmlAttr}>${css}</style>`;
   };

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -26,7 +26,7 @@ import hoist from '../utils/hoist';
 import isFunction from '../utils/isFunction';
 import isStyledComponent from '../utils/isStyledComponent';
 import isTag from '../utils/isTag';
-import joinStrings from '../utils/joinStrings';
+import { joinStrings } from '../utils/joinStrings';
 import merge from '../utils/mixinDeep';
 import ComponentStyle from './ComponentStyle';
 import { useStyleSheetContext } from './StyleSheetManager';

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -143,15 +143,21 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Executio
     forwardedComponent.warnTooManyClasses(generatedClassName);
   }
 
+  let classString = joinStrings(foldedComponentIds, styledComponentId);
+  if (generatedClassName) {
+    classString += ' ' + generatedClassName;
+  }
+  if (context.className) {
+    classString += ' ' + context.className;
+  }
+
   propsForElement[
     // handle custom elements which React doesn't properly alias
     isTag(elementToBeCreated) &&
     domElements.indexOf(elementToBeCreated as Extract<typeof domElements, string>) === -1
       ? 'class'
       : 'className'
-  ] = [foldedComponentIds, styledComponentId, generatedClassName, context.className]
-    .filter(Boolean)
-    .join(' ');
+  ] = classString;
 
   propsForElement.ref = forwardedRef;
 

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -154,7 +154,7 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Executio
   propsForElement[
     // handle custom elements which React doesn't properly alias
     isTag(elementToBeCreated) &&
-    domElements.indexOf(elementToBeCreated as Extract<typeof domElements, string>) === -1
+    !domElements.has(elementToBeCreated as Extract<typeof domElements, string>)
       ? 'class'
       : 'className'
   ] = classString;

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -149,8 +149,7 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Executio
     domElements.indexOf(elementToBeCreated as Extract<typeof domElements, string>) === -1
       ? 'class'
       : 'className'
-  ] = foldedComponentIds
-    .concat(styledComponentId, generatedClassName, context.className)
+  ] = [foldedComponentIds, styledComponentId, generatedClassName, context.className]
     .filter(Boolean)
     .join(' ');
 
@@ -241,8 +240,8 @@ function createStyledComponent<
   // this static is used to preserve the cascade of static classes for component selector
   // purposes; this is especially important with usage of the css prop
   WrappedStyledComponent.foldedComponentIds = isTargetStyledComp
-    ? styledComponentTarget.foldedComponentIds.concat(styledComponentTarget.styledComponentId)
-    : (EMPTY_ARRAY as string[]);
+    ? joinStrings(styledComponentTarget.foldedComponentIds, styledComponentTarget.styledComponentId)
+    : '';
 
   WrappedStyledComponent.styledComponentId = styledComponentId;
 

--- a/packages/styled-components/src/test/utils.ts
+++ b/packages/styled-components/src/test/utils.ts
@@ -8,6 +8,7 @@ import { mainSheet } from '../models/StyleSheetManager';
 import { resetGroupIds } from '../sheet/GroupIDAllocator';
 import { rehydrateSheet } from '../sheet/Rehydration';
 import styledError from '../utils/error';
+import { joinStringArray } from '../utils/joinStrings';
 
 /* Ignore hashing, just return class names sequentially as .a .b .c etc */
 let mockIndex = 0;
@@ -68,9 +69,10 @@ export const stripWhitespace = (str: string) =>
     .replace(/\s+/g, ' ');
 
 export const getCSS = (scope: Document | HTMLElement) =>
-  Array.from(scope.querySelectorAll('style'))
-    .map(tag => tag.innerHTML)
-    .join('\n')
+  joinStringArray(
+    Array.from(scope.querySelectorAll('style')).map(tag => tag.innerHTML),
+    '\n'
+  )
     .replace(/ {/g, '{')
     .replace(/:\s+/g, ':')
     .replace(/:\s+;/g, ':;');

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -141,7 +141,7 @@ export interface IStyledStatics<R extends Runtime, OuterProps extends object>
   extends CommonStatics<R, OuterProps> {
   componentStyle: R extends 'web' ? ComponentStyle : never;
   // this is here because we want the uppermost displayName retained in a folding scenario
-  foldedComponentIds: R extends 'web' ? Array<string> : never;
+  foldedComponentIds: R extends 'web' ? string : never;
   inlineStyle: R extends 'native' ? InstanceType<IInlineStyleConstructor<OuterProps>> : never;
   target: StyledTarget<R>;
   styledComponentId: R extends 'web' ? string : never;

--- a/packages/styled-components/src/utils/domElements.ts
+++ b/packages/styled-components/src/utils/domElements.ts
@@ -1,6 +1,6 @@
 // Thanks to ReactDOMFactories for this handy list!
 
-export default [
+export default new Set([
   'a',
   'abbr',
   'address',
@@ -136,4 +136,4 @@ export default [
   'svg',
   'text',
   'tspan',
-] as const;
+] as const);

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -28,14 +28,16 @@ export const objToCssArray = (obj: Dict<any>, prevKey?: string): string[] => {
   const rules = [];
 
   for (const key in obj) {
-    if (!obj.hasOwnProperty(key) || isFalsish(obj[key])) continue;
+    const val = obj[key];
+    if (!obj.hasOwnProperty(key) || isFalsish(val)) continue;
 
-    if ((Array.isArray(obj[key]) && obj[key].isCss) || isFunction(obj[key])) {
-      rules.push(`${hyphenate(key)}:`, obj[key], ';');
-    } else if (isPlainObject(obj[key])) {
-      rules.push(...objToCssArray(obj[key], key));
+    // @ts-expect-error Property 'isCss' does not exist on type 'any[]'
+    if ((Array.isArray(val) && val.isCss) || isFunction(val)) {
+      rules.push(`${hyphenate(key)}:`, val, ';');
+    } else if (isPlainObject(val)) {
+      rules.push(...objToCssArray(val, key));
     } else {
-      rules.push(`${hyphenate(key)}: ${addUnitIfNeeded(key, obj[key])};`);
+      rules.push(`${hyphenate(key)}: ${addUnitIfNeeded(key, val)};`);
     }
   }
 

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -24,7 +24,7 @@ import isStyledComponent from './isStyledComponent';
 const isFalsish = (chunk: any): chunk is undefined | null | false | '' =>
   chunk === undefined || chunk === null || chunk === false || chunk === '';
 
-export const objToCssArray = (obj: Dict<any>, prevKey?: string): string[] => {
+export const objToCssArray = (obj: Dict<any>): string[] => {
   const rules = [];
 
   for (const key in obj) {
@@ -35,13 +35,13 @@ export const objToCssArray = (obj: Dict<any>, prevKey?: string): string[] => {
     if ((Array.isArray(val) && val.isCss) || isFunction(val)) {
       rules.push(`${hyphenate(key)}:`, val, ';');
     } else if (isPlainObject(val)) {
-      rules.push(...objToCssArray(val, key));
+      rules.push(`${key} {`, ...objToCssArray(val), '}');
     } else {
       rules.push(`${hyphenate(key)}: ${addUnitIfNeeded(key, val)};`);
     }
   }
 
-  return prevKey ? [`${prevKey} {`, ...rules, '}'] : rules;
+  return rules;
 };
 
 export default function flatten<Props extends object>(

--- a/packages/styled-components/src/utils/hyphenateStyleName.ts
+++ b/packages/styled-components/src/utils/hyphenateStyleName.ts
@@ -1,11 +1,4 @@
-/**
- * inlined version of
- * https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/core/hyphenateStyleName.js
- */
-const uppercaseCheck = /[A-Z]/;
-const uppercasePattern = /[A-Z]/g;
-const msPattern = /^ms-/;
-const prefixAndLowerCase = (char: string): string => `-${char.toLowerCase()}`;
+const isUpper = (c: string) => c >= 'A' && c <= 'Z';
 
 /**
  * Hyphenates a camelcased CSS property name, for example:
@@ -20,8 +13,22 @@ const prefixAndLowerCase = (char: string): string => `-${char.toLowerCase()}`;
  * As Modernizr suggests (http://modernizr.com/docs/#prefixed), an `ms` prefix
  * is converted to `-ms-`.
  */
-export default function hyphenateStyleName(string: string) {
-  return uppercaseCheck.test(string) && !string.startsWith('--')
-    ? string.replace(uppercasePattern, prefixAndLowerCase).replace(msPattern, '-ms-')
-    : string;
+export default function hyphenateStyleName(string: string): string {
+  let output = '';
+
+  for (let i = 0; i < string.length; i++) {
+    const c = string[i];
+    // Check for CSS variable prefix
+    if (i === 1 && c === '-' && string[0] === '-') {
+      return string;
+    }
+
+    if (isUpper(c)) {
+      output += '-' + c.toLowerCase();
+    } else {
+      output += c;
+    }
+  }
+
+  return output.startsWith('ms-') ? '-' + output : output;
 }

--- a/packages/styled-components/src/utils/joinStrings.ts
+++ b/packages/styled-components/src/utils/joinStrings.ts
@@ -1,6 +1,18 @@
 /**
  * Convenience function for joining strings to form className chains
  */
-export default function joinStrings(a: string | undefined, b: string): string {
+export function joinStrings(a: string | undefined, b: string): string {
   return a && b ? `${a} ${b}` : a || b;
+}
+
+export function joinStringArray(arr: string[], sep?: string): string {
+  if (arr.length === 0) {
+    return '';
+  }
+
+  let result = arr[0];
+  for (let i = 1; i < arr.length; i++) {
+    result += sep ? sep + arr[i] : arr[i];
+  }
+  return result;
 }

--- a/packages/styled-components/src/utils/test/joinStrings.test.ts
+++ b/packages/styled-components/src/utils/test/joinStrings.test.ts
@@ -1,4 +1,4 @@
-import joinStrings from '../joinStrings';
+import { joinStringArray, joinStrings } from '../joinStrings';
 
 describe('joinStrings(string?, string?)', () => {
   it('joins the two strings with a space between', () => {
@@ -13,5 +13,27 @@ describe('joinStrings(string?, string?)', () => {
     expect(joinStrings('a', '')).toBe('a');
     expect(joinStrings(null, 'b')).toBe('b');
     expect(joinStrings('', 'b')).toBe('b');
+  });
+});
+
+describe('joinStringArray(string[], string?)', () => {
+  it('joins the strings with the separator between', () => {
+    expect(joinStringArray(['a', 'b'], ' ')).toBe('a b');
+    expect(joinStringArray(['a ', 'b'], ' ')).toBe('a  b');
+    expect(joinStringArray(['a ', ' b'], ' ')).toBe('a   b');
+  });
+
+  it('joins the strings with no separator when separator is falsy', () => {
+    expect(joinStringArray(['a', 'b'])).toBe('ab');
+    expect(joinStringArray(['a', 'b'], '')).toBe('ab');
+  });
+
+  it('returns the string unmodified if only one in array', () => {
+    expect(joinStringArray(['a'])).toBe('a');
+    expect(joinStringArray(['a'], ' ')).toBe('a');
+  });
+
+  it('returns an empty string for an empty array', () => {
+    expect(joinStringArray([])).toBe('');
   });
 });


### PR DESCRIPTION
I was looking into using object literals instead of template literals for CSS with SC and wanted to compare performance beforehand and found a few easy wins. I used [stitches-bench](https://github.com/stitchesjs/stitches-bench) since the benchmark package in the styled-components repo hasn't been functional for a while.

I ran most of the stitches-bench benchmarks, comparing the latest `main` of styled-components with the changes here. Most tests were run for both object and template literals. All numbers given are the average time of a run. These were all based on [this commit](https://github.com/styled-components/styled-components/commit/9aa317eadc2b4f29f12080751b95ab6b8ae9ee0f), just before the recent optimizations that were pushed to main.

The gzip'd size of `styled-components.min.js` goes up by 32 bytes with these changes.

### Benchies
<details>
<summary>stitches-bench results (Chrome 111)</summary>
Create & mount button: 1000 iterations, 20 runs

| Version | Time     | Improvement |
| ------- | -------- | ----------- |
| v6      | 0.178360 |
| new     | 0.173725 | ~2.6%       |

Mount deep tree: 250 iterations, 20 runs

| Version | Type     | Time     | Improvement |
| ------- | -------- | -------- | ----------- |
| v6      | object   | 7.400660 |
| new     | object   | 6.725380 | ~10%        |
| v6      | template | 5.396240 |
| new     | template | 4.987980 | ~8.1%       |

Change a variant: 1,000 iterations, 20 runs

| Version | Type     | Time     | Improvement |
| ------- | -------- | -------- | ----------- |
| v6      | object   | 0.061315 |
| new     | object   | 0.053685 | ~14%        |
| v6      | template | 0.039755 |
| new     | template | 0.037960 | ~4.7%       |

Change CSS prop: 20,000 iterations, 20 runs

| Version | Type     | Time     | Improvement |
| ------- | -------- | -------- | ----------- |
| v6      | object   | 0.152887 |
| new     | object   | 0.141753 | ~7.8%       |
| v6      | template | 0.128297 |
| new     | template | 0.123021 | ~4.2%       |

Sierpinski triangle: 100 iterations, 20 runs

| Version | Type     | Time     | Improvement |
| ------- | -------- | -------- | ----------- |
| v6      | object   | 9.453550 |
| new     | object   | 8.788950 | ~7.5%       |
| v6      | template | 8.705250 |
| new     | template | 8.369000 | ~4%         |

Mount wide tree: 50 iterations, 10 runs

| Version | Type   | Time      | Improvement |
| ------- | ------ | --------- | ----------- |
| v6      | object | 11.584400 |
| new     | object | 10.300800 | ~12%        |

</details>

I only ran one of the benchmarks in Firefox, just to sanity check:

<details>
<summary>stitches-bench results (Firefox 111)</summary>
Mount deep tree: 250 iterations, 20 runs (Firefox 111)

| Version | Type     | Time      | Improvement |
| ------- | -------- | --------- | ----------- |
| v6      | object   | 11.342000 |
| new     | object   | 9.752200  | ~16%        |
| v6      | template | 9.710400  |
| new     | template | 8.477800  | ~14%        |

</details>

### The changes

The two main themes here are "regex is slow" and "`[...].join()` is slow". There are other cases of these that could be improved, but they didn't show up as particularly heavy functions so it didn't seem worth the increase in code & complexity.

### What else could be done

After these changes, `flatten` and `generateAndInjectStyles` are still the biggest time-eaters with templates, but just behind `objToCssArray` when using objects. I'm not sure what's slow in `generateAndInjectStyles` as Chrome's profiler gives line-level timings that don't match the time spent in that function. The others can be improved, but I haven't found a nice way to do it without a bunch of code duplication yet.
Edit: This might be different now due to the recent optimizations that were just pushed to main.

Some significant perf improvements would come from transpiling to es6 to use es6 features directly, as the es5 replacements of template strings & the spread syntax slows things down quite a bit. Then, consumers of the package could transpile to es5 if needed as they're probably babeling it all anyway. On the other hand, I'm guessing most people will still end up targeting es5 themselves so these benefits won't be realised. ¯\\\_(ツ)\_/¯
