### PR TITLE
fix: missing type declarations

### DIFF
--- a/packages/styled-components/tsconfig.json
+++ b/packages/styled-components/tsconfig.json
@@ -15,7 +15,7 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
-    "declarationDir": ".",
+    // "declarationDir": ".",
     // "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
Fixes #4234 and #4235

In tsconfig.json "declarationDir" was set to ".", by removing that type declarations are included in the "dist" output.

This looks like the Rollup TypeScript Plugin workaround when using file output. As far as I can see styled-components doesn't need that. See [this issue](https://github.com/rollup/plugins/issues/934) for the workaround.
