### PR TITLE
feat: use insertion effects when available

### DIFF
--- a/.changeset/silly-carpets-train.md
+++ b/.changeset/silly-carpets-train.md
@@ -1,0 +1,5 @@
+---
+'styled-components': minor
+---
+
+use insertion effects when available

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@emotion/is-prop-valid": "1.2.2",
     "@emotion/unitless": "0.8.1",
+    "@emotion/use-insertion-effect-with-fallbacks": "1.0.1",
     "@types/stylis": "4.2.5",
     "css-to-react-native": "3.2.0",
     "csstype": "3.1.3",

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -1,3 +1,4 @@
+import { useInsertionEffectWithLayoutFallback } from '@emotion/use-insertion-effect-with-fallbacks';
 import React from 'react';
 import { STATIC_EXECUTION_CONTEXT } from '../constants';
 import GlobalStyle from '../models/GlobalStyle';
@@ -49,7 +50,7 @@ export default function createGlobalStyle<Props extends object>(
     }
 
     if (!__SERVER__) {
-      React.useLayoutEffect(() => {
+      useInsertionEffectWithLayoutFallback(() => {
         if (!ssc.styleSheet.server) {
           renderStyles(instance, props, ssc.styleSheet, theme, ssc.stylis);
           return () => globalStyle.removeStyles(instance, ssc.styleSheet);

--- a/packages/styled-components/src/global.d.ts
+++ b/packages/styled-components/src/global.d.ts
@@ -19,6 +19,17 @@ declare module '@emotion/unitless' {
   export default {} as { [key: string]: boolean };
 }
 
+declare module '@emotion/use-insertion-effect-with-fallbacks' {
+  export const useInsertionEffectAlwaysWithSyncFallback: (
+    effect: React.EffectCallback,
+    deps?: React.DependencyList | undefined
+  ) => void;
+  export const useInsertionEffectWithLayoutFallback: (
+    effect: React.EffectCallback,
+    deps?: React.DependencyList | undefined
+  ) => void;
+}
+
 declare module 'babel-plugin-styled-components' {
   export default function ({ types: any }): {
     inherits: any;

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -1,6 +1,7 @@
 import isPropValid from '@emotion/is-prop-valid';
+import { useInsertionEffectAlwaysWithSyncFallback } from '@emotion/use-insertion-effect-with-fallbacks';
 import React, { createElement, Ref, useDebugValue } from 'react';
-import { SC_VERSION } from '../constants';
+import { IS_BROWSER, SC_VERSION } from '../constants';
 import type {
   AnyComponent,
   Attrs,
@@ -37,6 +38,13 @@ import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
 const identifiers: { [key: string]: number } = {};
 
+// @ts-expect-error - this is fine
+const useInsertionEffect = React['useInsertion' + 'Effect']
+  ? // @ts-expect-error - this is fine
+    React['useInsertion' + 'Effect']
+  : false;
+const shouldUseInsertionEffect = !IS_BROWSER ? false : Boolean(useInsertionEffect);
+
 /* We depend on components having unique IDs */
 function generateId(
   displayName?: string | undefined,
@@ -61,11 +69,23 @@ function useInjectedStyle<T extends ExecutionContext>(
 ) {
   const ssc = useStyleSheetContext();
 
+  const insertionEffectBuffer: [name: string, rules: string[]][] | false =
+    !ssc.styleSheet.server && shouldUseInsertionEffect && [];
   const className = componentStyle.generateAndInjectStyles(
     resolvedAttrs,
     ssc.styleSheet,
-    ssc.stylis
+    ssc.stylis,
+    insertionEffectBuffer
   );
+
+  if (shouldUseInsertionEffect) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useInsertionEffectAlwaysWithSyncFallback(() => {
+      if (Array.isArray(insertionEffectBuffer) && insertionEffectBuffer.length > 0) {
+        componentStyle.flushStyles(insertionEffectBuffer, ssc.styleSheet);
+      }
+    });
+  }
 
   if (process.env.NODE_ENV !== 'production') useDebugValue(className);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,7 +2083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/use-insertion-effect-with-fallbacks@npm:^1.0.1":
+"@emotion/use-insertion-effect-with-fallbacks@npm:1.0.1, @emotion/use-insertion-effect-with-fallbacks@npm:^1.0.1":
   version: 1.0.1
   resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.0.1"
   peerDependencies:
@@ -10587,6 +10587,7 @@ __metadata:
     "@babel/preset-typescript": "npm:7.24.1"
     "@emotion/is-prop-valid": "npm:1.2.2"
     "@emotion/unitless": "npm:0.8.1"
+    "@emotion/use-insertion-effect-with-fallbacks": "npm:1.0.1"
     "@rollup/plugin-typescript": "npm:11.1.6"
     "@types/enzyme": "npm:3.10.18"
     "@types/jest": "npm:29.5.12"


### PR DESCRIPTION
At sanity we use `styled-components` extensively, [our `@sanity/ui` design system](https://www.sanity.io/ui) is built upon it, and most of the Sanity Studio codebase is as well. We've been testing the impact of implementing `useInsertionEffect` and see a noticeable performance improvement both on component mounting and rerender perf when the CSS is changed and it motivated us to open a PR 🙌 

The [new React docs explains `useInsertionEffect`](https://react.dev/reference/react/useInsertionEffect) really well, [especially the section at the end](https://react.dev/reference/react/useInsertionEffect#how-is-this-better-than-injecting-styles-during-rendering-or-uselayouteffect): 

![How is this better than injecting styles during rendering or useLayoutEffect?](https://github.com/user-attachments/assets/8e0cae8c-0513-4676-8f5f-11e720283a68)
![If you insert styles during rendering and React is processing a non-blocking update, the browser will recalculate the styles every single frame while rendering a component tree, which can be extremely slow.
useInsertionEffect is better than inserting styles during useLayoutEffect or useEffect because it ensures that by the time other Effects run in your components, the < style > tags have already been inserted. Otherwise, layout calculations in regular Effects would be wrong due to outdated styles.](https://github.com/user-attachments/assets/1355a851-28fc-407a-9956-67f33c820677)


# Using Insertion Effects in `StyledComponent`

The work in this implementation builds upon @alexandernanberg's work in #3821 and how Emotion implements it.
By using `useInsertionEffectAlwaysWithSyncFallback` from `@emotion/use-insertion-effect-with-fallbacks` we are able to:
- React 18 and later the `useInsertionEffect` hook is used to write to the CSSOM.
- React 17 and older will continue to emit during render, ensuring the CSSOM is updated before userland `useEffect` and `useLayoutEffect` hooks are called.

# Using Insertion Effects in `createGlobalStyle`

I'm using `useInsertionEffectWithLayoutFallback` from `@emotion/use-insertion-effect-with-fallbacks` to ensure that Insertion Effects are used while available, otherwise Layout Effects are used like it is now.

I saw that global styles used to opt-in to Insertion Effects in the past, but it was reverted in [#4101](https://github.com/styled-components/styled-components/pull/4101).
It seems like the React team [doesn't see the behaviour as a bug](https://github.com/facebook/react/issues/26670#issuecomment-1685121303), and there's ways to make global styles mounted in a suspended component (like in a React.lazy) eagerly run teardown and remove global styles:
- use a startTransition to wrap events that lead to React.lazy, or general suspense 
- change the key of the parent Suspense boundary when you load a different React.lazy or suspending component
- if changing the suspense key isn't viable then separate suspense boundaries could be used.

I forked @mdeschamps [codesandbox](https://codesandbox.io/s/styled-components-base-forked-9nszy4?file=/index.js) and [modified it](https://codesandbox.io/p/sandbox/styled-components-base-forked-mzzcsl?file=%2Findex.js) to demonstrate how using a `key` prop on the outer `Suspense` boundary solves it (using our `speedy-styled-components` fork that implements this PR), it also has commented out code that uses `startTransition` instead of changing the key.

# Testing
<del>To run the benchmark, and tests, I've bumped react from 17 to 18. </del> One doesn't simply bump test dependencies 😮‍💨 I changed it back to 17.
There's also a forked version of `styled-components` on npm that you can use to test the changes in this PR in userland: `"styled-components": "npm:speedy-styled-components@6.1.12-canary.4"`.
