### PR TITLE
refactor(types): thread ability to replace Theme through typings

### DIFF
--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -42,6 +42,36 @@ type AttrsTarget<
     : FallbackTarget
   : FallbackTarget;
 
+/**
+ * A factory for creating styled-components. You may use it directly via `styled()` or one of the
+ * convenience methods like `styled.div` to create a particular element.
+ *
+ * ```tsx
+ * // syntaxes for making a component
+ * styled('div')``;
+ * styled(CustomReactComponent)``;
+ * styled.div``;
+ *
+ * // syntaxes for composing styles (note these work with any way of making a styled-component from above)
+ * styled.div`
+ *   color: red;
+ *
+ *   > * {
+ *     color: black;
+ *   }
+ * `;
+ *
+ * styled.div({
+ *   color: 'red',
+ *   '> *': { color: 'black' }
+ * });
+ *
+ * styled.div(props => ({
+ *   color: 'red',
+ *   '> *': { color: 'black' }
+ * }));
+ * ```
+ */
 export interface Styled<
   R extends Runtime,
   Theme extends object,

--- a/packages/styled-components/src/constructors/css.ts
+++ b/packages/styled-components/src/constructors/css.ts
@@ -1,5 +1,6 @@
 import {
   BaseObject,
+  DefaultTheme,
   Interpolation,
   NoInfer,
   RuleSet,
@@ -17,27 +18,32 @@ import isPlainObject from '../utils/isPlainObject';
  * Used when flattening object styles to determine if we should
  * expand an array of styles.
  */
-const addTag = <T extends RuleSet<any>>(arg: T): T & { isCss: true } =>
+const addTag = <T extends RuleSet<any, any>>(arg: T): T & { isCss: true } =>
   Object.assign(arg, { isCss: true } as const);
 
-function css(styles: Styles<object>, ...interpolations: Interpolation<object>[]): RuleSet<object>;
-function css<Props extends object>(
-  styles: Styles<NoInfer<Props>>,
-  ...interpolations: Interpolation<NoInfer<Props>>[]
-): RuleSet<NoInfer<Props>>;
-function css<Props extends object = BaseObject>(
-  styles: Styles<NoInfer<Props>>,
-  ...interpolations: Interpolation<NoInfer<Props>>[]
-): RuleSet<NoInfer<Props>> {
+function css<Props extends object = BaseObject, Theme extends object = DefaultTheme>(
+  styles: Styles<Props, Theme>,
+  ...interpolations: Interpolation<Props, Theme>[]
+): RuleSet<Props, Theme>;
+function css<Props extends object, Theme extends object = DefaultTheme>(
+  styles: Styles<NoInfer<Props>, Theme>,
+  ...interpolations: Interpolation<NoInfer<Props>, Theme>[]
+): RuleSet<NoInfer<Props>, Theme>;
+function css<Props extends object = BaseObject, Theme extends object = DefaultTheme>(
+  styles: Styles<NoInfer<Props>, Theme>,
+  ...interpolations: Interpolation<NoInfer<Props>, Theme>[]
+): RuleSet<NoInfer<Props>, Theme> {
   if (isFunction(styles) || isPlainObject(styles)) {
-    const styleFunctionOrObject = styles as StyleFunction<Props> | StyledObject<Props>;
+    const styleFunctionOrObject = styles as
+      | StyleFunction<Props, Theme>
+      | StyledObject<Props, Theme>;
 
     return addTag(
-      flatten<Props>(
-        interleave<Props>(EMPTY_ARRAY, [
-          styleFunctionOrObject,
-          ...interpolations,
-        ]) as Interpolation<object>
+      flatten<Props, Theme>(
+        interleave<Props>(EMPTY_ARRAY, [styleFunctionOrObject, ...interpolations]) as Interpolation<
+          object,
+          Theme
+        >
       )
     );
   }
@@ -49,11 +55,13 @@ function css<Props extends object = BaseObject>(
     styleStringArray.length === 1 &&
     typeof styleStringArray[0] === 'string'
   ) {
-    return flatten<Props>(styleStringArray);
+    return flatten<Props, Theme>(styleStringArray);
   }
 
   return addTag(
-    flatten<Props>(interleave<Props>(styleStringArray, interpolations) as Interpolation<object>)
+    flatten<Props, Theme>(
+      interleave<Props>(styleStringArray, interpolations) as Interpolation<object, Theme>
+    )
   );
 }
 

--- a/packages/styled-components/src/constructors/styled.tsx
+++ b/packages/styled-components/src/constructors/styled.tsx
@@ -1,18 +1,86 @@
 import createStyledComponent from '../models/StyledComponent';
-import { DefaultTheme, WebTarget } from '../types';
+import { BaseObject, DefaultTheme, KnownTarget, WebTarget } from '../types';
 import domElements from '../utils/domElements';
 import constructWithOptions, { Styled } from './constructWithOptions';
 
 const baseStyled = <Target extends WebTarget>(tag: Target) =>
   constructWithOptions<'web', DefaultTheme, Target>(createStyledComponent, tag);
 
+/**
+ * A factory for creating styled-components. You may use it directly via `styled()` or one of the
+ * convenience methods like `styled.div` to create a particular element.
+ *
+ * ```tsx
+ * // syntaxes for making a component
+ * styled('div')``;
+ * styled(CustomReactComponent)``;
+ * styled.div``;
+ *
+ * // syntaxes for composing styles (note these work with any way of making a styled-component from above)
+ * styled.div`
+ *   color: red;
+ *
+ *   > * {
+ *     color: black;
+ *   }
+ * `;
+ *
+ * styled.div({
+ *   color: 'red',
+ *   '> *': { color: 'black' }
+ * });
+ *
+ * styled.div(props => ({
+ *   color: 'red',
+ *   '> *': { color: 'black' }
+ * }));
+ *
+ * // then use it like any other React component
+ * const Box = styled.div`
+ *   color: red;
+ * `;
+ *
+ * function MyUI() {
+ *   return (
+ *     <Box>Things inside are red</Box>
+ *   );
+ * }
+ * ```
+ */
 const styled = baseStyled as typeof baseStyled & {
   [E in keyof JSX.IntrinsicElements]: Styled<'web', DefaultTheme, E, JSX.IntrinsicElements[E]>;
 };
 
 // Shorthands for all valid HTML Elements
 domElements.forEach(domElement => {
+  // @ts-ignore weird SVG element stuff
   styled[domElement] = baseStyled<typeof domElement>(domElement);
 });
 
 export default styled;
+
+export type ThemedStyledWebFactory<Theme extends object = DefaultTheme> = (<
+  Target extends WebTarget
+>(
+  tag: Target
+) => Styled<
+  'web',
+  Theme,
+  Target,
+  Target extends KnownTarget ? React.ComponentPropsWithRef<Target> : BaseObject
+>) & { [E in keyof JSX.IntrinsicElements]: Styled<'web', Theme, E, JSX.IntrinsicElements[E]> };
+
+/**
+ * This method is only necessary if there is a desire to provide separate `styled` factories that
+ * are preconfigured for a particular custom theme. Most commonly this will be third-party libraries
+ * composing styled-components that wish to skip the module-augmentation step that is typically
+ * required for providing custom theme data.
+ *
+ * ```tsx
+ * const styled = createThemedWebFactory<MyCustomTheme>();
+ *
+ * styled.div``
+ * ```
+ */
+export const createThemedWebFactory = <Theme extends object>() =>
+  styled as ThemedStyledWebFactory<Theme>;

--- a/packages/styled-components/src/constructors/styled.tsx
+++ b/packages/styled-components/src/constructors/styled.tsx
@@ -1,13 +1,13 @@
 import createStyledComponent from '../models/StyledComponent';
-import { WebTarget } from '../types';
+import { DefaultTheme, WebTarget } from '../types';
 import domElements from '../utils/domElements';
 import constructWithOptions, { Styled } from './constructWithOptions';
 
 const baseStyled = <Target extends WebTarget>(tag: Target) =>
-  constructWithOptions<'web', Target>(createStyledComponent, tag);
+  constructWithOptions<'web', DefaultTheme, Target>(createStyledComponent, tag);
 
 const styled = baseStyled as typeof baseStyled & {
-  [E in keyof JSX.IntrinsicElements]: Styled<'web', E, JSX.IntrinsicElements[E]>;
+  [E in keyof JSX.IntrinsicElements]: Styled<'web', DefaultTheme, E, JSX.IntrinsicElements[E]>;
 };
 
 // Shorthands for all valid HTML Elements

--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -1,4 +1,4 @@
-import styled from './constructors/styled';
+import styled, { createThemedWebFactory, type ThemedStyledWebFactory } from './constructors/styled';
 
 export * from './base';
 export {
@@ -17,4 +17,4 @@ export {
   StyledOptions,
   WebTarget,
 } from './types';
-export { styled, styled as default };
+export { createThemedWebFactory, styled, styled as default, type ThemedStyledWebFactory };

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -12,15 +12,15 @@ const SEED = hash(SC_VERSION);
 /**
  * ComponentStyle is all the CSS-specific stuff, not the React-specific stuff.
  */
-export default class ComponentStyle {
+export default class ComponentStyle<Theme extends object> {
   baseHash: number;
-  baseStyle: ComponentStyle | null | undefined;
+  baseStyle: ComponentStyle<Theme> | null | undefined;
   componentId: string;
   isStatic: boolean;
-  rules: RuleSet<any>;
+  rules: RuleSet<any, Theme>;
   staticRulesId: string;
 
-  constructor(rules: RuleSet<any>, componentId: string, baseStyle?: ComponentStyle) {
+  constructor(rules: RuleSet<any, Theme>, componentId: string, baseStyle?: ComponentStyle<Theme>) {
     this.rules = rules;
     this.staticRulesId = '';
     this.isStatic =
@@ -37,7 +37,7 @@ export default class ComponentStyle {
   }
 
   generateAndInjectStyles(
-    executionContext: ExecutionContext,
+    executionContext: ExecutionContext<Theme>,
     styleSheet: StyleSheet,
     stylis: Stringifier
   ): string {

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -21,20 +21,22 @@ export const resetStyleCache = (): void => {
 /**
  * InlineStyle takes arbitrary CSS and generates a flat object
  */
-export default function makeInlineStyleClass<Props extends object>(styleSheet: StyleSheet) {
-  const InlineStyle: IInlineStyleConstructor<Props> = class InlineStyle
-    implements IInlineStyle<Props>
+export default function makeInlineStyleClass<Props extends object, Theme extends object>(
+  styleSheet: StyleSheet
+) {
+  const InlineStyle: IInlineStyleConstructor<Props, Theme> = class InlineStyle
+    implements IInlineStyle<Props, Theme>
   {
-    rules: RuleSet<Props>;
+    rules: RuleSet<Props, Theme>;
 
-    constructor(rules: RuleSet<Props>) {
+    constructor(rules: RuleSet<Props, Theme>) {
       this.rules = rules;
     }
 
-    generateStyleObject(executionContext: ExecutionContext & Props) {
+    generateStyleObject(executionContext: ExecutionContext<Theme> & Props) {
       // keyframes, functions, and component selectors are not allowed for React Native
       const flatCSS = joinStringArray(
-        flatten(this.rules as RuleSet<object>, executionContext) as string[]
+        flatten(this.rules as RuleSet<object, Theme>, executionContext) as string[]
       );
       const hash = generateComponentId(flatCSS);
 

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -73,8 +73,8 @@ function mergeTheme(theme: ThemeArgument, outerTheme?: DefaultTheme): DefaultThe
  * uncertain composition scenario, `React.useContext(ThemeContext)` will not emit an error if there
  * is no `ThemeProvider` ancestor.
  */
-export function useTheme(): DefaultTheme {
-  const theme = useContext(ThemeContext);
+export function useTheme<Theme extends object = DefaultTheme>(): Theme {
+  const theme = useContext(ThemeContext) as Theme;
 
   if (!theme) {
     throw styledError(18);

--- a/packages/styled-components/src/native/index.ts
+++ b/packages/styled-components/src/native/index.ts
@@ -4,8 +4,13 @@ import css from '../constructors/css';
 import withTheme from '../hoc/withTheme';
 import _InlineStyle from '../models/InlineStyle';
 import _StyledNativeComponent from '../models/StyledNativeComponent';
-import ThemeProvider, { ThemeConsumer, ThemeContext, useTheme } from '../models/ThemeProvider';
-import { NativeTarget } from '../types';
+import ThemeProvider, {
+  DefaultTheme,
+  ThemeConsumer,
+  ThemeContext,
+  useTheme,
+} from '../models/ThemeProvider';
+import { BaseObject, NativeTarget } from '../types';
 import isStyledComponent from '../utils/isStyledComponent';
 
 const reactNative = require('react-native') as Awaited<typeof import('react-native')>;
@@ -14,7 +19,7 @@ const InlineStyle = _InlineStyle(reactNative.StyleSheet);
 const StyledNativeComponent = _StyledNativeComponent(InlineStyle);
 
 const baseStyled = <Target extends NativeTarget>(tag: Target) =>
-  constructWithOptions<'native', Target>(StyledNativeComponent, tag);
+  constructWithOptions<'native', DefaultTheme, Target>(StyledNativeComponent, tag);
 
 /* React native lazy-requires each of these modules for some reason, so let's
  *  assume it's for a good reason and not eagerly load them all */
@@ -54,9 +59,47 @@ type RNComponents = {
     : never;
 };
 
-const styled = baseStyled as typeof baseStyled & {
-  [E in KnownComponents]: Styled<'native', RNComponents[E], React.ComponentProps<RNComponents[E]>>;
+export const styled = baseStyled as typeof baseStyled & {
+  [E in KnownComponents]: Styled<
+    'native',
+    DefaultTheme,
+    RNComponents[E],
+    React.ComponentProps<RNComponents[E]>
+  >;
 };
+
+export type ThemedStyledNativeFactory<Theme extends object = DefaultTheme> = (<
+  Target extends NativeTarget
+>(
+  tag: Target
+) => Styled<
+  'web',
+  Theme,
+  Target,
+  Target extends React.ComponentType<any> ? React.ComponentPropsWithRef<Target> : BaseObject
+>) & {
+  [E in keyof typeof reactNative]: Styled<
+    'native',
+    Theme,
+    RNComponents[E],
+    React.ComponentPropsWithRef<RNComponents[E]>
+  >;
+};
+
+/**
+ * This method is only necessary if there is a desire to provide separate `styled` factories that
+ * are preconfigured for a particular custom theme. Most commonly this will be third-party libraries
+ * composing styled-components that wish to skip the module-augmentation step that is typically
+ * required for providing custom theme data.
+ *
+ * ```tsx
+ * const styled = createThemedFactory<MyCustomTheme>();
+ *
+ * styled.View``
+ * ```
+ */
+export const createThemedNativeFactory = <Theme extends object>() =>
+  styled as ThemedStyledNativeFactory<Theme>;
 
 /* Define a getter for each alias which simply gets the reactNative component
  * and passes it to styled */
@@ -91,4 +134,4 @@ export {
   StyledOptions,
 } from '../types';
 export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme };
-export { styled, styled as default };
+export { styled as default };

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -2,7 +2,7 @@
  * This file is meant for typing-related tests that don't need to go through Jest.
  */
 import React from 'react';
-import { css, CSSProp, IStyledComponent, StyledObject } from '../index';
+import { css, CSSProp, DefaultTheme, IStyledComponent, StyledObject } from '../index';
 import styled from '../index-standalone';
 import { DataAttributes } from '../types';
 import { VeryLargeUnionType } from './veryLargeUnionType';
@@ -204,10 +204,10 @@ const InheritedDivWithProps = styled(DivWithProps)`
 /** StyledObject should accept undefined properties
  * https://github.com/styled-components/styled-components/issues/3800#issuecomment-1548941843
  */
-interface MyStyle extends StyledObject<object> {
+interface MyStyle extends StyledObject<object, DefaultTheme> {
   fontSize: string;
   lineHeight: string;
-  textTransform?: StyledObject<object>['textTransform'];
+  textTransform?: StyledObject<object, DefaultTheme>['textTransform'];
 }
 
 const DivWithRequiredProps = styled.div.attrs<{ foo?: number; bar: string }>({
@@ -309,7 +309,7 @@ const StyledDiv = styled.div``;
 
 const CustomComponent = (({ ...props }) => {
   return <StyledDiv {...props} />;
-}) as IStyledComponent<'web', JSX.IntrinsicElements['div']>;
+}) as IStyledComponent<'web', DefaultTheme, JSX.IntrinsicElements['div']>;
 
 const StyledCustomComponent = styled(CustomComponent)``;
 

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -2,7 +2,15 @@
  * This file is meant for typing-related tests that don't need to go through Jest.
  */
 import React from 'react';
-import { css, CSSProp, DefaultTheme, IStyledComponent, StyledObject } from '../index';
+import { createThemedWebFactory } from '../constructors/styled';
+import {
+  createGlobalStyle,
+  css,
+  CSSProp,
+  DefaultTheme,
+  IStyledComponent,
+  StyledObject,
+} from '../index';
 import styled from '../index-standalone';
 import { DataAttributes } from '../types';
 import { VeryLargeUnionType } from './veryLargeUnionType';
@@ -411,3 +419,18 @@ const StylingText = styled(Text2)({
 const ButtonEventTest = styled.button``;
 
 const ButtonEventTestExample = () => <ButtonEventTest onClick={e => console.log(e)} />;
+
+/** Custom theming */
+type CustomTheme = {
+  color: 'red' | 'black';
+};
+
+const themedStyled = createThemedWebFactory<CustomTheme>();
+
+const CustomThemeGlobalStyle = createGlobalStyle<object, CustomTheme>`
+  color: ${p => p.theme.color};
+`;
+
+const ThemedStyledDiv = themedStyled.div`
+  color: ${p => p.theme.color};
+`;

--- a/packages/styled-components/src/utils/determineTheme.ts
+++ b/packages/styled-components/src/utils/determineTheme.ts
@@ -1,10 +1,10 @@
 import { DefaultTheme, ExecutionProps } from '../types';
 import { EMPTY_OBJECT } from './empties';
 
-export default function determineTheme(
-  props: ExecutionProps,
-  providedTheme?: DefaultTheme,
-  defaultProps: { theme?: DefaultTheme } = EMPTY_OBJECT
-): DefaultTheme | undefined {
+export default function determineTheme<Theme extends object = DefaultTheme>(
+  props: ExecutionProps<Theme>,
+  providedTheme?: Theme,
+  defaultProps: { theme?: Theme } = EMPTY_OBJECT
+): Theme | undefined {
   return (props.theme !== defaultProps.theme && props.theme) || providedTheme || defaultProps.theme;
 }

--- a/packages/styled-components/src/utils/domElements.ts
+++ b/packages/styled-components/src/utils/domElements.ts
@@ -1,6 +1,6 @@
 // Thanks to ReactDOMFactories for this handy list!
 
-export default new Set([
+export default new Set<keyof JSX.IntrinsicElements>([
   'a',
   'abbr',
   'address',

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -45,19 +45,19 @@ export const objToCssArray = (obj: Dict<any>): string[] => {
   return rules;
 };
 
-export default function flatten<Props extends object>(
-  chunk: Interpolation<object>,
-  executionContext?: ExecutionContext & Props,
+export default function flatten<Props extends object, Theme extends object>(
+  chunk: Interpolation<object, Theme>,
+  executionContext?: ExecutionContext<Theme> & Props,
   styleSheet?: StyleSheet,
   stylisInstance?: Stringifier
-): RuleSet<Props> {
+): RuleSet<Props, Theme> {
   if (isFalsish(chunk)) {
     return [];
   }
 
   /* Handle other components */
   if (isStyledComponent(chunk)) {
-    return [`.${(chunk as unknown as IStyledComponent<'web', any>).styledComponentId}`];
+    return [`.${(chunk as unknown as IStyledComponent<'web', Theme, any>).styledComponentId}`];
   }
 
   /* Either execute or defer the function */
@@ -80,9 +80,9 @@ export default function flatten<Props extends object>(
         );
       }
 
-      return flatten<Props>(result, executionContext, styleSheet, stylisInstance);
+      return flatten<Props, Theme>(result, executionContext, styleSheet, stylisInstance);
     } else {
-      return [chunk as unknown as IStyledComponent<'web'>];
+      return [chunk as unknown as IStyledComponent<'web', Theme>];
     }
   }
 
@@ -97,7 +97,7 @@ export default function flatten<Props extends object>(
 
   /* Handle objects */
   if (isPlainObject(chunk)) {
-    return objToCssArray(chunk as StyledObject<Props>);
+    return objToCssArray(chunk as StyledObject<Props, Theme>);
   }
 
   if (!Array.isArray(chunk)) {
@@ -105,7 +105,7 @@ export default function flatten<Props extends object>(
   }
 
   return flatMap(chunk, chunklet =>
-    flatten<Props>(chunklet, executionContext, styleSheet, stylisInstance)
+    flatten<Props, Theme>(chunklet, executionContext, styleSheet, stylisInstance)
   );
 }
 


### PR DESCRIPTION
This is a WIP to create a mechanism for strongly-typed styled components themes without overriding `DefaultTheme` via module augmentation.