### PR TITLE
Add failing TS tests for `forwardedAs` and css prop

### DIFF
--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -84,6 +84,8 @@ declare module 'react' {
   `}
 />;
 
+<Button css="padding: 0.5em 1em;" />;
+
 interface ColorizedComponentProps {
   color: string;
 }
@@ -97,6 +99,11 @@ function ColorizedComponent(props: ColorizedComponentProps) {
     color: ${props => props.color};
   `}
 />;
+
+/** forwardedAs should be a valid prop */
+const ForwardedTo = styled.button``;
+const ForwardedThrough = styled(ForwardedTo)``;
+<ForwardedThrough forwardedAs="a" href="#" />;
 
 // SVG generating overly-complex typings
 const MySVG = styled.svg.attrs({


### PR DESCRIPTION
Add failing type tests in `v6.0.0-rc.2` for the following issues:

1. `forwardedAs` prop is currently erroring, stating it does not exist.

![Screen Shot 2023-05-30 at 2 08 51 pm](https://github.com/styled-components/styled-components/assets/40346716/9cdd03b3-f232-4aa1-98ba-84c00e15ccbd)

2. `css` prop does not accept a simple string (as per docs example - https://styled-components.com/docs/api#css-prop)
    - This works if the string is passed as part of an array but not as just a string

![Screen Shot 2023-05-30 at 2 10 32 pm](https://github.com/styled-components/styled-components/assets/40346716/d99fe8cd-efba-4341-8db1-fb0d3f4a9c53)
