### PR TITLE
fix: add documentation link for Dynamic Creation console warning

### DIFF
--- a/.changeset/small-cows-dance.md
+++ b/.changeset/small-cows-dance.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+fix: add info link to console

--- a/packages/styled-components/src/utils/checkDynamicCreation.ts
+++ b/packages/styled-components/src/utils/checkDynamicCreation.ts
@@ -9,7 +9,8 @@ export const checkDynamicCreation = (displayName: string, componentId?: string |
     const message =
       `The component ${displayName}${parsedIdString} has been created dynamically.\n` +
       "You may see this warning because you've called styled inside another component.\n" +
-      'To resolve this only create new StyledComponents outside of any render method and function component.';
+      'To resolve this only create new StyledComponents outside of any render method and function component.\n' +
+      'See https://styled-components.com/docs/basics#define-styled-components-outside-of-the-render-method for more info.\n';
 
     // If a hook is called outside of a component:
     // React 17 and earlier throw an error


### PR DESCRIPTION
Hi,

I added a documentation link for the Dynamic Creation console warning.
(It took me a while to understand why it must be defined outside the render method.)

I also added a line break at the end because 'Error Component Stack' was continuing without a line break.
<img width="812" alt="スクリーンショット 2025-03-19 11 18 04" src="https://github.com/user-attachments/assets/dc189e82-096d-4286-ac2e-9f1971e8cf4b" />
