### PR TITLE
Export rehydrate from StyleSheet

### DIFF
--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -61,6 +61,12 @@ export default class StyleSheet implements Sheet {
     setToString(this, () => outputSheet(this));
   }
 
+  rehydrate(): void {
+    if (!this.server && IS_BROWSER) {
+      rehydrateSheet(this);
+    }
+  }
+
   reconstructWithOptions(options: SheetConstructorArgs, withNames = true) {
     return new StyleSheet(
       { ...this.options, ...options },

--- a/packages/styled-components/src/sheet/types.ts
+++ b/packages/styled-components/src/sheet/types.ts
@@ -33,5 +33,6 @@ export interface Sheet {
   options: SheetOptions;
   names: Map<string, Set<string>>;
   registerName(id: string, name: string): void;
+  rehydrate(): void;
   toString(): string;
 }


### PR DESCRIPTION
This will help rehydrate sheet on NextJS/React 18 streaming when initial rehydration is already done and we receive a new chunk from NextJS `useServerInsertedHTML` afterwards.
With this change we can manually get the stylesheet and call rehydration.