### PR TITLE
Keep displayName in production environment

### DIFF
--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -23,9 +23,7 @@ export default function withTheme<T extends AnyComponent>(Component: T) {
     }
   );
 
-  if (process.env.NODE_ENV !== 'production') {
-    WithTheme.displayName = `WithTheme(${getComponentName(Component)})`;
-  }
+  WithTheme.displayName = `WithTheme(${getComponentName(Component)})`;
 
   return hoist(WithTheme, Component);
 }

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -250,9 +250,7 @@ function createStyledComponent<
     return useStyledComponentImpl<OuterProps>(WrappedStyledComponent, props, ref);
   }
 
-  if (process.env.NODE_ENV !== 'production') {
-    forwardRefRender.displayName = displayName;
-  }
+  forwardRefRender.displayName = displayName;
 
   /**
    * forwardRef creates a new interim component, which we'll take advantage of
@@ -265,11 +263,8 @@ function createStyledComponent<
     Statics;
   WrappedStyledComponent.attrs = finalAttrs;
   WrappedStyledComponent.componentStyle = componentStyle;
+  WrappedStyledComponent.displayName = displayName;
   WrappedStyledComponent.shouldForwardProp = shouldForwardProp;
-
-  if (process.env.NODE_ENV !== 'production') {
-    WrappedStyledComponent.displayName = displayName;
-  }
 
   // this static is used to preserve the cascade of static classes for component selector
   // purposes; this is especially important with usage of the css prop

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -147,9 +147,7 @@ export default (InlineStyle: IInlineStyleConstructor<any>) => {
     const forwardRefRender = (props: ExecutionProps & OuterProps, ref: React.Ref<any>) =>
       useStyledComponentImpl<OuterProps>(WrappedStyledComponent, props, ref);
 
-    if (process.env.NODE_ENV !== 'production') {
-      forwardRefRender.displayName = displayName;
-    }
+    forwardRefRender.displayName = displayName;
 
     /**
      * forwardRef creates a new interim component, which we'll take advantage of
@@ -165,11 +163,8 @@ export default (InlineStyle: IInlineStyleConstructor<any>) => {
     WrappedStyledComponent.inlineStyle = new InlineStyle(
       isTargetStyledComp ? styledComponentTarget.inlineStyle.rules.concat(rules) : rules
     ) as InstanceType<IInlineStyleConstructor<OuterProps>>;
+    WrappedStyledComponent.displayName = displayName;
     WrappedStyledComponent.shouldForwardProp = shouldForwardProp;
-
-    if (process.env.NODE_ENV !== 'production') {
-      WrappedStyledComponent.displayName = displayName;
-    }
 
     // @ts-expect-error we don't actually need this for anything other than detection of a styled-component
     WrappedStyledComponent.styledComponentId = true;


### PR DESCRIPTION
Description in this issue: https://github.com/styled-components/styled-components/issues/4207

This PR simply reverts the commit that has removed the display name on react components in production env.