### PR TITLE
fix: react 19 compatibility

### DIFF
--- a/.changeset/afraid-plants-bathe.md
+++ b/.changeset/afraid-plants-bathe.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+fix react 19 compatibility

--- a/packages/styled-components/src/hoc/withTheme.tsx
+++ b/packages/styled-components/src/hoc/withTheme.tsx
@@ -3,9 +3,15 @@ import { ThemeContext } from '../models/ThemeProvider';
 import { AnyComponent, ExecutionProps } from '../types';
 import determineTheme from '../utils/determineTheme';
 import getComponentName from '../utils/getComponentName';
-import hoist from '../utils/hoist';
+import hoist, { NonReactStatics } from '../utils/hoist';
 
-export default function withTheme<T extends AnyComponent>(Component: T) {
+export default function withTheme<T extends AnyComponent>(
+  Component: T
+): React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<React.JSX.LibraryManagedAttributes<T, ExecutionProps>> &
+    React.RefAttributes<T>
+> &
+  NonReactStatics<T> {
   const WithTheme = React.forwardRef<T, React.JSX.LibraryManagedAttributes<T, ExecutionProps>>(
     (props, ref) => {
       const theme = React.useContext(ThemeContext);

--- a/packages/styled-components/src/utils/hoist.ts
+++ b/packages/styled-components/src/utils/hoist.ts
@@ -90,7 +90,7 @@ type ExcludeList = {
   [key: string]: true;
 };
 
-type NonReactStatics<S extends OmniComponent, C extends ExcludeList = {}> = {
+export type NonReactStatics<S extends OmniComponent, C extends ExcludeList = {}> = {
   [key in Exclude<
     keyof S,
     S extends React.MemoExoticComponent<any>


### PR DESCRIPTION
the `withTheme` types in the build output still referenced the old `JSX` namespace instead of `React.JSX`

this caused issues in react 19 where the old `JSX` namespace was removed.

fixes https://github.com/styled-components/styled-components/issues/4359