### PR TITLE
fix: release of native typings wasn't working

### DIFF
--- a/.changeset/nasty-kids-count.md
+++ b/.changeset/nasty-kids-count.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Native typings weren't on the correct folder, which caused issues on React Native projects using this library

--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -28,7 +28,7 @@ const esm = {
 const getCJS = override => ({ ...cjs, ...override });
 const getESM = override => ({ ...esm, ...override });
 
-const commonPlugins = [
+const defaultTypescriptPlugin =
   typescript({
     // The build breaks if the tests are included by the typescript plugin.
     // Since un-excluding them in tsconfig.json, we must explicitly exclude them
@@ -36,7 +36,22 @@ const commonPlugins = [
     exclude: ['**/*.test.ts', '**/*.test.tsx', 'dist', 'src/test/types.tsx'],
     outputToFilesystem: true,
     tsconfig: './tsconfig.json',
-  }),
+  });
+
+const nativeTypescriptPlugin =
+  typescript({
+    // The build breaks if the tests are included by the typescript plugin.
+    // Since un-excluding them in tsconfig.json, we must explicitly exclude them
+    // here.
+    exclude: ['**/*.test.ts', '**/*.test.tsx', 'dist', 'src/test/types.tsx'],
+    outputToFilesystem: true,
+    tsconfig: './tsconfig.json',
+    compilerOptions: {
+      outDir: 'native/dist'
+    }
+  });
+
+const basePlugins = [
   sourceMaps(),
   json(),
   nodeResolve(),
@@ -85,6 +100,11 @@ const minifierPlugin = terser({
     preserve_annotations: true,
   },
 });
+
+const commonPlugins = [
+  defaultTypescriptPlugin,
+  basePlugins
+];
 
 const configBase = {
   input: './src/index.ts',
@@ -179,7 +199,11 @@ const nativeConfig = {
       file: 'native/dist/styled-components.native.esm.js',
     }),
   ],
-  plugins: configBase.plugins.concat(minifierPlugin),
+  plugins: [
+    nativeTypescriptPlugin,
+    ...commonPlugins,
+    minifierPlugin
+  ],
 };
 
 export default [standaloneConfig, standaloneProdConfig, serverConfig, browserConfig, nativeConfig];


### PR DESCRIPTION
This should address #5516 (and probably some similar issues). The gist of it is that when the library is built, native/dist should have the typings alongside of the cjs and esm builds, but it doesn't by default (I do see the files in the published package, but they're under native/dist/dist instead of native/dist, I guess something manual was done before publishing the package like a cp command that missed/had one too many leading slashes in it?). So this change updates the typescript's outDir for the native compilation to properly output into the native/dist folder.