### PR TITLE
Bump postcss version from 8.4.23 to 8.4.31

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -73,7 +73,7 @@
     "@types/stylis": "^4.0.2",
     "css-to-react-native": "^3.2.0",
     "csstype": "^3.1.2",
-    "postcss": "^8.4.23",
+    "postcss": "^8.4.31",
     "shallowequal": "^1.1.0",
     "stylis": "^4.3.0",
     "tslib": "^2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7859,10 +7859,10 @@ postcss@^8.4.19:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.23:
-  version "8.4.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
-  integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
+postcss@^8.4.31:
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
@@ -9084,7 +9084,7 @@ style-loader@^3.3.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "6.0.7"
+  version "6.0.8"
   dependencies:
     "@babel/cli" "^7.21.0"
     "@babel/core" "^7.21.0"
@@ -9101,7 +9101,7 @@ style-loader@^3.3.1:
     "@types/stylis" "^4.0.2"
     css-to-react-native "^3.2.0"
     csstype "^3.1.2"
-    postcss "^8.4.23"
+    postcss "^8.4.31"
     shallowequal "^1.1.0"
     stylis "^4.3.0"
     tslib "^2.5.0"


### PR DESCRIPTION
## Summary
Fix security vulnerability related to `postcss` dependency [Link to the issue](https://security.snyk.io/vuln/SNYK-JS-POSTCSS-5926692)

## Related issues:
- https://github.com/styled-components/styled-components/issues/4186