### PR TITLE
Add ESM-compatible exports

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -5,13 +5,27 @@
   "publishConfig": {
     "access": "public"
   },
-  "types": "dist/index.d.ts",
-  "main": "dist/styled-components.cjs.js",
-  "module": "./dist/styled-components.esm.js",
-  "react-native": "native/dist/styled-components.native.cjs.js",
-  "browser": {
-    "./dist/styled-components.cjs.js": "./dist/styled-components.browser.cjs.js",
-    "./dist/styled-components.esm.js": "./dist/styled-components.browser.esm.js"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "browser": {
+        "import": "./dist/styled-components.browser.mjs",
+        "require": "./dist/styled-components.browser.cjs"
+      },
+      "react-native": {
+        "import": "./native/dist/styled-components.native.mjs",
+        "require": "./native/dist/styled-components.native.cjs"
+      },
+      "default": {
+        "import": "./dist/styled-components.mjs",
+        "require": "./dist/styled-components.cjs"
+      }
+    },
+    "./native": {
+      "types": "./native/dist/native/index.d.ts",
+      "import": "./native/dist/styled-components.native.mjs",
+      "require": "./native/dist/styled-components.native.cjs"
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -163,8 +163,8 @@ const standaloneProdConfig = {
 const serverConfig = {
   ...configBase,
   output: [
-    getESM({ file: 'dist/styled-components.esm.js' }),
-    getCJS({ file: 'dist/styled-components.cjs.js' }),
+    getESM({ file: 'dist/styled-components.mjs' }),
+    getCJS({ file: 'dist/styled-components.cjs' }),
   ],
   plugins: configBase.plugins.concat(
     replace({
@@ -177,8 +177,8 @@ const serverConfig = {
 const browserConfig = {
   ...configBase,
   output: [
-    getESM({ file: 'dist/styled-components.browser.esm.js' }),
-    getCJS({ file: 'dist/styled-components.browser.cjs.js' }),
+    getESM({ file: 'dist/styled-components.browser.mjs' }),
+    getCJS({ file: 'dist/styled-components.browser.cjs' }),
   ],
   plugins: configBase.plugins.concat(
     replace({
@@ -193,10 +193,10 @@ const nativeConfig = {
   input: './src/native/index.ts',
   output: [
     getCJS({
-      file: 'native/dist/styled-components.native.cjs.js',
+      file: 'native/dist/styled-components.native.cjs',
     }),
     getESM({
-      file: 'native/dist/styled-components.native.esm.js',
+      file: 'native/dist/styled-components.native.mjs',
     }),
   ],
   plugins: [


### PR DESCRIPTION
This adds an `exports` field to the package.json with conditional exports to allow this packaged to be used with strict ESM.

The exports field and conditional exports have been supported since Node 12.

It should be noted that this is a breaking change, and so this should be released with a new major version only.

Fixes #4268 