### PR TITLE
fix: correct dep declaration for styled-components

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -72,22 +72,10 @@
   "peerDependencies": {
     "babel-plugin-styled-components": ">= 2",
     "react": ">= 16.8.0",
-    "react-dom": ">= 16.8.0",
-    "shallowequal": ">= 1",
-    "stylis": "^4.0.0",
-    "tslib": "^2.0.0"
+    "react-dom": ">= 16.8.0"
   },
   "peerDependenciesMeta": {
     "babel-plugin-styled-components": {
-      "optional": true
-    },
-    "shallowequal": {
-      "optional": true
-    },
-    "stylis": {
-      "optional": true
-    },
-    "tslib": {
       "optional": true
     }
   },


### PR DESCRIPTION
## What changed

Remove the `shallowequal`、`stylis` and `tslib` from `peerDependencies` and `peerDependenciesMeta`

## Why do this

Firstly, PNPM will skip install the peer dependencies which mark as `optional: true`, even if they are declared in `dependencies`, so we will get the `Cannot resolve 'xxx'` error when compiling.

And I think these above peer dependencies should be dependencies, because `tslib` is similar to `@babel/runtime`, and the `stylis`, `shallowequal` are low-level dependencies, styled-components should not ask users for them, and the official documentation also does not require users to install them