### PR TITLE
Support for StyleSheetManager props in collectStyles

### DIFF
--- a/.changeset/rare-socks-glow.md
+++ b/.changeset/rare-socks-glow.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Add support for passing StyleSheetManager props from collect styles

--- a/packages/sandbox/pages/_document.tsx
+++ b/packages/sandbox/pages/_document.tsx
@@ -1,5 +1,4 @@
 import Document, { DocumentContext } from 'next/document';
-import React from 'react';
 import { ServerStyleSheet } from 'styled-components';
 
 export default class MyDocument extends Document {
@@ -10,7 +9,10 @@ export default class MyDocument extends Document {
     try {
       ctx.renderPage = () =>
         originalRenderPage({
-          enhanceApp: App => props => sheet.collectStyles(<App {...props} />),
+          enhanceApp: App => props =>
+            sheet.collectStyles(<App {...props} />, {
+              enableVendorPrefixes: true,
+            }),
         });
 
       const initialProps = await Document.getInitialProps(ctx);

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.ssr.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.ssr.test.tsx
@@ -24,13 +24,29 @@ describe(`createGlobalStyle`, () => {
 
   it(`injects global <style> when rendered to string`, () => {
     const sheet = new ServerStyleSheet();
-    const Component = createGlobalStyle`[data-test-inject]{color:red;} `;
+    const Component = createGlobalStyle`[data-test-inject]{color:red;align-items:center;} `;
     const html = context.renderToString(sheet.collectStyles(<Component />));
     const styles = stripOuterHTML(sheet.getStyleTags());
 
     expect(html).toBe('');
     expect(stripWhitespace(stripComments(styles))).toMatchInlineSnapshot(
-      `"[data-test-inject]{ color:red; } data-styled.g1[id="sc-global-a1"]{ content:"sc-global-a1,"} "`
+      `"[data-test-inject]{ color:red; align-items:center; } data-styled.g1[id="sc-global-a1"]{ content:"sc-global-a1,"} "`
+    );
+  });
+
+  it(`injects global <style> when rendered to string and adds vendor prefix if required`, () => {
+    const sheet = new ServerStyleSheet();
+    const Component = createGlobalStyle`[data-test-inject]{color:red;align-items:center;} `;
+    const html = context.renderToString(
+      sheet.collectStyles(<Component />, {
+        enableVendorPrefixes: true,
+      })
+    );
+    const styles = stripOuterHTML(sheet.getStyleTags());
+
+    expect(html).toBe('');
+    expect(stripWhitespace(stripComments(styles))).toMatchInlineSnapshot(
+      `"[data-test-inject]{ color:red; -webkit-align-items:center; -webkit-box-align:center; -ms-flex-align:center; align-items:center; } data-styled.g1[id="sc-global-a1"]{ content:"sc-global-a1,"} "`
     );
   });
 });

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -6,7 +6,7 @@ import StyleSheet from '../sheet';
 import styledError from '../utils/error';
 import { joinStringArray } from '../utils/joinStrings';
 import getNonce from '../utils/nonce';
-import { StyleSheetManager } from './StyleSheetManager';
+import { IStyleSheetManager, StyleSheetManager } from './StyleSheetManager';
 
 declare const __SERVER__: boolean;
 
@@ -35,12 +35,22 @@ export default class ServerStyleSheet {
     return `<style ${htmlAttr}>${css}</style>`;
   };
 
-  collectStyles(children: any): React.JSX.Element {
+  collectStyles(
+    children: any,
+    styleSheetProps?: Omit<IStyleSheetManager, 'sheet' | 'children'>
+  ): React.JSX.Element {
     if (this.sealed) {
       throw styledError(2);
     }
 
-    return <StyleSheetManager sheet={this.instance}>{children}</StyleSheetManager>;
+    return (
+      <StyleSheetManager
+        sheet={this.instance}
+        enableVendorPrefixes={styleSheetProps?.enableVendorPrefixes || false}
+      >
+        {children}
+      </StyleSheetManager>
+    );
   }
 
   getStyleTags = (): string => {

--- a/packages/styled-components/src/test/__snapshots__/ssr.test.tsx.snap
+++ b/packages/styled-components/src/test/__snapshots__/ssr.test.tsx.snap
@@ -75,6 +75,21 @@ data-styled.g1[id="sc-a"]{content:"b,"}/*!sc*/
 </style>
 `;
 
+exports[`ssr should extract the vendor CSS in a simple case 1`] = `
+<h1 class="sc-a b">
+  Hello SSR!
+</h1>
+`;
+
+exports[`ssr should extract the vendor CSS in a simple case 2`] = `
+<style data-styled="true"
+       data-styled-version="JEST_MOCK_VERSION"
+>
+  .b{color:red;-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;}/*!sc*/
+data-styled.g1[id="sc-a"]{content:"b,"}/*!sc*/
+</style>
+`;
+
 exports[`ssr should handle errors while streaming 1`] = `[Error: ahhh]`;
 
 exports[`ssr should interleave styles with rendered HTML when utilitizing streaming 1`] = `

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -37,6 +37,24 @@ describe('ssr', () => {
     expect(css).toMatchSnapshot();
   });
 
+  it('should extract the vendor CSS in a simple case', () => {
+    const Heading = styled.h1`
+      color: red;
+      align-items: center;
+    `;
+
+    const sheet = new ServerStyleSheet();
+    const html = renderToString(
+      sheet.collectStyles(<Heading>Hello SSR!</Heading>, {
+        enableVendorPrefixes: true,
+      })
+    );
+    const css = sheet.getStyleTags();
+
+    expect(html).toMatchSnapshot();
+    expect(css).toMatchSnapshot();
+  });
+
   it('should extract both global and local CSS', () => {
     const Component = createGlobalStyle`
       body { background: papayawhip; }


### PR DESCRIPTION
Upgrading to v6 from v5 for SSR apps would require everyone to add another StyleSheetManager instance if they want to add vendor prefixes.

This increases code size, and rendering time, since StyleSheetManager would need to be evaluated twice. This adds support for passing in StyleSheetManager props, and directly reusing the already initialized StyleSheetManager.