### PR TITLE
Expose FastOmit to improve emit performance

### DIFF
--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -23,7 +23,7 @@ export type BaseObject = {};
 // from https://stackoverflow.com/a/69852402
 export type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
 
-type FastOmit<T extends object, U extends string | number | symbol> = {
+export type FastOmit<T extends object, U extends string | number | symbol> = {
   [K in keyof T as K extends U ? never : K]: T[K];
 };
 


### PR DESCRIPTION
Fixes #4229

Emitted declaration files end up very large because HTML props are explicitly listed instead of referencing the `FastOmit` type. This causes a huge performance loss due to larger `.d.ts` files needing to be written, as well as a much larger file size.

I myself noticed my builds taking 2x-3x longer due to the shear amount of additional writes to disk having to happen.

The bug happens because `FastOmit` is not exposed, so TypeScript ends up explicitly defining the resulting type instead.  Exposing `FastOmit` fixes the issue.