### PR TITLE
Fixes an issue where keyframes are declared inside a namespaced StyleSheetManager

### DIFF
--- a/packages/styled-components/src/constructors/test/keyframes.test.tsx
+++ b/packages/styled-components/src/constructors/test/keyframes.test.tsx
@@ -375,4 +375,35 @@ describe('keyframes', () => {
       }"
     `);
   });
+  it('namespaced StyleSheetManager works with animations', () => {
+    const rotate = keyframes`
+    0% {
+      transform: rotate(0deg)
+    }
+    100% {
+      transform: rotate(360deg)
+    }
+  `;
+
+    const TestAnim = styled.div`
+      color: blue;
+      animation: ${rotate} 0.75s infinite linear;
+    `;
+
+    TestRenderer.create(
+      <StyleSheetManager namespace=".animparent">
+        <div>
+          <TestAnim>Foo</TestAnim>
+        </div>
+      </StyleSheetManager>
+    );
+
+    expect(document.head.innerHTML).toMatchInlineSnapshot(`
+      <style data-styled="active"
+             data-styled-version="JEST_MOCK_VERSION"
+      >
+        .animparent .c{color:blue;animation:a 0.75s infinite linear;}@keyframes a{0%{transform:rotate(0deg);}100%{transform:rotate(360deg);}}
+      </style>
+    `);
+  });
 });

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -4,7 +4,6 @@ import { renderToString } from 'react-dom/server';
 import Frame, { FrameContextConsumer } from 'react-frame-component';
 import TestRenderer, { act } from 'react-test-renderer';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
-import { keyframes } from '../../base';
 import StyleSheet from '../../sheet';
 import { resetStyled } from '../../test/utils';
 import ServerStyleSheet from '../ServerStyleSheet';
@@ -659,37 +658,6 @@ describe('StyleSheetManager', () => {
              data-styled-version="JEST_MOCK_VERSION"
       >
         .parent .b{color:red;}.parent .child2 .sc-a,.parent .child .b{color:green;}@media (min-width: 768px){.parent .b{color:blue;}.parent .child2 .sc-a,.parent .child .b{color:cyan;}}
-      </style>
-    `);
-  });
-  it('namespaced StyleSheetManager works with animations', () => {
-    const rotate = keyframes`
-    0% {
-      transform: rotate(0deg)
-    }
-    100% {
-      transform: rotate(360deg)
-    }
-  `;
-
-    const TestAnim = styled.div`
-      color: blue;
-      animation: ${rotate} 0.75s infinite linear;
-    `;
-
-    TestRenderer.create(
-      <StyleSheetManager namespace=".animparent">
-        <div>
-          <TestAnim>Foo</TestAnim>
-        </div>
-      </StyleSheetManager>
-    );
-
-    expect(document.head.innerHTML).toMatchInlineSnapshot(`
-      <style data-styled="active"
-             data-styled-version="JEST_MOCK_VERSION"
-      >
-        .animparent .a{color:blue;animation:iayyQJ 0.75s infinite linear;}@keyframes iayyQJ{0%{transform:rotate(0deg);}100%{transform:rotate(360deg);}}
       </style>
     `);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9063,7 +9063,7 @@ style-loader@^3.3.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "6.0.0-beta.13"
+  version "6.0.0-beta.14"
   dependencies:
     "@babel/cli" "^7.21.0"
     "@babel/core" "^7.21.0"


### PR DESCRIPTION
This fixes an issue that I spotted when declaring keyframs inside a styled component inside a StyleSheetManager with a namespace

the outputted code was adding the namespace to the start of the keyframes e.g. the `.parent` seen below

```@keyframes dvUGTh{.parent 0%{transform:rotate(0deg);}.parent 100%{transform:rotate(360deg);}}```