### PR TITLE
feat(types): add types to support third-party wrapping scenarios

### DIFF
--- a/packages/styled-components/src/constructors/styled.tsx
+++ b/packages/styled-components/src/constructors/styled.tsx
@@ -1,13 +1,20 @@
+import { ComponentPropsWithRef } from 'react';
 import createStyledComponent from '../models/StyledComponent';
-import { WebTarget } from '../types';
+import { BaseObject, KnownTarget, WebTarget } from '../types';
 import domElements, { SupportedHTMLElements } from '../utils/domElements';
-import constructWithOptions, { Styled } from './constructWithOptions';
+import constructWithOptions, { Styled as StyledInstance } from './constructWithOptions';
 
-const baseStyled = <Target extends WebTarget>(tag: Target) =>
-  constructWithOptions<'web', Target>(createStyledComponent, tag);
+const baseStyled = <Target extends WebTarget, InjectedProps extends object = BaseObject>(
+  tag: Target
+) =>
+  constructWithOptions<
+    'web',
+    Target,
+    Target extends KnownTarget ? ComponentPropsWithRef<Target> & InjectedProps : InjectedProps
+  >(createStyledComponent, tag);
 
 const styled = baseStyled as typeof baseStyled & {
-  [E in SupportedHTMLElements]: Styled<'web', E, JSX.IntrinsicElements[E]>;
+  [E in SupportedHTMLElements]: StyledInstance<'web', E, JSX.IntrinsicElements[E]>;
 };
 
 // Shorthands for all valid HTML Elements
@@ -17,3 +24,17 @@ domElements.forEach(domElement => {
 });
 
 export default styled;
+export { StyledInstance };
+
+/**
+ * This is the type of the `styled` HOC.
+ */
+export type Styled = typeof styled;
+
+/**
+ * Use this higher-order type for scenarios where you are wrapping `styled`
+ * and providing extra props as a third-party library.
+ */
+export type LibraryStyled<LibraryProps extends object = BaseObject> = <Target extends WebTarget>(
+  tag: Target
+) => typeof baseStyled<Target, LibraryProps>;

--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -1,4 +1,4 @@
-import styled from './constructors/styled';
+import styled, { LibraryStyled, Styled, StyledInstance } from './constructors/styled';
 
 export * from './base';
 export {
@@ -25,4 +25,4 @@ export {
   SupportedHTMLElements,
   WebTarget,
 } from './types';
-export { styled as default, styled };
+export { LibraryStyled, Styled, StyledInstance, styled as default, styled };

--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -11,6 +11,7 @@ export {
   DefaultTheme,
   ExecutionContext,
   ExecutionProps,
+  FastOmit,
   IStyledComponent,
   IStyledComponentFactory,
   IStyledStatics,


### PR DESCRIPTION
This PR exposes some new types that are intended to aid in third-party library adoption for scenarios where the library is wrapping `styled-components` and injecting additional props.

The new types are:

- `LibraryStyled`: a higher-order type that takes `LibraryProps` and merges them in with any downstream component props
- `Styled`: the type for the `styled()` HOC (the same as `typeof styled`)
- `StyledInstance`: the return type for a usage of the `styled()` HOC

The `FastOmit` type has also been exposed to make it more convenient to match behaviors.