### PR TITLE
Prevent StyleSheetManager updating context on every render

### DIFF
--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -111,10 +111,17 @@ export function StyleSheetManager(props: IStyleSheetManager): JSX.Element {
     if (!shallowequal(plugins, props.stylisPlugins)) setPlugins(props.stylisPlugins);
   }, [props.stylisPlugins]);
 
+  const styleSheetContextValue = useMemo(
+    () => ({
+      shouldForwardProp: props.shouldForwardProp,
+      styleSheet: resolvedStyleSheet,
+      stylis,
+    }),
+    [props.shouldForwardProp, resolvedStyleSheet, stylis]
+  );
+
   return (
-    <StyleSheetContext.Provider
-      value={{ shouldForwardProp: props.shouldForwardProp, styleSheet: resolvedStyleSheet, stylis }}
-    >
+    <StyleSheetContext.Provider value={styleSheetContextValue}>
       <StylisContext.Provider value={stylis}>{props.children}</StylisContext.Provider>
     </StyleSheetContext.Provider>
   );


### PR DESCRIPTION
In v6 the `StyleSheetManager` component returns the following:

```jsx
<StyleSheetContext.Provider
  value={
    {
      shouldForwardProp: props.shouldForwardProp,
      styleSheet: resolvedStyleSheet,
      stylis
    }
  }
>
```

Even though the `resolvedStyleSheet` and `stylis` are memoized, they are being wrapped in a new object on every render, which causes the context value to change, and Styled Components throughout the tree to be re-rendered.

Its only a problem when `StyleSheetManager` is re-rendered of course, but still, probably shouldn't happen.