### PR TITLE
fix: improve types for .attrs()

### DIFF
--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -41,15 +41,26 @@ type AttrsTarget<
     : FallbackTarget
   : FallbackTarget;
 
+/**
+ * Extract non-optional fields from given object type.
+ */
+type RequiredFields<T> = Pick<
+  T,
+  {
+    [K in keyof T]-?: undefined extends T[K] ? never : K;
+  }[keyof T]
+>;
+
 export interface Styled<
   R extends Runtime,
   Target extends StyledTarget<R>,
   OuterProps extends object,
   OuterStatics extends object = BaseObject,
+  InnerProps extends object = OuterProps,
 > {
   <Props extends object = BaseObject, Statics extends object = BaseObject>(
-    initialStyles: Styles<Substitute<OuterProps, NoInfer<Props>>>,
-    ...interpolations: Interpolation<Substitute<OuterProps, NoInfer<Props>>>[]
+    initialStyles: Styles<Substitute<InnerProps, NoInfer<Props>>>,
+    ...interpolations: Interpolation<Substitute<InnerProps, NoInfer<Props>>>[]
   ): IStyledComponent<R, Substitute<OuterProps, Props>> &
     OuterStatics &
     Statics &
@@ -72,10 +83,16 @@ export interface Styled<
     PrivateResolvedTarget extends KnownTarget
       ? Substitute<
           Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-          Props
+          Props & Partial<RequiredFields<PrivateAttrsArg>>
         >
       : PrivateMergedProps,
-    OuterStatics
+    OuterStatics,
+    PrivateResolvedTarget extends KnownTarget
+      ? Substitute<
+          Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
+          Props
+        >
+      : PrivateMergedProps
   >;
 
   withConfig: (config: StyledOptions<R, OuterProps>) => Styled<R, Target, OuterProps, OuterStatics>;

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -105,11 +105,12 @@ export default function constructWithOptions<
     ? React.ComponentPropsWithRef<Target>
     : BaseObject,
   OuterStatics extends object = BaseObject,
+  InnerProps extends object = OuterProps,
 >(
   componentConstructor: IStyledComponentFactory<R, StyledTarget<R>, object, any>,
   tag: StyledTarget<R>,
   options: StyledOptions<R, OuterProps> = EMPTY_OBJECT
-): Styled<R, Target, OuterProps, OuterStatics> {
+): Styled<R, Target, OuterProps, OuterStatics, InnerProps> {
   /**
    * We trust that the tag is a valid component as long as it isn't
    * falsish. Typically the tag here is a string or function (i.e.
@@ -123,13 +124,13 @@ export default function constructWithOptions<
 
   /* This is callable directly as a template function */
   const templateFunction = <Props extends object = BaseObject, Statics extends object = BaseObject>(
-    initialStyles: Styles<Substitute<OuterProps, Props>>,
-    ...interpolations: Interpolation<Substitute<OuterProps, Props>>[]
+    initialStyles: Styles<Substitute<InnerProps, Props>>,
+    ...interpolations: Interpolation<Substitute<InnerProps, Props>>[]
   ) =>
-    componentConstructor<Substitute<OuterProps, Props>, Statics>(
+    componentConstructor<Substitute<InnerProps, Props>, Statics>(
       tag,
-      options as StyledOptions<R, Substitute<OuterProps, Props>>,
-      css<Substitute<OuterProps, Props>>(initialStyles, ...interpolations)
+      options as StyledOptions<R, Substitute<InnerProps, Props>>,
+      css<Substitute<InnerProps, Props>>(initialStyles, ...interpolations)
     );
 
   /**
@@ -152,10 +153,16 @@ export default function constructWithOptions<
       PrivateResolvedTarget extends KnownTarget
         ? Substitute<
             Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-            Props
+            Props & Partial<RequiredFields<PrivateAttrsArg>>
           >
         : PrivateMergedProps,
-      OuterStatics
+      OuterStatics,
+      PrivateResolvedTarget extends KnownTarget
+        ? Substitute<
+            Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
+            Props
+          >
+        : PrivateMergedProps
     >(componentConstructor, tag, {
       ...options,
       attrs: Array.prototype.concat(options.attrs, attrs).filter(Boolean),

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -1,7 +1,6 @@
 import {
   Attrs,
   BaseObject,
-  ExecutionProps,
   Interpolation,
   IStyledComponent,
   IStyledComponentFactory,
@@ -24,22 +23,6 @@ type AttrsResult<T extends Attrs<any>> = T extends (...args: any) => infer P
   : T extends object
   ? T
   : never;
-
-/**
- * Based on Attrs being a simple object or function that returns
- * a prop object, inspect the attrs result and attempt to extract
- * any "as" prop usage to modify the runtime target.
- */
-type AttrsTarget<
-  R extends Runtime,
-  T extends Attrs<any>,
-  FallbackTarget extends StyledTarget<R>,
-  Result extends ExecutionProps = AttrsResult<T>,
-> = Result extends { as: infer RuntimeTarget }
-  ? RuntimeTarget extends KnownTarget
-    ? RuntimeTarget
-    : FallbackTarget
-  : FallbackTarget;
 
 /**
  * Extract non-optional fields from given object type.

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -44,11 +44,11 @@ type AttrsTarget<
 /**
  * Extract non-optional fields from given object type.
  */
-type RequiredFields<T> = Pick<
+type RequiredFields<T, Ex> = Pick<
   T,
   {
     [K in keyof T]-?: undefined extends T[K] ? never : K;
-  }[keyof T]
+  }[Exclude<keyof T, Ex>]
 >;
 
 export interface Styled<
@@ -83,7 +83,7 @@ export interface Styled<
     PrivateResolvedTarget extends KnownTarget
       ? Substitute<
           Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-          Props & Partial<RequiredFields<PrivateAttrsArg>>
+          Props & Partial<RequiredFields<PrivateAttrsArg, 'as'>>
         >
       : PrivateMergedProps,
     OuterStatics,
@@ -153,7 +153,7 @@ export default function constructWithOptions<
       PrivateResolvedTarget extends KnownTarget
         ? Substitute<
             Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-            Props & Partial<RequiredFields<PrivateAttrsArg>>
+            Props & Partial<RequiredFields<PrivateAttrsArg, 'as'>>
           >
         : PrivateMergedProps,
       OuterStatics,

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -270,6 +270,31 @@ const AttrRequiredTest4 = styled(DivWithUnfulfilledRequiredProps).attrs({
   waz: 42,
 })``;
 
+{
+  const DivWithRequiredFooBar = styled.div<{ foo: number; bar: string }>``;
+  // @ts-expect-error must provide both foo and bar
+  <DivWithRequiredFooBar />;
+  // @ts-expect-error must provide both foo and bar
+  <DivWithRequiredFooBar foo={3} />;
+  // @ts-expect-error must provide both foo and bar
+  <DivWithRequiredFooBar bar="3" />;
+  // OK
+  <DivWithRequiredFooBar foo={3} bar="3" />;
+
+  // foo is provided, so it becomes optional
+  const DivWithRequiredBar = styled(DivWithRequiredFooBar).attrs({ foo: 42 })`
+    margin; ${props => props.foo * 10}px;
+  `;
+  // @ts-expect-error must provide bar
+  <DivWithRequiredBar />;
+  // OK
+  <DivWithRequiredBar bar="3" />;
+  // OK. Can still provide foo if we want
+  <DivWithRequiredBar foo={3} bar="3" />;
+  // @ts-expect-error foo must be a number
+  <DivWithRequiredBar foo="3" bar="3" />;
+}
+
 /** Intrinsic props and ref are being incorrectly types when using `as`
  * https://github.com/styled-components/styled-components/issues/3800#issuecomment-1548941843
  */

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -295,6 +295,18 @@ const AttrRequiredTest4 = styled(DivWithUnfulfilledRequiredProps).attrs({
   <DivWithRequiredBar foo="3" bar="3" />;
 }
 
+{
+  // double overriding
+  const Div = styled.div``;
+  const H1 = styled(Div).attrs({ as: 'h1' })``;
+  const Label = styled(H1).attrs({ as: 'label' })``;
+
+  <Label
+    ref={(el: HTMLLabelElement | null) => {}}
+    onCopy={(e: React.ClipboardEvent<HTMLLabelElement>) => {}}
+  />;
+}
+
 /** Intrinsic props and ref are being incorrectly types when using `as`
  * https://github.com/styled-components/styled-components/issues/3800#issuecomment-1548941843
  */

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -293,6 +293,33 @@ const AttrRequiredTest4 = styled(DivWithUnfulfilledRequiredProps).attrs({
   <DivWithRequiredBar foo={3} bar="3" />;
   // @ts-expect-error foo must be a number
   <DivWithRequiredBar foo="3" bar="3" />;
+
+  const Div = styled(DivWithRequiredBar).attrs({ bar: '42' })`
+    margin: ${props => {
+      // @ts-expect-error foo is optional
+      const foo: number = props.foo;
+      const bar: string = props.bar;
+      return foo * Number(bar);
+    }}px;
+  `;
+  // OK
+  <Div />;
+  <Div foo={3} />;
+  <Div bar="3" />;
+  <Div foo={3} bar="3" />;
+}
+
+{
+  // double attrs
+  const DivWithRequiredFooBar = styled.div<{ foo: number; bar: number }>``;
+  const Div = styled(DivWithRequiredFooBar).attrs({ foo: 42 }).attrs({ bar: 42 })`
+    margin: ${props => props.foo * props.bar}px;
+    `;
+
+  <Div />;
+  <Div foo={3} />;
+  <Div bar={3} />;
+  <Div foo={3} bar={3} />;
 }
 
 {


### PR DESCRIPTION
closes #4076
closes #4138
closes #4183

Hello, the above issue is blocking us from upgrading to v6, so here is a possible fix.

## Improvement

The improvement brought by this PR can be seen in this example:

```tsx
  const DivWithRequiredFooBar = styled.div<{ foo: number; bar: string }>``;

  // foo is provided, so it becomes optional
  const DivWithRequiredBar = styled(DivWithRequiredFooBar).attrs({ foo: 42 })`
    margin; ${props => props.foo * 10}px;
  `;
  // @ts-expect-error must provide bar
  <DivWithRequiredBar />;
  // OK (NEW)
  <DivWithRequiredBar bar="3" />;
  // OK. Can still provide foo if we want
  <DivWithRequiredBar foo={3} bar="3" />;
  // @ts-expect-error foo must be a number
  <DivWithRequiredBar foo="3" bar="3" />;
```

The part marked as `(NEW)` is made possible by this PR. Once `foo` is provided through the `.attrs` call, the resulting component (`DivWithRequiredBar`) no longer requires `foo` as a prop.

## Implementation

To achieve this, the `Styled` interface now has distinction between Outer props and Inner props:

```tsx
  const DivWithRequiredBar = styled(DivWithRequiredFooBar).attrs({ foo: 42 })`
    // ↓ `props` here is the inner props which have undergone the defaulting,
    // so `props.foo` is always supplied (not optional)
    margin; ${props => props.foo * 10}px;
  `;
  // User of the resulting component sees the outer props,
  // so foo is optional here
  <DivWithRequiredBar bar="3" />;
```

Thus the `Styled` interface now has new `InnerProps` type attribute. It is usually same as `OuterProps`, but the updated `attrs()` types can make them diverge.