### PR TITLE
fix image unsupported border color style

### DIFF
--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -50,7 +50,17 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
           }
         });
 
-        const styleObject = transformDeclPairs(declPairs);
+      // RN currently does not support differing values for the border color of Image
+      // components (but does for View). It is almost impossible to tell whether we'll have
+      // support, so we'll just disable multiple values here.
+      // https://github.com/styled-components/styled-components/issues/4181
+
+        const styleObject = transformDeclPairs(declPairs, [
+          'borderWidth',
+          'borderColor',
+          'borderStyle',
+        ])
+
         const styles = styleSheet.create({
           generated: styleObject,
         });

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -55,10 +55,7 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
         // support, so we'll just disable multiple values here.
         // https://github.com/styled-components/styled-components/issues/4181
 
-        const styleObject = transformDeclPairs(declPairs, [
-          'borderWidth',
-          'borderColor',
-        ]);
+        const styleObject = transformDeclPairs(declPairs, ['borderWidth', 'borderColor']);
 
         const styles = styleSheet.create({
           generated: styleObject,

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -50,16 +50,16 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
           }
         });
 
-      // RN currently does not support differing values for the border color of Image
-      // components (but does for View). It is almost impossible to tell whether we'll have
-      // support, so we'll just disable multiple values here.
-      // https://github.com/styled-components/styled-components/issues/4181
+        // RN currently does not support differing values for the border color of Image
+        // components (but does for View). It is almost impossible to tell whether we'll have
+        // support, so we'll just disable multiple values here.
+        // https://github.com/styled-components/styled-components/issues/4181
 
         const styleObject = transformDeclPairs(declPairs, [
           'borderWidth',
           'borderColor',
           'borderStyle',
-        ])
+        ]);
 
         const styles = styleSheet.create({
           generated: styleObject,

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -58,7 +58,6 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
         const styleObject = transformDeclPairs(declPairs, [
           'borderWidth',
           'borderColor',
-          'borderStyle',
         ]);
 
         const styles = styleSheet.create({

--- a/packages/styled-components/src/native/index.ts
+++ b/packages/styled-components/src/native/index.ts
@@ -94,7 +94,7 @@ const toStyleSheet = (rules: RuleSet<object>) => {
     }
   });
 
-  const styleObject = transformDeclPairs(declPairs);
+  const styleObject = transformDeclPairs(declPairs, ['borderWidth', 'borderColor']);
 
   return reactNative.StyleSheet.create({ style: styleObject }).style;
 };

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -146,7 +146,7 @@ describe('native', () => {
 
     const loremPicsumUri = 'https://picsum.photos/200/300';
 
-    const wrapper = TestRenderer.create(<Comp source={{uri: loremPicsumUri}} />);
+    const wrapper = TestRenderer.create(<Comp source={{ uri: loremPicsumUri }} />);
     const image = wrapper.root.findByType(Image);
 
     expect(image.props.style).toEqual({ borderWidth: 10, borderColor: 'red' });

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { Text, View, ViewProps } from 'react-native';
+import { Text, View, ViewProps, Image } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import styled, { ThemeProvider, css, toStyleSheet } from '../';
 
@@ -136,6 +136,20 @@ describe('native', () => {
     const wrapper = TestRenderer.create(<Comp2 forwardedAs={Text} />);
 
     expect(wrapper.root.findByType(Text)).not.toBeUndefined();
+  });
+
+  it('should not add different border values for Image component as its not supported', () => {
+    const Comp = styled.Image`
+      border-width: 10px;
+      border-color: red;
+    `;
+
+    const loremPicsumUri = 'https://picsum.photos/200/300';
+
+    const wrapper = TestRenderer.create(<Comp source={{uri: loremPicsumUri}} />);
+    const image = wrapper.root.findByType(Image);
+
+    expect(image.props.style).toEqual({ borderWidth: 10, borderColor: 'red' });
   });
 
   describe('attrs', () => {

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { Text, View, ViewProps, Image } from 'react-native';
+import { Image, Text, View, ViewProps } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import styled, { ThemeProvider, css, toStyleSheet } from '../';
 
@@ -373,9 +373,10 @@ describe('native', () => {
     it('convert css to styleSheet', () => {
       const cssStyle = css`
         background-color: red;
+        border-width: 10px;
       `;
 
-      expect(toStyleSheet(cssStyle)).toEqual({ backgroundColor: 'red' });
+      expect(toStyleSheet(cssStyle)).toEqual({ backgroundColor: 'red', borderWidth: 10 });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8976,7 +8976,7 @@ style-loader@^3.3.1:
     supports-color "^5.5.0"
 
 "styled-components@link:packages/styled-components":
-  version "6.0.9"
+  version "6.1.0"
   dependencies:
     "@emotion/is-prop-valid" "^1.2.1"
     "@emotion/unitless" "^0.8.0"


### PR DESCRIPTION
Hi,
According to the current RN [docs](https://reactnative.dev/docs/image-style-props#props), those styles `borderColor, borderWidth, borderStyle` can be only one instead of multiple.

Note: how I can test those changes?

Fixes https://github.com/styled-components/styled-components/issues/4181