### PR TITLE
Add missing types CSSProperties, CSSObject, CSSPseudos and CSSKeyframes

### DIFF
--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -2,7 +2,11 @@ import styled from './constructors/styled';
 
 export * from './base';
 export {
+  CSSKeyframes,
+  CSSObject,
   CSSProp,
+  CSSProperties,
+  CSSPseudos,
   DefaultTheme,
   ExecutionContext,
   ExecutionProps,
@@ -17,4 +21,4 @@ export {
   StyledOptions,
   WebTarget,
 } from './types';
-export { styled, styled as default };
+export { styled as default, styled };

--- a/packages/styled-components/src/native/index.ts
+++ b/packages/styled-components/src/native/index.ts
@@ -77,6 +77,10 @@ aliases.forEach(alias =>
 );
 
 export {
+  CSSKeyframes,
+  CSSObject,
+  CSSProperties,
+  CSSPseudos,
   DefaultTheme,
   ExecutionContext,
   ExecutionProps,
@@ -90,5 +94,14 @@ export {
   StyledObject,
   StyledOptions,
 } from '../types';
-export { css, isStyledComponent, ThemeProvider, ThemeConsumer, ThemeContext, withTheme, useTheme };
-export { styled, styled as default };
+export {
+  ThemeConsumer,
+  ThemeContext,
+  ThemeProvider,
+  css,
+  styled as default,
+  isStyledComponent,
+  styled,
+  useTheme,
+  withTheme,
+};

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -237,15 +237,25 @@ export interface IInlineStyle<Props extends object> {
   generateStyleObject(executionContext: ExecutionContext & Props): object;
 }
 
-export type StyledObject<Props extends object> = CSS.Properties<number | (string & {})> & {
-  [key: string]:
-    | string
-    | number
-    | StyleFunction<Props>
-    | StyledObject<Props>
-    | RuleSet<any>
-    | undefined;
-};
+export type CSSProperties = CSS.Properties<number | (string & {})>;
+
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
+
+export type CSSKeyframes = object & { [key: string]: CSSObject };
+
+export type CSSObject = StyledObject<any>;
+
+export type StyledObject<Props extends object> = CSSProperties &
+  CSSPseudos & {
+    [key: string]:
+      | StyledObject<any> // StyledObject<any> instead of CSSObject. Because writing CSSObject directly results in a circularly references.
+      | string
+      | number
+      | StyleFunction<Props>
+      | StyledObject<Props>
+      | RuleSet<any>
+      | undefined;
+  };
 
 /**
  * The `css` prop is not declared by default in the types as it would cause `css` to be present
@@ -275,13 +285,3 @@ export type CSSProp = Interpolation<any>;
 export type NoInfer<T> = [T][T extends any ? 0 : never];
 
 export type Substitute<A extends object, B extends object> = FastOmit<A, keyof B> & B;
-
-export type CSSProperties = CSS.Properties<string | number>;
-
-export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
-
-export interface CSSObject extends CSSProperties, CSSPseudos {
-  [key: string]: CSSObject | string | number | undefined;
-}
-
-export type CSSKeyframes = object & { [key: string]: CSSObject };

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -126,7 +126,12 @@ export interface Flattener<Props extends object> {
 }
 
 export interface Stringifier {
-  (css: string, selector?: string | undefined, prefix?: string | undefined, componentId?: string | undefined): string[];
+  (
+    css: string,
+    selector?: string | undefined,
+    prefix?: string | undefined,
+    componentId?: string | undefined
+  ): string[];
   hash: string;
 }
 
@@ -148,7 +153,9 @@ export interface IStyledStatics<R extends Runtime, OuterProps extends object>
   inlineStyle: R extends 'native' ? InstanceType<IInlineStyleConstructor<OuterProps>> : never;
   target: StyledTarget<R>;
   styledComponentId: R extends 'web' ? string : never;
-  warnTooManyClasses?: (R extends 'web' ? ReturnType<typeof createWarnTooManyClasses> : never) | undefined;
+  warnTooManyClasses?:
+    | (R extends 'web' ? ReturnType<typeof createWarnTooManyClasses> : never)
+    | undefined;
 }
 
 /**
@@ -268,3 +275,13 @@ export type CSSProp = Interpolation<any>;
 export type NoInfer<T> = [T][T extends any ? 0 : never];
 
 export type Substitute<A extends object, B extends object> = FastOmit<A, keyof B> & B;
+
+export type CSSProperties = CSS.Properties<string | number>;
+
+export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
+
+export interface CSSObject extends CSSProperties, CSSPseudos {
+  [key: string]: CSSObject | string | number | undefined;
+}
+
+export type CSSKeyframes = object & { [key: string]: CSSObject };


### PR DESCRIPTION
https://github.com/styled-components/styled-components/issues/4062

I found that styled-components has lost some types since v6. There is actually an issue.

I added some of them.

- CSSProperties
- CSSObject
- CSSPseudos
- CSSKeyframes

I tried to work on the other types, but they were too complicated, so I am dealing with what I can for now.