### PR TITLE
chore: remove --clipboard option in envinfo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,7 +30,7 @@ Please keep it product-centric.
 <!-- BUG TEMPLATE -->
 ## Environment
 <!-- Please run this command inside your project and paste its contents here (it automatically copies to your clipboard) -->
-`npx envinfo --system --binaries --npmPackages styled-components,babel-plugin-styled-components --markdown --clipboard`
+`npx envinfo --system --binaries --npmPackages styled-components,babel-plugin-styled-components --markdown`
 
 ## Reproduction
 


### PR DESCRIPTION
clipboard argument in envinfo isn't supported anymore, we should directly use clipboardly or clipboard-cli.