### PR TITLE
Fix production mode inconsistent CSS rendering when dynamic property values are the same but property names are different

### DIFF
--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -78,7 +78,8 @@ export default class ComponentStyle {
           const partString = joinStringArray(
             flatten(partRule, executionContext, styleSheet, stylis) as string[]
           );
-          dynamicHash = phash(dynamicHash, partString);
+          // The same value can switch positions in the array, so we include "i" in the hash.
+          dynamicHash = phash(dynamicHash, partString + i);
           css += partString;
         }
       }

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -73,7 +73,7 @@ export default class ComponentStyle {
         if (typeof partRule === 'string') {
           css += partRule;
 
-          if (process.env.NODE_ENV !== 'production') dynamicHash = phash(dynamicHash, partRule);
+          dynamicHash = phash(dynamicHash, partRule);
         } else if (partRule) {
           const partString = joinStringArray(
             flatten(partRule, executionContext, styleSheet, stylis) as string[]

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -73,7 +73,7 @@ export default class ComponentStyle {
         if (typeof partRule === 'string') {
           css += partRule;
 
-          dynamicHash = phash(dynamicHash, partRule);
+          if (process.env.NODE_ENV !== 'production') dynamicHash = phash(dynamicHash, partRule);
         } else if (partRule) {
           const partString = joinStringArray(
             flatten(partRule, executionContext, styleSheet, stylis) as string[]

--- a/packages/styled-components/src/test/basic.test.tsx
+++ b/packages/styled-components/src/test/basic.test.tsx
@@ -66,7 +66,7 @@ describe('basic', () => {
     `);
   });
 
-  it('should inject two different styles if the same compnoent is mounted with different props and css', () => {
+  it('should inject two different styles if the same component is mounted with different props and css', () => {
     const Comp = styled.div<{ $variant: 'text' | 'background' }>`
       color: ${props => props.$variant == 'text' && 'red'};
       background-color: ${props => props.$variant == 'background' && 'red'};

--- a/packages/styled-components/src/test/basic.test.tsx
+++ b/packages/styled-components/src/test/basic.test.tsx
@@ -66,6 +66,23 @@ describe('basic', () => {
     `);
   });
 
+  it('should inject two different styles if the same compnoent is mounted with different props and css', () => {
+    const Comp = styled.div<{ $variant: 'text' | 'background' }>`
+      color: ${props => props.$variant == 'text' && 'red'};
+      background-color: ${props => props.$variant == 'background' && 'red'};
+    `;
+    TestRenderer.create(<Comp $variant="text" />);
+    TestRenderer.create(<Comp $variant="background" />);
+    expect(getRenderedCSS()).toMatchInlineSnapshot(`
+      ".b {
+        color: red;
+      }
+      .c {
+        background-color: red;
+      }"
+    `);
+  });
+
   it('Should have the correct styled(component) displayName', () => {
     const CompWithoutName = () => (() => <div />) as React.FC<any>;
 
@@ -524,6 +541,36 @@ describe('basic', () => {
       );
 
       expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('production mode', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should inject two different styles if the same compnoent is mounted with different props and css', () => {
+      const Comp = styled.div<{ $variant: 'text' | 'background' }>`
+        color: ${props => props.$variant == 'text' && 'red'};
+        background-color: ${props => props.$variant == 'background' && 'red'};
+      `;
+      TestRenderer.create(<Comp $variant="text" />);
+      TestRenderer.create(<Comp $variant="background" />);
+      expect(getRenderedCSS()).toMatchInlineSnapshot(`
+        ".b {
+          color: red;
+        }
+        .c {
+          background-color: red;
+        }"
+      `);
     });
   });
 });


### PR DESCRIPTION
This PR fixes https://github.com/styled-components/styled-components/issues/4113

This problem occurs when dynamic interpolations in different places can return the same value. 

An example of how this problem can happen:

```ts
const MyComponent = styled.div<{ $variant: 'text' | 'background' }>`
      color: ${props => props.$variant == 'text' && 'red'};
      background-color: ${props => props.$variant == 'background' && 'red'};
`;
```

In the example above, there are two interpolation functions. Each returns the exact same value, but appears next to a different CSS property name. 

In production builds, the logic which determines if a new class name needs to be created fails to check for this situation and outputs the same CSS for both `<MyComponent $variant="text" />` and `<MyComponent $variant="background" />`.

In non-production builds, this problem does not occur. 