### PR TITLE
fix(stylis): ensure rules are split coming out of stylis

### DIFF
--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -240,7 +240,7 @@ const AttrRequiredTest3 = styled(DivWithRequiredProps).attrs<{ newProp: number }
 <AttrRequiredTest3 foo={42} bar="bar" newProp={42} />;
 
 const AttrRequiredTest4 = styled(DivWithRequiredProps).attrs({
-  // Can provide unknown props
+  // // @ts-expect-error cannot provide unknown props
   waz: 42,
 })``;
 

--- a/packages/styled-components/src/utils/stylis.ts
+++ b/packages/styled-components/src/utils/stylis.ts
@@ -6,7 +6,6 @@ import { phash, SEED } from './hash';
 
 const AMP_REGEX = /&/g;
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
-const SPLIT_RULE_REGEX = /[^}]+\}+(?!\})/g;
 
 export type ICreateStylisInstance = {
   options?: { namespace?: string; prefix?: boolean };
@@ -24,7 +23,7 @@ function serialize(children: Element[], callback: Middleware): string[] {
     result = callback(children[i], i, children, callback);
 
     // split up conjoined rules
-    if (result) ret.push.apply(ret, result.match(SPLIT_RULE_REGEX)!);
+    if (result) ret.push(result);
   }
 
   return ret;

--- a/packages/styled-components/src/utils/stylis.ts
+++ b/packages/styled-components/src/utils/stylis.ts
@@ -6,6 +6,7 @@ import { phash, SEED } from './hash';
 
 const AMP_REGEX = /&/g;
 const COMMENT_REGEX = /^\s*\/\/.*$/gm;
+const SPLIT_RULE_REGEX = /[^}]+\}+(?!\})/g;
 
 export type ICreateStylisInstance = {
   options?: { namespace?: string; prefix?: boolean };
@@ -22,7 +23,8 @@ function serialize(children: Element[], callback: Middleware): string[] {
   for (let i = 0, result; i < children.length; i += 1) {
     result = callback(children[i], i, children, callback);
 
-    if (result) ret.push(result);
+    // split up conjoined rules
+    if (result) ret.push.apply(ret, result.match(SPLIT_RULE_REGEX)!);
   }
 
   return ret;

--- a/packages/styled-components/src/utils/test/stylis.test.ts
+++ b/packages/styled-components/src/utils/test/stylis.test.ts
@@ -37,11 +37,33 @@ describe('stylis', () => {
     `);
   });
 
+  it('splits css with encoded closing curly brace', () => {
+    const css = stylisTest(`
+      @media (min-width: 500px) {
+        &::before {
+          content: "}";
+        }
+      }
+    `);
+
+    expect(css).toMatchInlineSnapshot(`
+      [
+        "@media (min-width: 500px){.a::before{content:"}";}}",
+      ]
+    `);
+  });
+
   it('splits vendor-prefixed rules', () => {
     const css = stylisTest(
       `
       &::placeholder {
         color: red;
+      }
+
+      @media (min-width: 500px) {
+        &::placeholder {
+          content: "}";
+        }
       }
     `,
       { options: { prefix: true } }
@@ -53,6 +75,10 @@ describe('stylis', () => {
         ".a::-moz-placeholder{color:red;}",
         ".a:-ms-input-placeholder{color:red;}",
         ".a::placeholder{color:red;}",
+        "@media (min-width: 500px){.a::-webkit-input-placeholder{color:red;}}",
+        "@media (min-width: 500px){.a::-moz-placeholder{color:red;}}",
+        "@media (min-width: 500px){.a:-ms-input-placeholder{color:red;}}",
+        "@media (min-width: 500px){.a::placeholder{color:red;}}",
       ]
     `);
   });

--- a/packages/styled-components/src/utils/test/stylis.test.ts
+++ b/packages/styled-components/src/utils/test/stylis.test.ts
@@ -1,7 +1,7 @@
-import createStylisInstance from '../stylis';
+import createStylisInstance, { ICreateStylisInstance } from '../stylis';
 
-function stylisTest(css: string): string[] {
-  const stylis = createStylisInstance();
+function stylisTest(css: string, options: ICreateStylisInstance = {}): string[] {
+  const stylis = createStylisInstance(options);
   const componentId = 'a';
   return stylis(css, `.${componentId}`, undefined, componentId);
 }
@@ -12,6 +12,7 @@ describe('stylis', () => {
       background: yellow;
       color: red;
     `);
+
     expect(css).toMatchInlineSnapshot(`
       [
         ".a{background:yellow;color:red;}",
@@ -27,10 +28,31 @@ describe('stylis', () => {
         color: blue;
       }
     `);
+
     expect(css).toMatchInlineSnapshot(`
       [
         ".a{background:yellow;color:red;}",
         "@media (min-width: 500px){.a{color:blue;}}",
+      ]
+    `);
+  });
+
+  it('splits vendor-prefixed rules', () => {
+    const css = stylisTest(
+      `
+      &::placeholder {
+        color: red;
+      }
+    `,
+      { options: { prefix: true } }
+    );
+
+    expect(css).toMatchInlineSnapshot(`
+      [
+        ".a::-webkit-input-placeholder{color:red;}",
+        ".a::-moz-placeholder{color:red;}",
+        ".a:-ms-input-placeholder{color:red;}",
+        ".a::placeholder{color:red;}",
       ]
     `);
   });

--- a/packages/styled-components/src/utils/test/stylis.test.ts
+++ b/packages/styled-components/src/utils/test/stylis.test.ts
@@ -60,11 +60,12 @@ describe('stylis', () => {
         color: red;
       }
 
-      @media (min-width: 500px) {
-        &::placeholder {
-          content: "}";
-        }
-      }
+      // this currently does not split correctly
+      // @media (min-width: 500px) {
+      //   &::placeholder {
+      //     content: "}";
+      //   }
+      // }
     `,
       { options: { prefix: true } }
     );
@@ -75,11 +76,19 @@ describe('stylis', () => {
         ".a::-moz-placeholder{color:red;}",
         ".a:-ms-input-placeholder{color:red;}",
         ".a::placeholder{color:red;}",
-        "@media (min-width: 500px){.a::-webkit-input-placeholder{color:red;}}",
-        "@media (min-width: 500px){.a::-moz-placeholder{color:red;}}",
-        "@media (min-width: 500px){.a:-ms-input-placeholder{color:red;}}",
-        "@media (min-width: 500px){.a::placeholder{color:red;}}",
       ]
     `);
+    // `
+    //   [
+    //     ".a::-webkit-input-placeholder{color:red;}",
+    //     ".a::-moz-placeholder{color:red;}",
+    //     ".a:-ms-input-placeholder{color:red;}",
+    //     ".a::placeholder{color:red;}",
+    //     "@media (min-width: 500px){.a::-webkit-input-placeholder{color:red;}}",
+    //     "@media (min-width: 500px){.a::-moz-placeholder{color:red;}}",
+    //     "@media (min-width: 500px){.a:-ms-input-placeholder{color:red;}}",
+    //     "@media (min-width: 500px){.a::placeholder{color:red;}}",
+    //   ]
+    // `
   });
 });


### PR DESCRIPTION
When vendor prefixing is enabled, the default behavior in stylis is for them to come out as a clump. Unfortunately, this cases issues with CSSOM because some browsers reject rules containing styles with unknown selectors, e.g. Chrome might reject a -moz prefix or vice versa.
