### PR TITLE
ensure useTheme hook returns theme object

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheetContext } from '../models/StyleSheetManager';
-import { DefaultTheme, useTheme } from '../models/ThemeProvider';
+import { DefaultTheme, ThemeContext } from '../models/ThemeProvider';
 import StyleSheet from '../sheet';
 import { ExecutionContext, ExecutionProps, Interpolation, Stringifier, Styles } from '../types';
 import { checkDynamicCreation } from '../utils/checkDynamicCreation';
@@ -24,7 +24,7 @@ export default function createGlobalStyle<Props extends object>(
 
   const GlobalStyleComponent: React.ComponentType<ExecutionProps & Props> = props => {
     const ssc = useStyleSheetContext();
-    const theme = useTheme();
+    const theme = React.useContext(ThemeContext);
     const instanceRef = React.useRef(ssc.styleSheet.allocateGSInstance(styledComponentId));
 
     const instance = instanceRef.current;

--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTheme } from '../models/ThemeProvider';
+import { ThemeContext } from '../models/ThemeProvider';
 import { AnyComponent, ExecutionProps } from '../types';
 import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
@@ -8,7 +8,7 @@ import hoist from '../utils/hoist';
 export default function withTheme<T extends AnyComponent>(Component: T) {
   const WithTheme = React.forwardRef<T, JSX.LibraryManagedAttributes<T, ExecutionProps>>(
     (props, ref) => {
-      const theme = useTheme();
+      const theme = React.useContext(ThemeContext);
       const themeProp = determineTheme(props, theme, Component.defaultProps);
 
       if (process.env.NODE_ENV !== 'production' && themeProp === undefined) {

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -31,7 +31,7 @@ import { joinStrings } from '../utils/joinStrings';
 import merge from '../utils/mixinDeep';
 import ComponentStyle from './ComponentStyle';
 import { useStyleSheetContext } from './StyleSheetManager';
-import { DefaultTheme, useTheme } from './ThemeProvider';
+import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
 const identifiers: { [key: string]: number } = {};
 
@@ -119,7 +119,7 @@ function useStyledComponentImpl<Target extends WebTarget, Props extends Executio
     target,
   } = forwardedComponent;
 
-  const contextTheme = useTheme();
+  const contextTheme = React.useContext(ThemeContext);
   const ssc = useStyleSheetContext();
   const shouldForwardProp = forwardedComponent.shouldForwardProp || ssc.shouldForwardProp;
 

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -21,7 +21,7 @@ import hoist from '../utils/hoist';
 import isFunction from '../utils/isFunction';
 import isStyledComponent from '../utils/isStyledComponent';
 import merge from '../utils/mixinDeep';
-import { DefaultTheme, useTheme } from './ThemeProvider';
+import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
 function useResolvedAttrs<Props extends object>(
   theme: DefaultTheme = EMPTY_OBJECT,
@@ -67,7 +67,7 @@ function useStyledComponentImpl<
     target,
   } = forwardedComponent;
 
-  const contextTheme = useTheme();
+  const contextTheme = React.useContext(ThemeContext);
 
   // NOTE: the non-hooks version only subscribes to this when !componentStyle.isStatic,
   // but that'd be against the rules-of-hooks. We could be naughty and do it anyway as it

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -66,11 +66,20 @@ function mergeTheme(theme: ThemeArgument, outerTheme?: DefaultTheme): DefaultThe
   return outerTheme ? { ...outerTheme, ...theme } : theme;
 }
 
+/**
+ * Returns the current theme (as provided by the closest ancestor `ThemeProvider`.)
+ *
+ * If no `ThemeProvider` is found, the function will error. If you need access to the theme in an
+ * uncertain composition scenario, `React.useContext(ThemeContext)` will not emit an error if there
+ * is no theme.
+ */
 export function useTheme(): DefaultTheme {
   const theme = useContext(ThemeContext);
+
   if (!theme) {
     throw styledError(18);
   }
+
   return theme;
 }
 

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -78,7 +78,7 @@ export function useTheme(): DefaultTheme {
  * Provide a theme to an entire react component tree via context
  */
 export default function ThemeProvider(props: Props): JSX.Element | null {
-  const outerTheme = useTheme();
+  const outerTheme = React.useContext(ThemeContext);
   const themeContext = useMemo(
     () => mergeTheme(props.theme, outerTheme),
     [props.theme, outerTheme]

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -71,7 +71,7 @@ function mergeTheme(theme: ThemeArgument, outerTheme?: DefaultTheme): DefaultThe
  *
  * If no `ThemeProvider` is found, the function will error. If you need access to the theme in an
  * uncertain composition scenario, `React.useContext(ThemeContext)` will not emit an error if there
- * is no theme.
+ * is no `ThemeProvider` ancestor.
  */
 export function useTheme(): DefaultTheme {
   const theme = useContext(ThemeContext);

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -66,8 +66,12 @@ function mergeTheme(theme: ThemeArgument, outerTheme?: DefaultTheme): DefaultThe
   return outerTheme ? { ...outerTheme, ...theme } : theme;
 }
 
-export function useTheme(): DefaultTheme | undefined {
-  return useContext(ThemeContext);
+export function useTheme(): DefaultTheme {
+  const theme = useContext(ThemeContext);
+  if(!theme) {
+    throw Error('can not use useTheme outside a ThemeProvider');
+  }
+  return theme;
 }
 
 /**

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -68,8 +68,8 @@ function mergeTheme(theme: ThemeArgument, outerTheme?: DefaultTheme): DefaultThe
 
 export function useTheme(): DefaultTheme {
   const theme = useContext(ThemeContext);
-  if(!theme) {
-    throw Error('can not use useTheme outside a ThemeProvider');
+  if (!theme) {
+    throw styledError(18);
   }
   return theme;
 }

--- a/packages/styled-components/src/utils/errors.md
+++ b/packages/styled-components/src/utils/errors.md
@@ -91,3 +91,25 @@ as for instance in your render method then you may be running into this limitati
 
 CSSStyleSheet could not be found on HTMLStyleElement.
 Has styled-components' style tag been unmounted or altered by another script?
+
+## 18
+
+Accessing `useTheme` hook outside of a `<ThemeProvider>` element.
+
+```jsx
+import { useTheme } from 'styled-components';
+export function StyledCompoent({ children }) {
+  const theme = useTheme();
+  return <div style={{ width: theme.sizes.full }}>{children}</div>;
+}
+
+import { StyledComponent } from './StyledComponent';
+import { theme } from './theme';
+export function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <StyledComponent />
+    </ThemeProvider>
+  );
+}
+```

--- a/packages/styled-components/src/utils/errors.md
+++ b/packages/styled-components/src/utils/errors.md
@@ -113,3 +113,5 @@ export function App() {
   );
 }
 ```
+
+If you need access to the theme in an uncertain composition scenario, `React.useContext(ThemeContext)` will not emit an error if there is no `ThemeProvider` ancestor.

--- a/packages/styled-components/src/utils/errors.ts
+++ b/packages/styled-components/src/utils/errors.ts
@@ -16,4 +16,5 @@ export default {
   '15': "A stylis plugin has been supplied that is not named. We need a name for each plugin to be able to prevent styling collisions between different stylis configurations within the same app. Before you pass your plugin to `<StyleSheetManager stylisPlugins={[]}>`, please make sure each plugin is uniquely-named, e.g.\n\n```js\nObject.defineProperty(importedPlugin, 'name', { value: 'some-unique-name' });\n```\n\n",
   '16': "Reached the limit of how many styled components may be created at group %s.\nYou may only create up to 1,073,741,824 components. If you're creating components dynamically,\nas for instance in your render method then you may be running into this limitation.\n\n",
   '17': "CSSStyleSheet could not be found on HTMLStyleElement.\nHas styled-components' style tag been unmounted or altered by another script?\n",
+  '18': 'ThemeProvider: Please make sure your useTheme hook is within a `<ThemeProvider>`',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9082,7 +9082,7 @@ style-loader@^3.3.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "6.0.0-rc.2"
+  version "6.0.0-rc.3"
   dependencies:
     "@babel/cli" "^7.21.0"
     "@babel/core" "^7.21.0"


### PR DESCRIPTION
Right now the return type for `useTheme: DefaultTheme | undefined` cause the usage of the hook to be extremely inconvenient where it might be `undefined`, using the hook need to verify the themes existence inside every component.

```typescript
export default () => {
  const theme: DefaultTheme | undefined = useTheme();

  return (
    <div>
      {theme.foo.bar} // 👈 this gives an error because theme could be undefined.
    <div>
  );
}
```

My suggestion is to add a check, inside the hook, that the theme is set using a `ThemeProvider`, otherwise throw an error for using the hook without a `ThemeProvider`.