### PR TITLE
feat: Add named export of `styled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ _The format is based on [Keep a Changelog](http://keepachangelog.com/) and this 
 
 ## Unreleased
 
+## [v.5.4.0] - 2024-06-03
+
+- Backport introduction of named export of `styled` to make migration to v6 easier to manage for consumers with large quantities of internal libraries.
+
 ## [v5.3.7] - 2023-03-01
 
 - fix: (React Native) passing testID as attrs property by @ku8ar (see #3857)

--- a/packages/styled-components/src/index.js
+++ b/packages/styled-components/src/index.js
@@ -2,4 +2,4 @@
 import styled from './constructors/styled';
 
 export * from './base';
-export { styled as default };
+export { styled as default, styled };


### PR DESCRIPTION
## [v.5.4.0] - 2024-06-03

- Backport introduction of named export of `styled` to make migration to v6 easier to manage for consumers with large quantities of internal libraries.

## Related issues
resolves #4281 