### PR TITLE
Allow Passing Shadow Root as Sheet Target

### DIFF
--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -75,7 +75,7 @@ export type IStyleSheetManager = React.PropsWithChildren<{
   /**
    * Provide an alternate DOM node to host generated styles; useful for iframes.
    */
-  target?: undefined | HTMLElement;
+  target?: undefined | HTMLElement | ShadowRoot;
 }>;
 
 export function StyleSheetManager(props: IStyleSheetManager): JSX.Element {

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 import shallowequal from 'shallowequal';
 import type stylis from 'stylis';
 import StyleSheet from '../sheet';
-import { ShouldForwardProp, Stringifier } from '../types';
+import { InsertionTarget, ShouldForwardProp, Stringifier } from '../types';
 import createStylisInstance from '../utils/stylis';
 
 export const mainSheet: StyleSheet = new StyleSheet();
@@ -75,7 +75,7 @@ export type IStyleSheetManager = React.PropsWithChildren<{
   /**
    * Provide an alternate DOM node to host generated styles; useful for iframes.
    */
-  target?: undefined | HTMLElement | ShadowRoot;
+  target?: undefined | InsertionTarget;
 }>;
 
 export function StyleSheetManager(props: IStyleSheetManager): JSX.Element {

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -1,4 +1,5 @@
 import { DISABLE_SPEEDY, IS_BROWSER } from '../constants';
+import { InsertionTarget } from '../types';
 import { EMPTY_OBJECT } from '../utils/empties';
 import { setToString } from '../utils/setToString';
 import { makeGroupedTag } from './GroupedTag';
@@ -12,7 +13,7 @@ let SHOULD_REHYDRATE = IS_BROWSER;
 type SheetConstructorArgs = {
   isServer?: boolean;
   useCSSOMInjection?: boolean;
-  target?: HTMLElement | ShadowRoot | undefined;
+  target?: InsertionTarget | undefined;
 };
 
 type GlobalStylesAllocationMap = {

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -12,7 +12,7 @@ let SHOULD_REHYDRATE = IS_BROWSER;
 type SheetConstructorArgs = {
   isServer?: boolean;
   useCSSOMInjection?: boolean;
-  target?: HTMLElement | undefined;
+  target?: HTMLElement | ShadowRoot | undefined;
 };
 
 type GlobalStylesAllocationMap = {

--- a/packages/styled-components/src/sheet/Tag.ts
+++ b/packages/styled-components/src/sheet/Tag.ts
@@ -19,7 +19,7 @@ export const CSSOMTag = class CSSOMTag implements Tag {
 
   length: number;
 
-  constructor(target?: HTMLElement | undefined) {
+  constructor(target?: HTMLElement | ShadowRoot | undefined) {
     this.element = makeStyleTag(target);
 
     // Avoid Edge bug where empty style elements don't create sheets
@@ -62,7 +62,7 @@ export const TextTag = class TextTag implements Tag {
   nodes: NodeListOf<Node>;
   length: number;
 
-  constructor(target?: HTMLElement | undefined) {
+  constructor(target?: HTMLElement | ShadowRoot | undefined) {
     this.element = makeStyleTag(target);
     this.nodes = this.element.childNodes;
     this.length = 0;
@@ -100,7 +100,7 @@ export const VirtualTag = class VirtualTag implements Tag {
 
   length: number;
 
-  constructor(_target?: HTMLElement | undefined) {
+  constructor(_target?: HTMLElement | ShadowRoot | undefined) {
     this.rules = [];
     this.length = 0;
   }

--- a/packages/styled-components/src/sheet/Tag.ts
+++ b/packages/styled-components/src/sheet/Tag.ts
@@ -1,3 +1,4 @@
+import { InsertionTarget } from '../types';
 import { getSheet, makeStyleTag } from './dom';
 import { SheetOptions, Tag } from './types';
 
@@ -19,7 +20,7 @@ export const CSSOMTag = class CSSOMTag implements Tag {
 
   length: number;
 
-  constructor(target?: HTMLElement | ShadowRoot | undefined) {
+  constructor(target?: InsertionTarget | undefined) {
     this.element = makeStyleTag(target);
 
     // Avoid Edge bug where empty style elements don't create sheets
@@ -62,7 +63,7 @@ export const TextTag = class TextTag implements Tag {
   nodes: NodeListOf<Node>;
   length: number;
 
-  constructor(target?: HTMLElement | ShadowRoot | undefined) {
+  constructor(target?: InsertionTarget | undefined) {
     this.element = makeStyleTag(target);
     this.nodes = this.element.childNodes;
     this.length = 0;
@@ -100,7 +101,7 @@ export const VirtualTag = class VirtualTag implements Tag {
 
   length: number;
 
-  constructor(_target?: HTMLElement | ShadowRoot | undefined) {
+  constructor(_target?: InsertionTarget | undefined) {
     this.rules = [];
     this.length = 0;
   }

--- a/packages/styled-components/src/sheet/dom.ts
+++ b/packages/styled-components/src/sheet/dom.ts
@@ -3,14 +3,14 @@ import styledError from '../utils/error';
 import getNonce from '../utils/nonce';
 
 /** Find last style element if any inside target */
-const findLastStyleTag = (target: HTMLElement): void | HTMLStyleElement => {
+const findLastStyleTag = (target: HTMLElement | ShadowRoot): void | HTMLStyleElement => {
   const arr = Array.from(target.querySelectorAll<HTMLStyleElement>(`style[${SC_ATTR}]`));
 
   return arr[arr.length - 1];
 };
 
 /** Create a style element inside `target` or <head> after the last */
-export const makeStyleTag = (target?: HTMLElement | undefined): HTMLStyleElement => {
+export const makeStyleTag = (target?: HTMLElement | ShadowRoot | undefined): HTMLStyleElement => {
   const head = document.head;
   const parent = target || head;
   const style = document.createElement('style');

--- a/packages/styled-components/src/sheet/dom.ts
+++ b/packages/styled-components/src/sheet/dom.ts
@@ -1,16 +1,17 @@
 import { SC_ATTR, SC_ATTR_ACTIVE, SC_ATTR_VERSION, SC_VERSION } from '../constants';
+import { InsertionTarget } from '../types';
 import styledError from '../utils/error';
 import getNonce from '../utils/nonce';
 
 /** Find last style element if any inside target */
-const findLastStyleTag = (target: HTMLElement | ShadowRoot): void | HTMLStyleElement => {
+const findLastStyleTag = (target: InsertionTarget): void | HTMLStyleElement => {
   const arr = Array.from(target.querySelectorAll<HTMLStyleElement>(`style[${SC_ATTR}]`));
 
   return arr[arr.length - 1];
 };
 
 /** Create a style element inside `target` or <head> after the last */
-export const makeStyleTag = (target?: HTMLElement | ShadowRoot | undefined): HTMLStyleElement => {
+export const makeStyleTag = (target?: InsertionTarget | undefined): HTMLStyleElement => {
   const head = document.head;
   const parent = target || head;
   const style = document.createElement('style');

--- a/packages/styled-components/src/sheet/types.ts
+++ b/packages/styled-components/src/sheet/types.ts
@@ -18,7 +18,7 @@ export interface GroupedTag {
 
 export type SheetOptions = {
   isServer: boolean;
-  target?: HTMLElement | undefined;
+  target?: HTMLElement | ShadowRoot | undefined;
   useCSSOMInjection: boolean;
 };
 

--- a/packages/styled-components/src/sheet/types.ts
+++ b/packages/styled-components/src/sheet/types.ts
@@ -1,3 +1,5 @@
+import { InsertionTarget } from '../types';
+
 /** CSSStyleSheet-like Tag abstraction for CSS rules */
 export interface Tag {
   insertRule(index: number, rule: string): boolean;
@@ -18,7 +20,7 @@ export interface GroupedTag {
 
 export type SheetOptions = {
   isServer: boolean;
-  target?: HTMLElement | ShadowRoot | undefined;
+  target?: InsertionTarget | undefined;
   useCSSOMInjection: boolean;
 };
 

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -321,3 +321,5 @@ export type CSSProp = Interpolation<any>;
 export type NoInfer<T> = [T][T extends any ? 0 : never];
 
 export type Substitute<A extends object, B extends object> = FastOmit<A, keyof B> & B;
+
+export type InsertionTarget = HTMLElement | ShadowRoot;


### PR DESCRIPTION
In `@types/styled-components`, the `target` prop of `StyleSheetManager` allows passing a `ShadowRoot` (see [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/86953d1148f231c8f1c534e4a718ac4fa7888767/types/styled-components/index.d.ts#L390-L397)).

As I'm not familiar with this codebase, I started from the change to `IStyleSheetManager`, then fixed any type errors that surfaced. @quantizor please let me know if you see any problems with what I've done here, or if you know of a reason why the `ShadowRoot` option wasn't carried over into v6!