### PR TITLE
Fix createGlobalStyle not removing styles on unmount

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -49,8 +49,7 @@ export default function createGlobalStyle<Props extends object>(
     }
 
     if (!__SERVER__) {
-      // @ts-expect-error still using React 17 types for the time being
-      (React.useInsertionEffect || React.useLayoutEffect)(() => {
+      React.useLayoutEffect(() => {
         if (!ssc.styleSheet.server) {
           renderStyles(instance, props, ssc.styleSheet, theme, ssc.stylis);
           return () => globalStyle.removeStyles(instance, ssc.styleSheet);


### PR DESCRIPTION
Fixes: https://github.com/styled-components/styled-components/issues/4100

Current implementation conditionally uses React18 `useInsertionEffect`; but useInsertionEffect does not have a return type: https://react.dev/reference/react/useInsertionEffect#returns and the global styles will not be removed when the GlobalStyle component is unmounted.