### PR TITLE
Fix runtime crash on Expo 53 / React Native >=0.79 when using unsupported web values

### DIFF
--- a/.changeset/tiny-tigers-learn.md
+++ b/.changeset/tiny-tigers-learn.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+fix for React Native >=0.79 crashes when using unsupported web-only CSS values (e.g., fit-content, min-content, max-content). The fix emits a warning and ignores the property using those values, instead of causing crashes.

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -12,6 +12,9 @@ import flatten from '../utils/flatten';
 import generateComponentId from '../utils/generateComponentId';
 import { joinStringArray } from '../utils/joinStrings';
 
+// List of CSS values not supported by React Native
+export const RN_UNSUPPORTED_VALUES = ['fit-content', 'min-content', 'max-content'];
+
 let generated: Dict<any> = {};
 
 export const resetStyleCache = (): void => {
@@ -44,6 +47,14 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
 
         root.each(node => {
           if (node.type === 'decl') {
+            if (RN_UNSUPPORTED_VALUES.includes(node.value)) {
+              if (process.env.NODE_ENV !== 'production') {
+                console.warn(
+                  `[styled-components/native] The value "${node.value}" for property "${node.prop}" is not supported in React Native and will be ignored.`
+                );
+              }
+              return;
+            }
             declPairs.push([node.prop, node.value]);
           } else if (process.env.NODE_ENV !== 'production' && node.type !== 'comment') {
             console.warn(`Node of type ${node.type} not supported as an inline style`);


### PR DESCRIPTION
This PR addresses an issue where using web-only CSS values (such as fit-content, min-content, max-content) in styled-components for Expo 53 / React Native >=0.79 would cause a runtime crash when interacting with the element containing these values. These values are not supported by React Native, and the underlying `css-to-react-native` library does not raise an error for them. Since the library `css-to-react-native` seems abandoned I'm proposing the change here.

**What’s changed:**
- When an unsupported value for react native is found, the property is skipped and a clear warning is emitted in development mode via `console.error`.
- Added comprehensive tests to ensure all unsupported values are properly warned about and excluded from the resulting style.

**Why:**
- Prevents runtime crashes in Expo 53 / React Native >=0.79 projects using styled-components with unsupported CSS values.
- Improves developer experience by providing a clear warning rather than failing silently or crashing.