### PR TITLE
fix(types): allow number for height/width/etc (#4090)

### DIFF
--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -362,6 +362,8 @@ const AttrFunctionRequiredTest5 = styled(DivWithUnfulfilledRequiredProps).attrs(
 type CSSPropTestType = { color?: string; css?: CSSProp };
 styled.div<CSSPropTestType>(_ => ({ css: 'color: red;' }));
 styled.div<CSSPropTestType>(_ => ({ css: { color: 'red' } }));
+styled.div<CSSPropTestType>(_ => ({ css: { height: '42px' } }));
+styled.div<CSSPropTestType>(_ => ({ css: { height: 42 } }));
 styled.div<CSSPropTestType>(_ => ({ css: () => ({ color: 'red' }) }));
 styled.div<CSSPropTestType>(_ => ({
   css: css`

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -230,7 +230,7 @@ export interface IInlineStyle<Props extends object> {
   generateStyleObject(executionContext: ExecutionContext & Props): object;
 }
 
-export type StyledObject<Props extends object> = CSS.Properties & {
+export type StyledObject<Props extends object> = CSS.Properties<number | (string & {})> & {
   [key: string]:
     | string
     | number


### PR DESCRIPTION
Fixes https://github.com/styled-components/styled-components/issues/4090

The `TLength` generic from `CSS.Properties` defaults to `TLength = 0 | (string & {})`, I verified that before my change I am able to provide `0`, but any other size needs to be a string.

With this changed to `number | (string & {})` I can provide any number or string.

I also added a test for this, providing the number as a height presented a type error before this fix but is resolved after.
