### PR TITLE
Update flatten.ts

### DIFF
--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -30,7 +30,7 @@ export const objToCssArray = (obj: Dict<any>): string[] => {
 
   for (const key in obj) {
     const val = obj[key];
-    if (!obj.hasOwnProperty(key) || isFalsish(val)) continue;
+    if (!Object.hasOwn(obj, key) || isFalsish(val)) continue;
 
     // @ts-expect-error Property 'isCss' does not exist on type 'any[]'
     if ((Array.isArray(val) && val.isCss) || isFunction(val)) {


### PR DESCRIPTION
To avoid situation where provided object do not have prototype we should use Object.hasOwn.

Test1:

`objToCssArray(Object.create(null))`

Test2:

```
const obj = Object.create(null);
obj.color = 'red';
objToCssArray(obj)
```

Test3:

```
const obj = {
  hasOwnProperty: () => { /*...*/ return true },
}
objToCssArray(obj)
```