### PR TITLE
Fix Typescript issues with StyleFunctions and StyledObjects

### DIFF
--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -448,7 +448,7 @@ styled.div<PropsWithVariant>`
 /**
  * Styled object as function return value when prop types are provided
  */
-const Bar = styled.div<PropsWithVariant>`
+styled.div<PropsWithVariant>`
   ${p => ({
     color: 'blue',
   })};

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -421,7 +421,7 @@ type Props = {
   $color: string;
 };
 
-const sizeStyles = css<Pick<Props, '$size'>>`
+const sizeStyles = css<Props>`
   font-size: ${props => props.$size}px;
 `;
 

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -411,3 +411,45 @@ const StylingText = styled(Text2)({
 const ButtonEventTest = styled.button``;
 
 const ButtonEventTestExample = () => <ButtonEventTest onClick={e => console.log(e)} />;
+
+/**
+ * Using "css" result as an interpolation value in a styled(Component)
+ * https://github.com/styled-components/styled-components/issues/4099
+ */
+type Props = {
+  $size: number;
+  $color: string;
+};
+
+const sizeStyles = css<Pick<Props, '$size'>>`
+  font-size: ${props => props.$size}px;
+`;
+
+styled.div<Props>`
+  color: ${props => props.$color};
+  ${sizeStyles};
+`;
+
+/**
+ * StyleFunction prop types when a StyleFunction returns another StyleFunction and prop types are provided
+ */
+type PropsWithVariant = {
+  variant: 'primary' | 'secondary';
+};
+
+function getStyle(p: PropsWithVariant) {
+  return p.variant === 'primary' ? 'blue' : 'green';
+}
+
+styled.div<PropsWithVariant>`
+  color: ${p => p => getStyle(p)};
+`;
+
+/**
+ * Styled object as function return value when prop types are provided
+ */
+const Bar = styled.div<PropsWithVariant>`
+  ${p => ({
+    color: 'blue',
+  })};
+`;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -91,7 +91,7 @@ export type Interpolation<Props extends object> =
   | null
   | Keyframes
   | StyledComponentBrand
-  | RuleSet<object>
+  | RuleSet<Props>
   | Interpolation<Props>[];
 
 export type Attrs<Props extends object = BaseObject> =

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -77,7 +77,7 @@ export interface ExecutionContext extends ExecutionProps {
 }
 
 export interface StyleFunction<Props extends object> {
-  (executionContext: ExecutionContext & Props): Interpolation<object>;
+  (executionContext: ExecutionContext & Props): Interpolation<Props>;
 }
 
 export type Interpolation<Props extends object> =
@@ -230,7 +230,7 @@ export interface IInlineStyle<Props extends object> {
   generateStyleObject(executionContext: ExecutionContext & Props): object;
 }
 
-export type StyledObject<Props extends object> = Substitute<Props, CSS.Properties> & {
+export type StyledObject<Props extends object> = CSS.Properties & {
   [key: string]:
     | string
     | number


### PR DESCRIPTION
This PR improves the types when a `StyleFunction` returns another `StyleFunction` or a `StyledObject` as the return value. This prevents type errors when component prop types are explicitly provided (i.e. `styled.div<Props>`)

Examples have been addd in `test/types.tsx` for three different test cases:

1. When a reusable `css` block is provided as an interpolation value
2. When a StyleFunction returns another StyleFunction
3. When a StyleFunction returns a StyledObject

This fixes https://github.com/styled-components/styled-components/issues/4099 