### PR TITLE
Compatibility with frozen Object prototype, part 2

### DIFF
--- a/packages/styled-components/src/models/Keyframes.ts
+++ b/packages/styled-components/src/models/Keyframes.ts
@@ -1,6 +1,7 @@
 import StyleSheet from '../sheet';
 import { Keyframes as KeyframesType, Stringifier } from '../types';
 import styledError from '../utils/error';
+import { setToString } from '../utils/setToString';
 import { mainStylis } from './StyleSheetManager';
 
 export default class Keyframes implements KeyframesType {
@@ -12,6 +13,10 @@ export default class Keyframes implements KeyframesType {
     this.name = name;
     this.id = `sc-keyframes-${name}`;
     this.rules = rules;
+
+    setToString(this, () => {
+      throw styledError(12, String(this.name));
+    });
   }
 
   inject = (styleSheet: StyleSheet, stylisInstance: Stringifier = mainStylis): void => {
@@ -24,10 +29,6 @@ export default class Keyframes implements KeyframesType {
         stylisInstance(this.rules, resolvedName, '@keyframes')
       );
     }
-  };
-
-  toString = (): void => {
-    throw styledError(12, String(this.name));
   };
 
   getName(stylisInstance: Stringifier = mainStylis): string {

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -29,6 +29,7 @@ import isStyledComponent from '../utils/isStyledComponent';
 import isTag from '../utils/isTag';
 import { joinStrings } from '../utils/joinStrings';
 import merge from '../utils/mixinDeep';
+import { setToString } from '../utils/setToString';
 import ComponentStyle from './ComponentStyle';
 import { useStyleSheetContext } from './StyleSheetManager';
 import { DefaultTheme, useTheme } from './ThemeProvider';
@@ -285,13 +286,7 @@ function createStyledComponent<
     );
   }
 
-  // If the Object prototype is frozen, the "toString" property is non-writable. This means that any objects which inherit this property
-  // cannot have the property changed using an assignment. If using strict mode, attempting that will cause an error. If not using strict
-  // mode, attempting that will be silently ignored.
-  // However, we can still explicitly shadow the prototype's "toString" property by defining a new "toString" property on this object.
-  Object.defineProperty(WrappedStyledComponent, 'toString', {
-    value: () => `.${WrappedStyledComponent.styledComponentId}`,
-  });
+  setToString(WrappedStyledComponent, () => `.${WrappedStyledComponent.styledComponentId}`);
 
   if (isCompositeComponent) {
     const compositeComponentTarget = target as AnyComponent;

--- a/packages/styled-components/src/models/test/Keyframes.test.ts
+++ b/packages/styled-components/src/models/test/Keyframes.test.ts
@@ -1,0 +1,8 @@
+import Keyframes from '../Keyframes';
+
+describe('Keyframes', () => {
+  it('should throw an error when converted to string', () => {
+    const keyframes = new Keyframes('foo', 'bar');
+    expect(() => keyframes.toString()).toThrowError(/It seems you are interpolating a keyframe declaration \(foo\) into an untagged string./)
+  });
+});

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -1,5 +1,6 @@
 import { DISABLE_SPEEDY, IS_BROWSER } from '../constants';
 import { EMPTY_OBJECT } from '../utils/empties';
+import { setToString } from '../utils/setToString';
 import { makeGroupedTag } from './GroupedTag';
 import { getGroupForId } from './GroupIDAllocator';
 import { outputSheet, rehydrateSheet } from './Rehydration';
@@ -56,6 +57,8 @@ export default class StyleSheet implements Sheet {
       SHOULD_REHYDRATE = false;
       rehydrateSheet(this);
     }
+
+    setToString(this, () => outputSheet(this));
   }
 
   reconstructWithOptions(options: SheetConstructorArgs, withNames = true) {
@@ -117,10 +120,5 @@ export default class StyleSheet implements Sheet {
     // NOTE: This does not clear the names, since it's only used during SSR
     // so that we can continuously output only new rules
     this.tag = undefined;
-  }
-
-  /** Outputs the current sheet as a CSS string with markers for SSR */
-  toString(): string {
-    return outputSheet(this);
   }
 }

--- a/packages/styled-components/src/sheet/test/Sheet.test.ts
+++ b/packages/styled-components/src/sheet/test/Sheet.test.ts
@@ -41,3 +41,12 @@ it('clears rules correctly', () => {
   expect(sheet.hasNameForId('id', 'name')).toBe(false);
   expect(sheet.hasNameForId('dummy', 'dummy')).toBe(true);
 });
+
+it('converts to string correctly', () => {
+  sheet.insertRules('id', 'name', ['.test {}']);
+  expect(sheet.toString()).toMatchInlineSnapshot(`
+    ".test {}/*!sc*/
+    data-styled.g1[id="id"]{content:"name,"}/*!sc*/
+    "
+  `);
+});

--- a/packages/styled-components/src/utils/setToString.ts
+++ b/packages/styled-components/src/utils/setToString.ts
@@ -1,0 +1,19 @@
+/**
+ * If the Object prototype is frozen, the "toString" property is non-writable. This means that any objects which inherit this property
+ * cannot have the property changed using a "=" assignment operator. If using strict mode, attempting that will cause an error. If not using
+ * strict mode, attempting that will be silently ignored.
+ *
+ * If the Object prototype is frozen, inherited non-writable properties can still be shadowed using one of two mechanisms:
+ *
+ *  1. ES6 class methods: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#methods
+ *  2. Using the `Object.defineProperty()` static method:
+ *     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
+ *
+ * However, this project uses Babel to transpile ES6 classes, and transforms ES6 class methods to use the assignment operator instead:
+ * https://babeljs.io/docs/babel-plugin-transform-class-properties#options
+ *
+ * Therefore, the most compatible way to shadow the prototype's "toString" property is to define a new "toString" property on this object.
+ */
+export function setToString(object: object, toStringFn: () => string) {
+  Object.defineProperty(object, 'toString', { value: toStringFn });
+}


### PR DESCRIPTION
## Background

This PR is a follow-on to #3963. To summarize:

* Freezing the global Object prototype is one of the best ways to defend against Prototype Pollution attacks
* Doing this changes all properties of the Object prototype to become non-writable
* JavaScript does not allow you to use the "=" assignment operator to "shadow" any inherited, non-writable object properties -- in particular, the "toString" property
* The correct way to do this is to use the `Object.defineProperty()` syntax instead

## Description

I wasn't aware that this package uses Babel to transform ES6 class methods to object assignment.

For example, take this class:

```ts
class Foo {
  constructor() {}
  toString = () => 'bar';
}
```

If you have frozen your global Object prototype, that ES6 class method syntax would still work just fine.

However, this project uses Babel to transpile its code, which changes the ES6 class to a plain function:

```ts
var Foo = function Foo() {
  this.toString = function () {
    return 'bar';
  };
};
```

So, if you have frozen your global Object prototype, and you try to stringify an instance of `Foo`, it will not work.

The solution here is the same as in #3963. This PR has two commits:

1. 84fb41bd8cb1b951f2f25a79bd66caacfd560e78 -- add tests that are passing
2. efba71241826685948716d0aefb3e6ca62725372 -- change existing ES6 classes that define "toString" methods to use the `Object.defineProperty()` syntax instead

I also have another PR ready with the same changes for the legacy-v5 branch: #4043