### PR TITLE
chore: add support for Node Corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   "engines": {
     "node": ">= 14"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Node ships with Corepack, a special module for managing package managers. It works by reading `packageManager` entry in `package.json`. Therefore it ensures that all developers run the same version of package manager:

- reducing changes for any incompatibilities that might be caused by different versions,
- making installation seamless - Yarn is installed transparently without any intervention, provided you have Corepack enabled
- making migration to e.g. modern Yarn or pnpm very easy, as developers don't need to take any further actions besides pulling the latest changes from origin