### PR TITLE
fix: Do not add px to unitless CSS variables

### DIFF
--- a/packages/styled-components/src/utils/addUnitIfNeeded.js
+++ b/packages/styled-components/src/utils/addUnitIfNeeded.js
@@ -9,8 +9,8 @@ export default function addUnitIfNeeded(name: string, value: any): any {
     return '';
   }
 
-  if (typeof value === 'number' && value !== 0 && !(name in unitless)) {
-    return `${value}px`; // Presumes implicit 'px' suffix for unitless numbers
+  if (typeof value === 'number' && value !== 0 && !(name in unitless) && !name.startsWith('--')) {
+    return `${value}px`; // Presumes implicit 'px' suffix for unitless numbers except for CSS variables
   }
 
   return String(value).trim();

--- a/packages/styled-components/src/utils/test/addUnitIfNeeded.test.js
+++ b/packages/styled-components/src/utils/test/addUnitIfNeeded.test.js
@@ -11,7 +11,7 @@ it('adds a px prefix if needed for properties that require a unit', () => {
 });
 
 it('does not add a px prefix for unitless properties', () => {
-  [['lineHeight', 1], ['flex', 2], ['fontWeight', 400]].forEach(([key, value]) =>
+  [['lineHeight', 1], ['flex', 2], ['fontWeight', 400], ['--tooltip-z-index', 1000]].forEach(([key, value]) =>
     expect(addUnitIfNeeded(key, value)).toEqual(String(value))
   );
 });


### PR DESCRIPTION
Currently, the `addUnitIfNeeded` function is adding `px` to CSS variables that could potentially be used unitless. i.e. `--tooltip-z-index` or `--font-weight-bold`. It should ignore adding `px` if it's used for CSS variables since we can't know what they are used for.