### PR TITLE
Remove deplicated type `StyledObject<Props>`

### DIFF
--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -266,7 +266,6 @@ export type StyledObject<Props extends object = BaseObject> = CSSProperties &
       | string
       | number
       | StyleFunction<Props>
-      | StyledObject<Props>
       | RuleSet<any>
       | undefined;
   };


### PR DESCRIPTION
At lines 265 and 269 are same types. 
https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/types.ts#L262-L272


Therefore, there should be no problem even if one is deleted.