### PR TITLE
fix: union type too complex

### DIFF
--- a/packages/styled-components/src/base.ts
+++ b/packages/styled-components/src/base.ts
@@ -56,13 +56,9 @@ if (
 export * from './secretInternals';
 export { Attrs, DefaultTheme, ShouldForwardProp } from './types';
 export {
-  createGlobalStyle,
-  css,
-  isStyledComponent,
-  IStyleSheetManager,
   IStyleSheetContext,
+  IStyleSheetManager,
   IStylisContext,
-  keyframes,
   ServerStyleSheet,
   StyleSheetConsumer,
   StyleSheetContext,
@@ -70,6 +66,10 @@ export {
   ThemeConsumer,
   ThemeContext,
   ThemeProvider,
+  createGlobalStyle,
+  css,
+  isStyledComponent,
+  keyframes,
   useTheme,
   SC_VERSION as version,
   withTheme,

--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -21,6 +21,7 @@ export {
   StyleFunction,
   StyledObject,
   StyledOptions,
+  SupportedHTMLElements,
   WebTarget,
 } from './types';
 export { styled as default, styled };

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -32,7 +32,7 @@ export type AnyComponent<P extends object = any> =
   | ExoticComponentWithDisplayName<P>
   | React.ComponentType<P>;
 
-export type KnownTarget = Exclude<keyof JSX.IntrinsicElements, 'symbol' | 'object'> | AnyComponent;
+export type KnownTarget = Exclude<keyof React.ReactDOM, 'symbol' | 'object'> | AnyComponent;
 
 export type WebTarget =
   | string // allow custom elements, etc.

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import ComponentStyle from './models/ComponentStyle';
 import { DefaultTheme } from './models/ThemeProvider';
 import createWarnTooManyClasses from './utils/createWarnTooManyClasses';
+import type { SupportedHTMLElements } from './utils/domElements';
 
 export { CSS, DefaultTheme };
 
@@ -32,7 +33,7 @@ export type AnyComponent<P extends object = any> =
   | ExoticComponentWithDisplayName<P>
   | React.ComponentType<P>;
 
-export type KnownTarget = Exclude<keyof React.ReactDOM, 'symbol' | 'object'> | AnyComponent;
+export type KnownTarget = SupportedHTMLElements | AnyComponent;
 
 export type WebTarget =
   | string // allow custom elements, etc.

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -5,7 +5,7 @@ import { DefaultTheme } from './models/ThemeProvider';
 import createWarnTooManyClasses from './utils/createWarnTooManyClasses';
 import type { SupportedHTMLElements } from './utils/domElements';
 
-export { CSS, DefaultTheme };
+export { CSS, DefaultTheme, SupportedHTMLElements };
 
 interface ExoticComponentWithDisplayName<P extends object = {}> extends React.ExoticComponent<P> {
   defaultProps?: Partial<P> | undefined;

--- a/packages/styled-components/src/utils/domElements.ts
+++ b/packages/styled-components/src/utils/domElements.ts
@@ -1,6 +1,6 @@
 // Thanks to ReactDOMFactories for this handy list!
 
-export default new Set([
+const elements = [
   'a',
   'abbr',
   'address',
@@ -46,7 +46,6 @@ export default new Set([
   'h4',
   'h5',
   'h6',
-  'head',
   'header',
   'hgroup',
   'hr',
@@ -106,7 +105,6 @@ export default new Set([
   'th',
   'thead',
   'time',
-  'title',
   'tr',
   'track',
   'u',
@@ -136,4 +134,7 @@ export default new Set([
   'svg',
   'text',
   'tspan',
-] as const);
+] as const;
+
+export default new Set(elements);
+export type SupportedHTMLElements = (typeof elements)[number];


### PR DESCRIPTION
As libraries like `@react-three/fiber` add to JSX.IntrinsicElements, it can get too large to convert to a union in some scenarios. I'm using the tag name maps from `lib.dom.d.ts` instead. In an environment with no JSX augmentations, this results in the same union.

For example, in the case of `@react-three/fiber`, the original union looks something like this:
`'h1' | 'h2' | 'h3' | 'meshPhysicalMaterial' | 'meshStandardMaterial' | 'meshPhongMaterial' ...`

And the new one only includes standard HTML tag names:
`'h1' | 'h2' | 'h3' ...`

From what I can tell, this is what makes sense. (Any edge cases this would screw up?)

fixes #4115 