### PR TITLE
fix: Node v22+ compatibility

### DIFF
--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -1,11 +1,14 @@
 import typescript from '@rollup/plugin-typescript';
+import { createRequire } from 'node:module';
 import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import { terser } from 'rollup-plugin-terser';
-import pkg from './package.json' assert { type: 'json' };
+const req = createRequire(import.meta.url);
+
+const pkg = req('./package.json');
 
 /**
  * NODE_ENV explicit replacement is only needed for standalone packages, as webpack


### PR DESCRIPTION
This PR is in reference to my issue #5570. There hasn't been any conversation on this issue but it was created shortly after styled-components was put in to maintenance mode. Since the project is in maintenance mode, I have made the change that would provide the widest Node support possible.

This should allow people on Node v22+ to also build the project and continue contributing.