### PR TITLE
Fix: Do not add Target to return type for constructWithOptions

### DIFF
--- a/packages/styled-components/jest.config.native.js
+++ b/packages/styled-components/jest.config.native.js
@@ -4,5 +4,5 @@ module.exports = Object.assign({}, baseConfig, {
   preset: 'react-native',
   setupFiles: ['<rootDir>/src/test/globals.ts'],
   testEnvironment: 'node',
-  testRegex: 'src/native/test/.*.tsx?$',
+  testRegex: 'src/native/test/.*.test.tsx?$',
 });

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -50,10 +50,7 @@ export interface Styled<
   <Props extends object = BaseObject, Statics extends object = BaseObject>(
     initialStyles: Styles<Substitute<OuterProps, NoInfer<Props>>>,
     ...interpolations: Interpolation<Substitute<OuterProps, NoInfer<Props>>>[]
-  ): IStyledComponent<R, Substitute<OuterProps, Props>> &
-    OuterStatics &
-    Statics &
-    (Target extends string ? {} : Target);
+  ): IStyledComponent<R, Substitute<OuterProps, Props>> & OuterStatics & Statics;
 
   attrs: <
     Props extends object = BaseObject,

--- a/packages/styled-components/src/native/test/types.tsx
+++ b/packages/styled-components/src/native/test/types.tsx
@@ -1,0 +1,17 @@
+/**
+ * This file is meant for typing-related tests that don't need to go through Jest.
+ */
+import React from 'react';
+import styledNative from '../index';
+
+/**
+ * Props incorrectly typed using styled components native
+ * https://github.com/styled-components/styled-components/issues/4165
+ */
+const NativeWrapper = styledNative.View<{ foo?: boolean }>`
+  ${props => props.foo && 'color: red;'}
+`;
+
+const NativeComponent = () => {
+  return <NativeWrapper foo />;
+};

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -459,7 +459,7 @@ styled.div<PropsWithVariant>`
 const TargetWithStaticProperties = (p: React.PropsWithChildren<{}>) => <div {...p} />;
 TargetWithStaticProperties.foo = 'bar';
 
-const StyledTargetWithStaticProperties = styled(TargetWithStaticProperties)``;
+const StyledTargetWithStaticProperties = styled(TargetWithStaticProperties)<{}, { foo: 'bar' }>``;
 StyledTargetWithStaticProperties.foo;
 
 /**


### PR DESCRIPTION
resolves https://github.com/styled-components/styled-components/issues/4165

The addition of the Target type in 6.0.8 breaks prop-Typing for styled-components with React Native.

Instead of inferring static properties, these should be specified by the implementor. As far as I understand, there already is the OuterStatics generic for this use case.