### PR TITLE
chore: update postcss to version 8.4.49 and nanoid to version 3.3.8

### DIFF
--- a/.changeset/two-rockets-pay.md
+++ b/.changeset/two-rockets-pay.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+chore: update postcss to version 8.4.49 and nanoid to version 3.3.8

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -59,7 +59,7 @@
     "@types/stylis": "4.2.5",
     "css-to-react-native": "3.2.0",
     "csstype": "3.1.3",
-    "postcss": "8.4.38",
+    "postcss": "8.4.49",
     "shallowequal": "1.1.0",
     "stylis": "4.3.2",
     "tslib": "2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8388,11 +8388,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.4, nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  checksum: 4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
   languageName: node
   linkType: hard
 
@@ -8952,6 +8952,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
@@ -9081,7 +9088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.38, postcss@npm:^8.4.33":
+"postcss@npm:8.4.38":
   version: 8.4.38
   resolution: "postcss@npm:8.4.38"
   dependencies:
@@ -9089,6 +9096,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.2.0"
   checksum: 955407b8f70cf0c14acf35dab3615899a2a60a26718a63c848cf3c29f2467b0533991b985a2b994430d890bd7ec2b1963e36352b0774a19143b5f591540f7c06
+  languageName: node
+  linkType: hard
+
+"postcss@npm:8.4.49, postcss@npm:^8.4.33":
+  version: 8.4.49
+  resolution: "postcss@npm:8.4.49"
+  dependencies:
+    nanoid: "npm:^3.3.7"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
   languageName: node
   linkType: hard
 
@@ -10206,6 +10224,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
 "source-map-loader@npm:4.0.2":
   version: 4.0.2
   resolution: "source-map-loader@npm:4.0.2"
@@ -10611,7 +10636,7 @@ __metadata:
     jest-serializer-html: "npm:7.1.0"
     jest-watch-typeahead: "npm:2.2.2"
     js-beautify: "npm:1.15.1"
-    postcss: "npm:8.4.38"
+    postcss: "npm:8.4.49"
     prettier: "npm:3.2.5"
     prop-types: "npm:15.8.1"
     react: "npm:17.0.2"


### PR DESCRIPTION
Fixes CVE-2024-55565