### PR TITLE
fix(types): allow using a styled component as a key inside object styles in the web runtime

### DIFF
--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -380,6 +380,9 @@ styled.div<CSSPropTestType>(p => ({
 // object styles
 styled.div({ color: 'red', '@media (min-width: 500px)': { fontSize: '11px' } });
 
+// object styles referencing another component
+styled.div({ [AttrFunctionRequiredTest5]: { color: 'red' } });
+
 type TextProps = React.PropsWithChildren<{
   color: 'primary' | 'secondary';
   size?: 'sm' | 'md' | 'lg';

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -220,35 +220,37 @@ export interface PolymorphicComponent<R extends Runtime, BaseProps extends objec
   ): JSX.Element;
 }
 
-/**
- * TypeScript doesn't allow using a styled component as a key inside object
- * styles because "A computed property name must be of type 'string', 'number',
- * 'symbol', or 'any'.". The toString() method only exists in the web runtime.
- * This hack intersects the `IStyledComponent` type with the built-in `string`
- * type to keep TSC happy.
- *
- * @example
- *  const H1 = styled.h1({
- *    fontSize: '2rem'
- *  });
- *
- *  const Header = styled.header({
- *    [H1]: {
- *      marginBottom: '1rem'
- *    }
- *  })
- */
-type WebRuntimeReferenceHack<R extends Runtime> = R extends 'web' ? string : {};
+interface IStyledComponentBase<R extends Runtime, Props extends object = BaseObject>
+  extends PolymorphicComponent<R, Props>,
+    IStyledStatics<R, Props>,
+    StyledComponentBrand {
+  defaultProps?: (ExecutionProps & Partial<Props>) | undefined;
+  toString: () => string;
+}
 
 export type IStyledComponent<
   R extends Runtime,
   Props extends object = BaseObject,
-> = PolymorphicComponent<R, Props> &
-  IStyledStatics<R, Props> &
-  StyledComponentBrand & {
-    defaultProps?: (ExecutionProps & Partial<Props>) | undefined;
-    toString: () => string;
-  } & WebRuntimeReferenceHack<R>;
+> = IStyledComponentBase<R, Props> &
+  /**
+   * TypeScript doesn't allow using a styled component as a key inside object
+   * styles because "A computed property name must be of type 'string', 'number',
+   * 'symbol', or 'any'.". The toString() method only exists in the web runtime.
+   * This hack intersects the `IStyledComponent` type with the built-in `string`
+   * type to keep TSC happy.
+   *
+   * @example
+   *  const H1 = styled.h1({
+   *    fontSize: '2rem'
+   *  });
+   *
+   *  const Header = styled.header({
+   *    [H1]: {
+   *      marginBottom: '1rem'
+   *    }
+   *  })
+   */
+  (R extends 'web' ? string : {});
 
 // corresponds to createStyledComponent
 export interface IStyledComponentFactory<


### PR DESCRIPTION
In v6 it's currently not possible to use a styled-component as a key inside object styles to reference its class name, because TypeScript is not happy about:

> A computed property name must be of type 'string', 'number', 'symbol', or 'any'.

This PR adds the same hack available in the older `@types/styled-components` package intersecting the main `IStyledComponent` type with the `string` type, available only in the web runtime.

Basically, this becomes possible:

```ts
const H1 = styled.h1({
  fontSize: '2rem'
})

const Header = styled.header({
  [H1]: {
    marginBottom: '1rem'
  }
})
```

---

I realize this can be worked around by wrapping they key in either:

1. `H1.toString()`
1. `String(H1)`
2. a template string `${H1}`

but in my opinion it's a bit annoying.

Would be willing to accept this PR? What kind of additional testing would this require? Currently I have developed this workaround locally inside a project using TypeScript and `styled-components`. I did not test if it affects the React Native runtime, but it shouldn't.