### PR TITLE
Prevent styled() from injecting an undefined ref prop in React 19

### DIFF
--- a/.changeset/tough-eyes-thank.md
+++ b/.changeset/tough-eyes-thank.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fix Accessing element.ref was removed in React 19

--- a/.changeset/tough-eyes-thank.md
+++ b/.changeset/tough-eyes-thank.md
@@ -2,4 +2,4 @@
 'styled-components': patch
 ---
 
-Fix Accessing element.ref was removed in React 19
+Prevent styled() from injecting an undefined ref prop in React 19

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -188,7 +188,12 @@ function useStyledComponentImpl<Props extends object>(
       : 'className'
   ] = classString;
 
-  propsForElement.ref = forwardedRef;
+  // forwardedRef is coming from React.forwardRef.
+  // But it might not exist. Since React 19 handles `ref` like a prop, it only define it if there is a value.
+  // We don't want to inject an empty ref.
+  if (forwardedRef) {
+    propsForElement.ref = forwardedRef;
+  }
 
   return createElement(elementToBeCreated, propsForElement);
 }

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -100,8 +100,12 @@ function useStyledComponentImpl<Props extends StyledComponentImplProps>(
           : generatedStyles,
     [props.style, generatedStyles]
   );
-
-  propsForElement.ref = refToForward;
+  // forwardedRef is coming from React.forwardRef.
+  // But it might not exist. Since React 19 handles `ref` like a prop, it only define it if there is a value.
+  // We don't want to inject an empty ref.
+  if (forwardedRef) {
+    propsForElement.ref = refToForward;
+  }
 
   return createElement(elementToBeCreated, propsForElement);
 }


### PR DESCRIPTION
Fix #4331