### PR TITLE
fix: bump stylis to 4.3.1 to resolve issue with leaking nested selectors 

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,13 @@ on:
 permissions:
   contents: read #  to fetch code (actions/checkout)
 
+env:
+  YARN_ENABLE_HARDENED_MODE: 0
+
 jobs:
   prettier:
+    env:
+      YARN_ENABLE_HARDENED_MODE: 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -58,7 +58,7 @@
     "csstype": "3.1.2",
     "postcss": "8.4.31",
     "shallowequal": "1.1.0",
-    "stylis": "4.3.0",
+    "stylis": "4.3.1",
     "tslib": "2.5.0"
   },
   "peerDependencies": {

--- a/packages/styled-components/src/test/styles.test.tsx
+++ b/packages/styled-components/src/test/styles.test.tsx
@@ -503,7 +503,7 @@ describe('with styles', () => {
     `);
   });
 
-  it('comma-joined selector chains should be namespaced', () => {
+  it('comma-joined complex selector chains should be namespaced', () => {
     const Comp = styled.h1`
       &.foo,
       p:not(:last-child) {

--- a/packages/styled-components/src/test/styles.test.tsx
+++ b/packages/styled-components/src/test/styles.test.tsx
@@ -408,7 +408,7 @@ describe('with styles', () => {
     `);
   });
 
-  it('failing test', () => {
+  it('conditional styles should only apply to the relevant component instance', () => {
     interface IconProps {
       color?: string;
       rounded?: boolean;
@@ -499,6 +499,23 @@ describe('with styles', () => {
       }
       .c > svg {
         stroke: darkred;
+      }"
+    `);
+  });
+
+  it('comma-joined selector chains should be namespaced', () => {
+    const Comp = styled.h1`
+      &.foo,
+      p:not(:last-child) {
+        color: red;
+      }
+    `;
+
+    TestRenderer.create(<Comp />);
+
+    expect(getRenderedCSS()).toMatchInlineSnapshot(`
+      ".a.foo, .a p:not(:last-child) {
+        color: red;
       }"
     `);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10033,7 +10033,7 @@ __metadata:
     rollup-plugin-sourcemaps: "npm:0.6.3"
     rollup-plugin-terser: "npm:7.0.2"
     shallowequal: "npm:1.1.0"
-    stylis: "npm:4.3.0"
+    stylis: "npm:4.3.1"
     stylis-plugin-rtl: "npm:2.1.1"
     ts-toolbelt: "npm:9.6.0"
     tslib: "npm:2.5.0"
@@ -10125,10 +10125,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:4.3.0":
-  version: 4.3.0
-  resolution: "stylis@npm:4.3.0"
-  checksum: 5a9f7e0cf2a15591efaacc1c6416a8785d2b57522cd38bb8e0a81a03c23d3bea2363659fa5f9d486a73d1b6ebaf1d32826ce1c1974c95afdb5b495d98acb25c0
+"stylis@npm:4.3.1":
+  version: 4.3.1
+  resolution: "stylis@npm:4.3.1"
+  checksum: 33e8ebd2bfa5f0bd0215f718dc2d3be896e1d00c5bcaeb9a4ae03cf239db6867af9eee230f57229bf1c29499357073ba3e6b547484ba1db2f5de1e8be7d4eee9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In some circumstances, prior versions of stylis would not properly
apply the component namespace to a nested rule when using comma-joined
selector chains, e.g. `&.foo, p:not(:last-child)`.

Fixes #4224 

Thank you very much @Andarist for patching!