### PR TITLE
Prevent ServerStyleSheet generating empty style tags/elements

### DIFF
--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -56,11 +56,14 @@ export default class ServerStyleSheet {
       throw styledError(2);
     }
 
+    const css = this.instance.toString();
+    if (!css) return [];
+
     const props = {
       [SC_ATTR]: '',
       [SC_ATTR_VERSION]: SC_VERSION,
       dangerouslySetInnerHTML: {
-        __html: this.instance.toString(),
+        __html: css,
       },
     };
 

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -23,6 +23,7 @@ export default class ServerStyleSheet {
 
   _emitSheetCSS = (): string => {
     const css = this.instance.toString();
+    if (!css) return '';
     const nonce = getNonce();
     const attrs = [
       nonce && `nonce="${nonce}"`,

--- a/packages/styled-components/src/sheet/Rehydration.ts
+++ b/packages/styled-components/src/sheet/Rehydration.ts
@@ -16,7 +16,7 @@ export const outputSheet = (sheet: Sheet) => {
 
     const names = sheet.names.get(id);
     const rules = tag.getGroup(group);
-    if (names === undefined || rules.length === 0) continue;
+    if (names === undefined || !names.size || rules.length === 0) continue;
 
     const selector = `${SC_ATTR}.g${group}[id="${id}"]`;
 

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.tsx.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.tsx.snap
@@ -18,6 +18,31 @@ data-styled.g2[id="sc-b"]{content:"c,"}/*!sc*/
 </style>
 `;
 
+exports[`ssr should emit global styles without any other components 1`] = `
+<style data-styled="true"
+       data-styled-version="JEST_MOCK_VERSION"
+>
+  body{background:papayawhip;}/*!sc*/
+data-styled.g1[id="sc-global-a1"]{content:"sc-global-a1,"}/*!sc*/
+</style>
+`;
+
+exports[`ssr should emit global styles without any other components 2`] = `
+[
+  <style
+    dangerouslySetInnerHTML={
+      {
+        "__html": "body{background:papayawhip;}/*!sc*/
+data-styled.g1[id="sc-global-a1"]{content:"sc-global-a1,"}/*!sc*/
+",
+      }
+    }
+    data-styled=""
+    data-styled-version="JEST_MOCK_VERSION"
+  />,
+]
+`;
+
 exports[`ssr should extract both global and local CSS 1`] = `
 <h1 class="sc-b c">
   Hello SSR!

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -81,13 +81,11 @@ describe('ssr', () => {
     `;
 
     const sheet = new ServerStyleSheet();
-    renderToString(
-      sheet.collectStyles(
-        <Component />
-      )
-    );
+    renderToString(sheet.collectStyles(<Component />));
+
     const cssTags = sheet.getStyleTags();
     expect(cssTags).toMatchSnapshot();
+
     const cssElements = sheet.getStyleElement();
     expect(cssElements).toMatchSnapshot();
   });

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -68,8 +68,11 @@ describe('ssr', () => {
     const sheet = new ServerStyleSheet();
     renderToString(sheet.collectStyles(<div />));
 
-    const css = sheet.getStyleTags();
-    expect(css).toBe('');
+    const cssTags = sheet.getStyleTags();
+    expect(cssTags).toBe('');
+
+    const cssElements = sheet.getStyleElement();
+    expect(cssElements).toEqual([]);
   });
 
   it('should not spill ServerStyleSheets into each other', () => {

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -60,6 +60,18 @@ describe('ssr', () => {
     expect(css).toMatchSnapshot();
   });
 
+  it('should emit nothing when no styles were generated', () => {
+    styled.h1`
+      color: red;
+    `;
+
+    const sheet = new ServerStyleSheet();
+    renderToString(sheet.collectStyles(<div />));
+
+    const css = sheet.getStyleTags();
+    expect(css).toBe('');
+  });
+
   it('should not spill ServerStyleSheets into each other', () => {
     const A = styled.h1`
       color: red;

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -75,6 +75,23 @@ describe('ssr', () => {
     expect(cssElements).toEqual([]);
   });
 
+  it('should emit global styles without any other components', () => {
+    const Component = createGlobalStyle`
+      body { background: papayawhip; }
+    `;
+
+    const sheet = new ServerStyleSheet();
+    renderToString(
+      sheet.collectStyles(
+        <Component />
+      )
+    );
+    const cssTags = sheet.getStyleTags();
+    expect(cssTags).toMatchSnapshot();
+    const cssElements = sheet.getStyleElement();
+    expect(cssElements).toMatchSnapshot();
+  });
+
   it('should not spill ServerStyleSheets into each other', () => {
     const A = styled.h1`
       color: red;


### PR DESCRIPTION
It seems like this PR not ported over to v6 and with React 18 streaming, it's possible to insert empty style tag in middle of html.
It should fix this issue: https://github.com/styled-components/styled-components/issues/4289

Ported over from: https://github.com/styled-components/styled-components/commit/b9e60f7efb66c0710002f0e133e42af1c7deb497