### PR TITLE
Fix `css` prop typings

### DIFF
--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -11,6 +11,7 @@ export {
   IStyledStatics,
   PolymorphicComponent,
   PolymorphicComponentProps,
+  RuleSet,
   Runtime,
   StyledObject,
   StyledOptions,

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -2,6 +2,7 @@
  * This file is meant for typing-related tests that don't need to go through Jest.
  */
 import React from 'react';
+import { css, CSSProp } from '../index';
 import styled from '../index-standalone';
 
 /**
@@ -60,3 +61,38 @@ const Example2 = styled.div.attrs({
 })`
   margin-top: ${props => props.theme.spacing};
 `;
+
+/**
+ * `css` prop
+ */
+declare module 'react' {
+  interface Attributes {
+    css?: CSSProp;
+  }
+}
+
+<div
+  css={css`
+    color: blue;
+  `}
+/>;
+
+<div
+  css={css`
+    color: ${Math.random() > 0.5 ? 'blue' : 'red'};
+  `}
+/>;
+
+interface ColorizedComponentProps {
+  color: string;
+}
+function ColorizedComponent(props: ColorizedComponentProps) {
+  return null;
+}
+
+<ColorizedComponent
+  color="blue"
+  css={css<ColorizedComponentProps>`
+    color: ${props => props.color};
+  `}
+/>;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -224,25 +224,24 @@ export interface StyledObject<Props extends object> {
 // [K in keyof CSS.Properties]: CSS.Properties[K] | ((...any: any[]) => CSS.Properties[K]);
 
 /**
- * Override DefaultTheme to get accurate typings for your project.
+ * The `css` prop is not declared by default in the types as it would cause `css` to be present
+ * on the types of anything that uses styled-components indirectly, even if they do not use the
+ * babel plugin.
  *
- * ```
- * // create styled-components.d.ts in your project source
- * // if it isn't being picked up, check tsconfig compilerOptions.types
+ * To enable support for the `css` prop in TypeScript, create a `styled-components.d.ts` file in
+ * your project source with the following contents:
+ *
+ * ```ts
  * import type { CSSProp } from "styled-components";
- * import Theme from './theme';
- *
- * type ThemeType = typeof Theme;
- *
- * declare module "styled-components" {
- *  export interface DefaultTheme extends ThemeType {}
- * }
  *
  * declare module "react" {
- *  interface DOMAttributes<T> {
+ *  interface Attributes {
  *    css?: CSSProp;
  *  }
  * }
  * ```
+ *
+ * In order to get accurate typings for `props.theme` in `css` interpolations, see
+ * {@link DefaultTheme}.
  */
 export type CSSProp = RuleSet<any>;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -245,4 +245,4 @@ export interface StyledObject<Props extends object> {
  * }
  * ```
  */
-export type CSSProp = string | StyledObject<any> | StyleFunction<any>;
+export type CSSProp = RuleSet<any>;


### PR DESCRIPTION
Fix the `css` prop typings to resolve TypeScript errors when using the prop (described in https://github.com/styled-components/styled-components/issues/3800#issuecomment-1498409379) and added type tests for a few common usages.

I also included some related improvements:
* Reworded and updated the `CSSProp` docblock
  * Updated the example usage to augment `Attributes` rather than `DOMAttributes`. This makes it possible to use `css` with custom components whose props don't extend DOMAttributes, and matches [the example usage in DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/35f7bccf0d312292ea79feac97d3b3274d34158c/types/styled-components/index.d.ts#L431).
  * Changed the description to be more oriented around the `css` prop rather than styled-components-related module augmentations in general (especially `DefaultTheme`).
* Export the `RuleSet` type, which could be useful when building functions that accept or return RuleSets (asked about in [this discussion topic](https://github.com/orgs/styled-components/discussions/3915)).