### PR TITLE
feat: get nonce from process.env or __webpack_nonce__

### DIFF
--- a/packages/styled-components/src/utils/nonce.ts
+++ b/packages/styled-components/src/utils/nonce.ts
@@ -1,5 +1,11 @@
 declare let __webpack_nonce__: string;
 
 export default function getNonce() {
-  return typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : null;
+  let nonce: string | null = null;
+  if (process.env.styled_component_nonce) {
+    nonce = process.env.styled_component_nonce;
+  } else if (typeof __webpack_nonce__ !== 'undefined') {
+    nonce = __webpack_nonce__;
+  }
+  return nonce;
 }


### PR DESCRIPTION
Modify getNonce function to prioritize process.env.nonce

This commit updates the existing `getNonce()` function in the `nonce.ts` file to prioritize retrieving the nonce value from `process.env.styled_component_nonce`. 

Changes made:
- Added a check for `process.env.styled_component_nonce` as the primary source of the nonce value
- Retained the fallback to `__webpack_nonce__` if `process.env.nonce` is not available

This modification enhances the flexibility of nonce retrieval, allowing easier configuration through environment variables while maintaining compatibility with webpack's nonce implementation.