### PR TITLE
add a failing test case for .attrs()

### DIFF
--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -527,3 +527,23 @@ class ParentClassComponent1 extends React.Component<{ $prop1?: boolean }> {}
 const ParentClassComponent2 = styled(ParentClassComponent1)<{ $prop2?: boolean }>``;
 
 <ParentClassComponent2 $prop1={true} $prop2={true} />;
+
+{
+  // React.forwardRef in combination with .attrs()
+
+  const Button = React.forwardRef<
+    HTMLButtonElement,
+    {
+      icon: 'a' | 'b' | 'c';
+    }
+  >((props, ref) => {
+    return (
+      <button ref={ref} {...props}>
+        button
+      </button>
+    );
+  });
+  const ButtonWithIcon = styled(Button).attrs({ icon: 'a' })``;
+
+  <ButtonWithIcon />;
+}


### PR DESCRIPTION
We're running in to some issues in our codebase on `6.1.9`. I managed to reproduce a minimal case that fails with the improved types from #4288.

@uhyo could you take a look at this? Perhaps that gives you a clue on how to fix it?