### PR TITLE
Fix don't omit theme at runtime

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -143,7 +143,7 @@ function useStyledComponentImpl<Props extends object>(
     if (context[key] === undefined) {
       // Omit undefined values from props passed to wrapped element.
       // This enables using .attrs() to remove props, for example.
-    } else if (key[0] === '$' || key === 'as' || key === 'theme') {
+    } else if (key[0] === '$' || key === 'as') {
       // Omit transient props and execution props.
     } else if (key === 'forwardedAs') {
       propsForElement.as = context.forwardedAs;

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -316,6 +316,7 @@ describe('StyleSheetManager', () => {
       <div
         bar={true}
         className="sc-a b"
+        theme={{}}
       >
         Foo
       </div>
@@ -381,12 +382,13 @@ describe('StyleSheetManager', () => {
     `);
 
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
-            <div
-              className="sc-a b"
-            >
-              Foo
-            </div>
-        `);
+      <div
+        className="sc-a b"
+        theme={{}}
+      >
+        Foo
+      </div>
+    `);
 
     act(() => {
       wrapper.update(
@@ -406,12 +408,13 @@ describe('StyleSheetManager', () => {
     `);
 
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
-            <div
-              className="sc-a c"
-            >
-              Foo
-            </div>
-        `);
+      <div
+        className="sc-a c"
+        theme={{}}
+      >
+        Foo
+      </div>
+    `);
 
     act(() => {
       wrapper.update(
@@ -431,12 +434,13 @@ describe('StyleSheetManager', () => {
     `);
 
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
-            <div
-              className="sc-a b"
-            >
-              Foo
-            </div>
-        `);
+      <div
+        className="sc-a b"
+        theme={{}}
+      >
+        Foo
+      </div>
+    `);
   });
 
   it('subtrees with different stylis configs should not conflict', () => {
@@ -465,11 +469,13 @@ describe('StyleSheetManager', () => {
       <div>
         <div
           className="sc-a b"
+          theme={{}}
         >
           Bar
         </div>
         <div
           className="sc-a c"
+          theme={{}}
         >
           Foo
         </div>

--- a/packages/styled-components/src/test/__snapshots__/attrs.test.tsx.snap
+++ b/packages/styled-components/src/test/__snapshots__/attrs.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`attrs does not pass transient props to HTML element 1`] = `
 <div
   className="sc-a sc-b c"
+  theme={{}}
 />
 `;
 
@@ -10,6 +11,7 @@ exports[`attrs merge attrs 1`] = `
 <button
   className="sc-a"
   tabIndex={0}
+  theme={{}}
   type="submit"
 />
 `;
@@ -18,6 +20,7 @@ exports[`attrs merge attrs when inheriting SC 1`] = `
 <button
   className="sc-a sc-b"
   tabIndex={0}
+  theme={{}}
   type="submit"
 />
 `;
@@ -33,6 +36,7 @@ exports[`attrs pass a React component 1`] = `
 exports[`attrs pass a simple attr via function with object return 1`] = `
 <button
   className="sc-a"
+  theme={{}}
   type="button"
 />
 `;
@@ -40,6 +44,7 @@ exports[`attrs pass a simple attr via function with object return 1`] = `
 exports[`attrs pass a simple attr via object 1`] = `
 <button
   className="sc-a"
+  theme={{}}
   type="button"
 />
 `;
@@ -49,12 +54,14 @@ exports[`attrs pass attrs to style block 1`] = `
   className="sc-a b"
   data-active-class-name="--is-active"
   href="#"
+  theme={{}}
 />
 `;
 
 exports[`attrs pass props to the attr function 1`] = `
 <button
   className="sc-a"
+  theme={{}}
   type="button"
 />
 `;
@@ -62,6 +69,7 @@ exports[`attrs pass props to the attr function 1`] = `
 exports[`attrs pass props to the attr function 2`] = `
 <button
   className="sc-a"
+  theme={{}}
   type="submit"
 />
 `;
@@ -70,30 +78,35 @@ exports[`attrs should apply given "as" prop to the progressive type 1`] = `
 <video
   className="sc-a"
   loop={true}
+  theme={{}}
 />
 `;
 
 exports[`attrs should merge className 1`] = `
 <div
   className="sc-a meow nya"
+  theme={{}}
 />
 `;
 
 exports[`attrs should merge className even if its a function 1`] = `
 <div
   className="sc-a meow nya"
+  theme={{}}
 />
 `;
 
 exports[`attrs should merge className even if its a function 2`] = `
 <div
   className="sc-a meow purr"
+  theme={{}}
 />
 `;
 
 exports[`attrs should override children of course 1`] = `
 <div
   className="sc-a"
+  theme={{}}
 >
   <span>
     Amazing
@@ -104,6 +117,7 @@ exports[`attrs should override children of course 1`] = `
 exports[`attrs should pass through children as a normal prop 1`] = `
 <div
   className="sc-a"
+  theme={{}}
 >
   Probably a bad idea
 </div>
@@ -112,6 +126,7 @@ exports[`attrs should pass through children as a normal prop 1`] = `
 exports[`attrs should pass through complex children as well 1`] = `
 <div
   className="sc-a"
+  theme={{}}
 >
   <span>
     Probably a bad idea
@@ -123,6 +138,7 @@ exports[`attrs should replace props with attrs 1`] = `
 <button
   className="sc-a"
   tabIndex={0}
+  theme={{}}
   type="button"
 />
 `;
@@ -131,6 +147,7 @@ exports[`attrs should replace props with attrs 2`] = `
 <button
   className="sc-a"
   tabIndex={0}
+  theme={{}}
   type="button"
 />
 `;
@@ -139,6 +156,7 @@ exports[`attrs should replace props with attrs 3`] = `
 <button
   className="sc-a"
   tabIndex={0}
+  theme={{}}
   type="button"
 />
 `;
@@ -148,17 +166,20 @@ exports[`attrs should work with data and aria attributes 1`] = `
   aria-label="A simple FooBar"
   className="sc-a"
   data-foo="bar"
+  theme={{}}
 />
 `;
 
 exports[`attrs work fine with a function that returns an empty object 1`] = `
 <div
   className="sc-a"
+  theme={{}}
 />
 `;
 
 exports[`attrs work fine with an empty object 1`] = `
 <div
   className="sc-a"
+  theme={{}}
 />
 `;

--- a/packages/styled-components/src/test/__snapshots__/expanded-api.test.tsx.snap
+++ b/packages/styled-components/src/test/__snapshots__/expanded-api.test.tsx.snap
@@ -3,77 +3,90 @@
 exports[`expanded api "as" prop changes the rendered element type 1`] = `
 <span
   className="sc-a b"
+  theme={{}}
 />
 `;
 
 exports[`expanded api "as" prop changes the rendered element type when used with attrs 1`] = `
 <header
   className="sc-a b"
+  theme={{}}
 />
 `;
 
 exports[`expanded api "as" prop works with custom components 1`] = `
 <figure
   className="sc-a b"
+  theme={{}}
 />
 `;
 
 exports[`expanded api chaining should keep the last value passed in when merging 1`] = `
 <div
   className="dn-5-id-4"
+  theme={{}}
 />
 `;
 
 exports[`expanded api chaining should merge the options strings 1`] = `
 <div
   className="dn-2-id-1"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be attached if passed in 1`] = `
 <div
   className="LOLOMG"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be attached if passed in 2`] = `
 <div
   className="OMGLOL"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be combined with displayName if both passed in 1`] = `
 <div
   className="Comp-LOLOMG"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be combined with displayName if both passed in 2`] = `
 <div
   className="Comp2-OMGLOL"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be generated as "sc" + hash 1`] = `
 <div
   className="sc-a"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be generated as "sc" + hash 2`] = `
 <div
   className="sc-b"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be generated from displayName + hash 1`] = `
 <div
   className="Comp-a"
+  theme={{}}
 />
 `;
 
 exports[`expanded api componentId should be generated from displayName + hash 2`] = `
 <div
   className="Comp2-b"
+  theme={{}}
 />
 `;

--- a/packages/styled-components/src/test/__snapshots__/props.test.tsx.snap
+++ b/packages/styled-components/src/test/__snapshots__/props.test.tsx.snap
@@ -5,10 +5,12 @@ exports[`props shouldForwardProp should inherit shouldForwardProp for wrapped st
   <div
     className="sc-a c"
     id="test-1"
+    theme={{}}
   />,
   <div
     className="sc-a sc-b d"
     id="test-2"
+    theme={{}}
   />,
 ]
 `;

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.tsx.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ssr should add a nonce to the stylesheet if webpack nonce is detected in the global scope 1`] = `
-<h1 class="sc-b c">
+<h1 theme="[object Object]"
+    class="sc-b c"
+>
   Hello SSR!
 </h1>
 `;
@@ -19,7 +21,9 @@ data-styled.g2[id="sc-b"]{content:"c,"}/*!sc*/
 `;
 
 exports[`ssr should extract both global and local CSS 1`] = `
-<h1 class="sc-b c">
+<h1 theme="[object Object]"
+    class="sc-b c"
+>
   Hello SSR!
 </h1>
 `;
@@ -36,7 +40,9 @@ data-styled.g2[id="sc-b"]{content:"c,"}/*!sc*/
 `;
 
 exports[`ssr should extract the CSS in a simple case 1`] = `
-<h1 class="sc-a b">
+<h1 theme="[object Object]"
+    class="sc-a b"
+>
   Hello SSR!
 </h1>
 `;
@@ -61,16 +67,22 @@ data-styled.g1[id="sc-global-a1"]{content:"sc-global-a1,"}/*!sc*/
 .c{color:red;}/*!sc*/
 data-styled.g2[id="sc-b"]{content:"c,"}/*!sc*/
 </style>
-<h1 class="sc-b c">
+<h1 theme="[object Object]"
+    class="sc-b c"
+>
   Hello SSR!
 </h1>
 `;
 
 exports[`ssr should render CSS in the order the components were defined, not rendered 1`] = `
 <div>
-  <h2 class="TWO a">
+  <h2 theme="[object Object]"
+      class="TWO a"
+  >
   </h2>
-  <h1 class="ONE b">
+  <h1 theme="[object Object]"
+      class="ONE b"
+  >
   </h1>
 </div>
 `;
@@ -116,7 +128,9 @@ data-styled.g1[id="sc-global-a1"]{content:"sc-global-a1,"}/*!sc*/
 .c{color:red;}/*!sc*/
 data-styled.g2[id="sc-b"]{content:"c,"}/*!sc*/
 </style>
-<h1 class="sc-b c">
+<h1 theme="[object Object]"
+    class="sc-b c"
+>
   Hello SSR!
 </h1>
 `;
@@ -144,7 +158,9 @@ data-styled.g1[id="sc-global-a1"]{content:"sc-global-a1,"}/*!sc*/
 .c{color:red;}/*!sc*/
 data-styled.g2[id="sc-b"]{content:"c,"}/*!sc*/
 </style>
-<h1 class="sc-b c">
+<h1 theme="[object Object]"
+    class="sc-b c"
+>
   Hello SSR!
 </h1>
 `;

--- a/packages/styled-components/src/test/attrs.test.tsx
+++ b/packages/styled-components/src/test/attrs.test.tsx
@@ -92,6 +92,11 @@ describe('attrs', () => {
       <button
         className="sc-a"
         data-color="red"
+        theme={
+          {
+            "color": "red",
+          }
+        }
       />
     `);
   });
@@ -111,6 +116,11 @@ describe('attrs', () => {
       <button
         className="sc-a"
         data-color="red"
+        theme={
+          {
+            "color": "red",
+          }
+        }
       />
     `);
   });
@@ -153,6 +163,7 @@ describe('attrs', () => {
     expect(TestRenderer.create(<Comp className="something" />).toJSON()).toMatchInlineSnapshot(`
       <div
         className="sc-a sc-b foo meow nya something"
+        theme={{}}
       />
     `);
   });
@@ -182,6 +193,7 @@ describe('attrs', () => {
             "color": "red",
           }
         }
+        theme={{}}
       />
     `);
   });
@@ -316,6 +328,7 @@ describe('attrs', () => {
             "fontSize": "4em",
           }
         }
+        theme={{}}
       >
         Hello
       </p>

--- a/packages/styled-components/src/test/basic.test.tsx
+++ b/packages/styled-components/src/test/basic.test.tsx
@@ -209,6 +209,7 @@ describe('basic', () => {
     expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
       <custom-element
         class="sc-a b"
+        theme={{}}
       />
     `);
   });
@@ -404,6 +405,7 @@ describe('basic', () => {
       expect(rendered.toJSON()).toMatchInlineSnapshot(`
         <div
           className="sc-a d sc-b c"
+          theme={{}}
         />
       `);
     });

--- a/packages/styled-components/src/test/expanded-api.test.tsx
+++ b/packages/styled-components/src/test/expanded-api.test.tsx
@@ -119,6 +119,7 @@ describe('expanded api', () => {
       expect(TestRenderer.create(<Comp as="span" />).toJSON()).toMatchInlineSnapshot(`
         <header
           className="sc-a b"
+          theme={{}}
         />
       `);
     });
@@ -152,16 +153,19 @@ describe('expanded api', () => {
       expect(TestRenderer.create(<Comp />).toJSON()).toMatchInlineSnapshot(`
         <div
           className="sc-a d"
+          theme={{}}
         />
       `);
       expect(TestRenderer.create(<Comp2 />).toJSON()).toMatchInlineSnapshot(`
         <div
           className="sc-a sc-b d e"
+          theme={{}}
         />
       `);
       expect(TestRenderer.create(<Comp3 as="span" />).toJSON()).toMatchInlineSnapshot(`
         <span
           className="sc-a sc-b sc-c d e f"
+          theme={{}}
         />
       `);
 

--- a/packages/styled-components/src/test/overriding.test.tsx
+++ b/packages/styled-components/src/test/overriding.test.tsx
@@ -78,6 +78,7 @@ describe('extending', () => {
     expect(tree.toJSON()).toMatchInlineSnapshot(`
       <div
         className="sc-a sc-b c d"
+        theme={{}}
       />
     `);
   });
@@ -171,12 +172,14 @@ describe('extending', () => {
           <h1
             className="sc-a d"
             color="primary"
+            theme={{}}
           />
         `);
         expect(TestRenderer.create(<Child />).toJSON()).toMatchInlineSnapshot(`
           <h2
             className="sc-a sc-b e"
             color="secondary"
+            theme={{}}
           />
         `);
 
@@ -184,6 +187,7 @@ describe('extending', () => {
           <h3
             className="sc-a sc-b sc-c d"
             color="primary"
+            theme={{}}
           />
         `);
         expect(getRenderedCSS()).toMatchInlineSnapshot(`

--- a/packages/styled-components/src/test/props.test.tsx
+++ b/packages/styled-components/src/test/props.test.tsx
@@ -69,10 +69,12 @@ describe('props', () => {
       [
         <div
           className="sc-a b"
+          theme={{}}
         />,
         <div
           className="sc-a c"
           fg="red"
+          theme={{}}
         />,
       ]
     `);
@@ -96,6 +98,7 @@ describe('props', () => {
     expect(TestRenderer.create(<Comp2 forwardedAs="button" />).toJSON()).toMatchInlineSnapshot(`
       <button
         className="sc-a b"
+        theme={{}}
       />
     `);
 

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -500,7 +500,9 @@ describe('ssr', () => {
     const css = sheet.getStyleTags();
 
     expect(html).toMatchInlineSnapshot(`
-      <h1 class="sc-a b">
+      <h1 theme="[object Object]"
+          class="sc-a b"
+      >
         Hello SSR!
       </h1>
     `);


### PR DESCRIPTION
https://github.com/styled-components/styled-components/issues/4074

Include the `theme` in the  execution props.

Some UI component libraries require a theme at runtime. (e.g. react-select)
If you skip here, you will not be able to refer to the theme when overwriting the theme, resulting in a runtime error.



In fact, if you try using the codesandbox in the [issue comment](https://github.com/styled-components/styled-components/issues/4074#issuecomment-1633601407), A runtime error occurs because the theme cannot be referenced.

> Cannot read properties of undefined (reading 'spacing')

