### PR TITLE
Replace deprecated global JSX namespace

### DIFF
--- a/packages/styled-components/src/constructors/styled.tsx
+++ b/packages/styled-components/src/constructors/styled.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithRef } from 'react';
+import * as React from 'react';
 import createStyledComponent from '../models/StyledComponent';
 import { BaseObject, KnownTarget, WebTarget } from '../types';
 import domElements, { SupportedHTMLElements } from '../utils/domElements';
@@ -10,11 +10,11 @@ const baseStyled = <Target extends WebTarget, InjectedProps extends object = Bas
   constructWithOptions<
     'web',
     Target,
-    Target extends KnownTarget ? ComponentPropsWithRef<Target> & InjectedProps : InjectedProps
+    Target extends KnownTarget ? React.ComponentPropsWithRef<Target> & InjectedProps : InjectedProps
   >(createStyledComponent, tag);
 
 const styled = baseStyled as typeof baseStyled & {
-  [E in SupportedHTMLElements]: StyledInstance<'web', E, JSX.IntrinsicElements[E]>;
+  [E in SupportedHTMLElements]: StyledInstance<'web', E, React.JSX.IntrinsicElements[E]>;
 };
 
 // Shorthands for all valid HTML Elements

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.ssr.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.ssr.test.tsx
@@ -12,7 +12,7 @@ describe(`createGlobalStyle`, () => {
 
   function setup() {
     return {
-      renderToString(comp: JSX.Element) {
+      renderToString(comp: React.JSX.Element) {
         return ReactDOMServer.renderToString(comp);
       },
     };

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
@@ -19,7 +19,7 @@ describe(`createGlobalStyle`, () => {
 
     return {
       container,
-      render(comp: JSX.Element) {
+      render(comp: React.JSX.Element) {
         ReactDOM.render(comp, container);
       },
       cleanup() {

--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -6,7 +6,7 @@ import getComponentName from '../utils/getComponentName';
 import hoist from '../utils/hoist';
 
 export default function withTheme<T extends AnyComponent>(Component: T) {
-  const WithTheme = React.forwardRef<T, JSX.LibraryManagedAttributes<T, ExecutionProps>>(
+  const WithTheme = React.forwardRef<T, React.JSX.LibraryManagedAttributes<T, ExecutionProps>>(
     (props, ref) => {
       const theme = React.useContext(ThemeContext);
       const themeProp = determineTheme(props, theme, Component.defaultProps);

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -35,7 +35,7 @@ export default class ServerStyleSheet {
     return `<style ${htmlAttr}>${css}</style>`;
   };
 
-  collectStyles(children: any): JSX.Element {
+  collectStyles(children: any): React.JSX.Element {
     if (this.sealed) {
       throw styledError(2);
     }

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -78,7 +78,7 @@ export type IStyleSheetManager = React.PropsWithChildren<{
   target?: undefined | HTMLElement;
 }>;
 
-export function StyleSheetManager(props: IStyleSheetManager): JSX.Element {
+export function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element {
   const [plugins, setPlugins] = useState(props.stylisPlugins);
   const { styleSheet } = useStyleSheetContext();
 

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -86,7 +86,7 @@ export function useTheme(): DefaultTheme {
 /**
  * Provide a theme to an entire react component tree via context
  */
-export default function ThemeProvider(props: Props): JSX.Element | null {
+export default function ThemeProvider(props: Props): React.JSX.Element | null {
   const outerTheme = React.useContext(ThemeContext);
   const themeContext = useMemo(
     () => mergeTheme(props.theme, outerTheme),

--- a/packages/styled-components/src/test/props.test.tsx
+++ b/packages/styled-components/src/test/props.test.tsx
@@ -127,7 +127,7 @@ describe('props', () => {
     });
 
     it('allows custom prop filtering for components', () => {
-      const InnerComp = (props: JSX.IntrinsicElements['div']) => <div {...props} />;
+      const InnerComp = (props: React.JSX.IntrinsicElements['div']) => <div {...props} />;
       const Comp = styled(InnerComp).withConfig({
         shouldForwardProp: prop => !['filterThis'].includes(prop),
       })<{ filterThis: string; passThru: string }>`
@@ -184,7 +184,7 @@ describe('props', () => {
     });
 
     it('should filter out props when using "as" to a custom component', () => {
-      const AsComp = (props: JSX.IntrinsicElements['div']) => <div {...props} />;
+      const AsComp = (props: React.JSX.IntrinsicElements['div']) => <div {...props} />;
       const Comp = styled('div').withConfig({
         shouldForwardProp: prop => !['filterThis'].includes(prop),
       })<{ filterThis: string; passThru: string }>`
@@ -202,7 +202,7 @@ describe('props', () => {
     });
 
     it('can set computed styles based on props that are being filtered out', () => {
-      const AsComp = (props: JSX.IntrinsicElements['div']) => <div {...props} />;
+      const AsComp = (props: React.JSX.IntrinsicElements['div']) => <div {...props} />;
       const Comp = styled('div').withConfig({
         shouldForwardProp: prop => !['filterThis'].includes(prop),
       })<{ filterThis: string; passThru: string }>`

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -306,7 +306,7 @@ describe('ssr', () => {
   });
 
   it('should handle errors while streaming', () => {
-    function ExplodingComponent(): JSX.Element {
+    function ExplodingComponent(): React.JSX.Element {
       throw new Error('ahhh');
     }
 

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -309,7 +309,7 @@ const StyledDiv = styled.div``;
 
 const CustomComponent = (({ ...props }) => {
   return <StyledDiv {...props} />;
-}) as IStyledComponent<'web', JSX.IntrinsicElements['div']>;
+}) as IStyledComponent<'web', React.JSX.IntrinsicElements['div']>;
 
 const StyledCustomComponent = styled(CustomComponent)``;
 

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -217,7 +217,7 @@ export interface PolymorphicComponent<R extends Runtime, BaseProps extends objec
     ForwardedAsTarget extends StyledTarget<R> | void = void,
   >(
     props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget>
-  ): JSX.Element;
+  ): React.JSX.Element;
 }
 
 export interface IStyledComponentBase<R extends Runtime, Props extends object = BaseObject>


### PR DESCRIPTION
The global `JSX` namespace is [deprecated](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript). This Replaces it with `React.JSX`.

Motivation:
This will make the library compatible with `types-react@19.0.0-rc.1` (Upcoming `@types/react` version). It comes at no backwards compatibility cost, the `React.JSX` namespace is already used in some places. At MUI we need `@types/react@19` compatibility (but not necessarily `react@19` compatibility) for https://github.com/mui/material-ui/pull/42824.