### PR TITLE
Fix React Native Typescript issues with v6 (ref and attrs)

### DIFF
--- a/.changeset/fifty-carrots-taste.md
+++ b/.changeset/fifty-carrots-taste.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fixed typescript types for react-native components (added missing ref props and made props optional with attrs)

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -70,9 +70,11 @@ export interface Styled<
     R,
     PrivateResolvedTarget,
     PrivateResolvedTarget extends KnownTarget
-      ? Substitute<
-          Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-          Props
+      ? Partial<
+          Substitute<
+            Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
+            Props
+          >
         >
       : PrivateMergedProps,
     OuterStatics
@@ -133,9 +135,11 @@ export default function constructWithOptions<
       R,
       PrivateResolvedTarget,
       PrivateResolvedTarget extends KnownTarget
-        ? Substitute<
-            Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-            Props
+        ? Partial<
+            Substitute<
+              Substitute<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
+              Props
+            >
           >
         : PrivateMergedProps,
       OuterStatics

--- a/packages/styled-components/src/native/index.ts
+++ b/packages/styled-components/src/native/index.ts
@@ -51,6 +51,14 @@ const aliases = [
 
 type KnownComponents = (typeof aliases)[number];
 
+type PropsWithRef<T> =
+  T extends React.ComponentType<infer P>
+    ? P &
+        React.RefAttributes<
+          T extends React.ComponentClass<any> ? InstanceType<T> : React.ElementRef<T>
+        >
+    : never;
+
 /** Isolates RN-provided components since they don't expose a helper type for this. */
 type RNComponents = {
   [K in keyof typeof reactNative]: (typeof reactNative)[K] extends React.ComponentType<any>
@@ -59,7 +67,7 @@ type RNComponents = {
 };
 
 const styled = baseStyled as typeof baseStyled & {
-  [E in KnownComponents]: Styled<'native', RNComponents[E], React.ComponentProps<RNComponents[E]>>;
+  [E in KnownComponents]: Styled<'native', RNComponents[E], PropsWithRef<RNComponents[E]>>;
 };
 
 /* Define a getter for each alias which simply gets the reactNative component
@@ -118,13 +126,13 @@ export {
   StyledOptions,
 } from '../types';
 export {
-  ThemeConsumer,
-  ThemeContext,
-  ThemeProvider,
   css,
   styled as default,
   isStyledComponent,
   styled,
+  ThemeConsumer,
+  ThemeContext,
+  ThemeProvider,
   toStyleSheet,
   useTheme,
   withTheme,


### PR DESCRIPTION
Fixes:
* #4143 
* #4076

Before, this:
```tsx
const CheckIcon = styled(Icon).attrs({
  name: 'check',
})`
  color: ${colors.black};
`
```
Would result in:
```
No overload matches this call.
  Overload 1 of 2, '(props: PolymorphicComponentProps<"native", FastOmit<FastOmit<Substitute<IconProps & RefAttributes<Icon>, IconProps & RefAttributes<Icon>>, never>, never>, void, void, {}, {}>): Element', gave the following error.
    Property 'name' is missing in type '{}' but required in type 'FastOmit<Substitute<FastOmit<FastOmit<Substitute<IconProps & RefAttributes<Icon>, IconProps & RefAttributes<Icon>>, never>, never>, FastOmit<...>>, keyof ExecutionProps>'.
  Overload 2 of 2, '(props: FastOmit<FastOmit<Substitute<IconProps & RefAttributes<Icon>, IconProps & RefAttributes<Icon>>, never>, never>): ReactNode', gave the following error.
    Property 'name' is missing in type '{}' but required in type 'FastOmit<FastOmit<Substitute<IconProps & RefAttributes<Icon>, IconProps & RefAttributes<Icon>>, never>, never>'. ts(2769)
```

Before, this:
```tsx
const StyledScrollView = styled.ScrollView`
  background: ${colors.white};
`
// ...
const scrollViewRef = useRef<ScrollView | null>(null)
// ...
return <StyledScrollView ref={scrollViewRef} />
```
Would result in:
```
No overload matches this call.
  Overload 1 of 2, '(props: PolymorphicComponentProps<"native", FastOmit<ScrollViewProps, never>, void, void, {}, {}>): Element', gave the following error.
    Type '{ children: (false | Element | Element[] | undefined)[]; ref: MutableRefObject<ScrollView | null>; $height: number; }' is not assignable to type 'IntrinsicAttributes & FastOmit<Substitute<FastOmit<ScrollViewProps, never>, FastOmit<{}, never>>, keyof ExecutionProps> & FastOmit<...> & { ...; }'.
      Property 'ref' does not exist on type 'IntrinsicAttributes & FastOmit<Substitute<FastOmit<ScrollViewProps, never>, FastOmit<{}, never>>, keyof ExecutionProps> & FastOmit<...> & { ...; }'.
  Overload 2 of 2, '(props: FastOmit<ScrollViewProps, never>): ReactNode', gave the following error.
    Type '{ children: (false | Element | Element[] | undefined)[]; ref: MutableRefObject<ScrollView | null>; $height: number; }' is not assignable to type 'IntrinsicAttributes & FastOmit<ScrollViewProps, never>'.
      Property 'ref' does not exist on type 'IntrinsicAttributes & FastOmit<ScrollViewProps, never>'. ts(2769)
```

native/index.d.ts before:
```ts
/// <reference path="../../../src/global.d.ts" />
import React from 'react';
import { Styled } from '../constructors/constructWithOptions';
import css from '../constructors/css';
import withTheme from '../hoc/withTheme';
import ThemeProvider, { ThemeConsumer, ThemeContext, useTheme } from '../models/ThemeProvider';
import { NativeTarget, RuleSet } from '../types';
import isStyledComponent from '../utils/isStyledComponent';
declare const styled: (<Target extends NativeTarget>(tag: Target) => Styled<"native", Target, Target extends import("../types").KnownTarget ? React.ComponentPropsWithRef<Target> : import("../types").BaseObject, import("../types").BaseObject>) & {
    ActivityIndicator: Styled<"native", typeof import("react-native").ActivityIndicator, import("react-native").ActivityIndicatorProps, import("../types").BaseObject>;
    Button: Styled<"native", typeof import("react-native").Button, import("react-native").ButtonProps, import("../types").BaseObject>;
    DatePickerIOS: Styled<"native", typeof import("react-native").DatePickerIOS, import("react-native").DatePickerIOSProps, import("../types").BaseObject>;
    DrawerLayoutAndroid: Styled<"native", typeof import("react-native").DrawerLayoutAndroid, import("react-native").DrawerLayoutAndroidProps, import("../types").BaseObject>;
    FlatList: Styled<"native", typeof import("react-native").FlatList, import("react-native").FlatListProps<unknown>, import("../types").BaseObject>;
    Image: Styled<"native", typeof import("react-native").Image, import("react-native").ImageProps, import("../types").BaseObject>;
    ImageBackground: Styled<"native", typeof import("react-native").ImageBackground, import("react-native").ImageBackgroundProps, import("../types").BaseObject>;
    KeyboardAvoidingView: Styled<"native", typeof import("react-native").KeyboardAvoidingView, import("react-native").KeyboardAvoidingViewProps, import("../types").BaseObject>;
    Modal: Styled<"native", typeof import("react-native").Modal, import("react-native").ModalBaseProps & import("react-native").ModalPropsIOS & import("react-native").ModalPropsAndroid & import("react-native").ViewProps, import("../types").BaseObject>;
    Pressable: Styled<"native", React.ForwardRefExoticComponent<import("react-native").PressableProps & React.RefAttributes<import("react-native").View>>, import("react-native").PressableProps & React.RefAttributes<import("react-native").View>, import("../types").BaseObject>;
    ProgressBarAndroid: Styled<"native", typeof import("react-native").ProgressBarAndroid, import("react-native").ProgressBarAndroidProps, import("../types").BaseObject>;
    ProgressViewIOS: Styled<"native", typeof import("react-native").ProgressViewIOS, import("react-native").ProgressViewIOSProps, import("../types").BaseObject>;
    RefreshControl: Styled<"native", typeof import("react-native").RefreshControl, import("react-native").RefreshControlProps, import("../types").BaseObject>;
    SafeAreaView: Styled<"native", typeof import("react-native").SafeAreaView, import("react-native").ViewProps, import("../types").BaseObject>;
    ScrollView: Styled<"native", typeof import("react-native").ScrollView, import("react-native").ScrollViewProps, import("../types").BaseObject>;
    SectionList: Styled<"native", typeof import("react-native").SectionList, import("react-native").SectionListProps<unknown, unknown>, import("../types").BaseObject>;
    Slider: Styled<"native", typeof import("react-native").Slider, import("react-native").SliderProps, import("../types").BaseObject>;
    Switch: Styled<"native", typeof import("react-native").Switch, import("react-native").SwitchProps, import("../types").BaseObject>;
    Text: Styled<"native", typeof import("react-native").Text, import("react-native").TextProps, import("../types").BaseObject>;
    TextInput: Styled<"native", typeof import("react-native").TextInput, import("react-native").TextInputProps, import("../types").BaseObject>;
    TouchableHighlight: Styled<"native", typeof import("react-native").TouchableHighlight, import("react-native").TouchableHighlightProps, import("../types").BaseObject>;
    TouchableOpacity: Styled<"native", typeof import("react-native").TouchableOpacity, import("react-native").TouchableOpacityProps, import("../types").BaseObject>;
    View: Styled<"native", typeof import("react-native").View, import("react-native").ViewProps, import("../types").BaseObject>;
    VirtualizedList: Styled<"native", typeof import("react-native").VirtualizedList, import("react-native").VirtualizedListProps<unknown>, import("../types").BaseObject>;
};
declare const toStyleSheet: (rules: RuleSet<object>) => import("css-to-react-native").Style;
export { CSSKeyframes, CSSObject, CSSProperties, CSSPseudos, DefaultTheme, ExecutionContext, ExecutionProps, IStyledComponent, IStyledComponentFactory, IStyledStatics, NativeTarget, PolymorphicComponent, PolymorphicComponentProps, Runtime, StyledObject, StyledOptions, } from '../types';
export { ThemeConsumer, ThemeContext, ThemeProvider, css, styled as default, isStyledComponent, styled, toStyleSheet, useTheme, withTheme, };
```
native/index.d.ts after:
```ts
/// <reference path="../../src/global.d.ts" />
import React from 'react';
import { Styled } from '../constructors/constructWithOptions';
import css from '../constructors/css';
import withTheme from '../hoc/withTheme';
import ThemeProvider, { ThemeConsumer, ThemeContext, useTheme } from '../models/ThemeProvider';
import { NativeTarget, RuleSet } from '../types';
import isStyledComponent from '../utils/isStyledComponent';
declare const styled: (<Target extends NativeTarget>(tag: Target) => Styled<"native", Target, Target extends import("../types").KnownTarget ? React.ComponentPropsWithRef<Target> : import("../types").BaseObject, import("../types").BaseObject>) & {
    ActivityIndicator: Styled<"native", typeof import("react-native").ActivityIndicator, import("react-native").ActivityIndicatorProps & React.RefAttributes<import("react-native").ActivityIndicator>, import("../types").BaseObject>;
    Button: Styled<"native", typeof import("react-native").Button, import("react-native").ButtonProps & React.RefAttributes<import("react-native").Button>, import("../types").BaseObject>;
    DatePickerIOS: Styled<"native", typeof import("react-native").DatePickerIOS, import("react-native").DatePickerIOSProps & React.RefAttributes<import("react-native").DatePickerIOS>, import("../types").BaseObject>;
    DrawerLayoutAndroid: Styled<"native", typeof import("react-native").DrawerLayoutAndroid, import("react-native").DrawerLayoutAndroidProps & React.RefAttributes<import("react-native").DrawerLayoutAndroid>, import("../types").BaseObject>;
    FlatList: Styled<"native", typeof import("react-native").FlatList, import("react-native").FlatListProps<unknown> & React.RefAttributes<import("react-native").FlatList<unknown>>, import("../types").BaseObject>;
    Image: Styled<"native", typeof import("react-native").Image, import("react-native").ImageProps & React.RefAttributes<import("react-native").Image>, import("../types").BaseObject>;
    ImageBackground: Styled<"native", typeof import("react-native").ImageBackground, import("react-native").ImageBackgroundProps & React.RefAttributes<import("react-native").ImageBackground>, import("../types").BaseObject>;
    KeyboardAvoidingView: Styled<"native", typeof import("react-native").KeyboardAvoidingView, import("react-native").KeyboardAvoidingViewProps & React.RefAttributes<import("react-native").KeyboardAvoidingView>, import("../types").BaseObject>;
    Modal: Styled<"native", typeof import("react-native").Modal, import("react-native").ModalBaseProps & import("react-native").ModalPropsIOS & import("react-native").ModalPropsAndroid & import("react-native").ViewProps & React.RefAttributes<import("react-native").Modal>, import("../types").BaseObject>;
    Pressable: Styled<"native", React.ForwardRefExoticComponent<import("react-native").PressableProps & React.RefAttributes<import("react-native").View>>, import("react-native").PressableProps & React.RefAttributes<import("react-native").View> & React.RefAttributes<import("react-native").View>, import("../types").BaseObject>;
    ProgressBarAndroid: Styled<"native", typeof import("react-native").ProgressBarAndroid, import("react-native").ProgressBarAndroidProps & React.RefAttributes<import("react-native").ProgressBarAndroid>, import("../types").BaseObject>;
    ProgressViewIOS: Styled<"native", typeof import("react-native").ProgressViewIOS, import("react-native").ProgressViewIOSProps & React.RefAttributes<import("react-native").ProgressViewIOS>, import("../types").BaseObject>;
    RefreshControl: Styled<"native", typeof import("react-native").RefreshControl, import("react-native").RefreshControlProps & React.RefAttributes<import("react-native").RefreshControl>, import("../types").BaseObject>;
    SafeAreaView: Styled<"native", typeof import("react-native").SafeAreaView, import("react-native").ViewProps & React.RefAttributes<import("react-native").SafeAreaView>, import("../types").BaseObject>;
    ScrollView: Styled<"native", typeof import("react-native").ScrollView, import("react-native").ScrollViewProps & React.RefAttributes<import("react-native").ScrollView>, import("../types").BaseObject>;
    SectionList: Styled<"native", typeof import("react-native").SectionList, import("react-native").SectionListProps<unknown, unknown> & React.RefAttributes<import("react-native").SectionList<unknown, unknown>>, import("../types").BaseObject>;
    Slider: Styled<"native", typeof import("react-native").Slider, import("react-native").SliderProps & React.RefAttributes<import("react-native").Slider>, import("../types").BaseObject>;
    Switch: Styled<"native", typeof import("react-native").Switch, import("react-native").SwitchProps & React.RefAttributes<import("react-native").Switch>, import("../types").BaseObject>;
    Text: Styled<"native", typeof import("react-native").Text, import("react-native").TextProps & React.RefAttributes<import("react-native").Text>, import("../types").BaseObject>;
    TextInput: Styled<"native", typeof import("react-native").TextInput, import("react-native").TextInputProps & React.RefAttributes<import("react-native").TextInput>, import("../types").BaseObject>;
    TouchableHighlight: Styled<"native", typeof import("react-native").TouchableHighlight, import("react-native").TouchableHighlightProps & React.RefAttributes<import("react-native").TouchableHighlight>, import("../types").BaseObject>;
    TouchableOpacity: Styled<"native", typeof import("react-native").TouchableOpacity, import("react-native").TouchableOpacityProps & React.RefAttributes<import("react-native").TouchableOpacity>, import("../types").BaseObject>;
    View: Styled<"native", typeof import("react-native").View, import("react-native").ViewProps & React.RefAttributes<import("react-native").View>, import("../types").BaseObject>;
    VirtualizedList: Styled<"native", typeof import("react-native").VirtualizedList, import("react-native").VirtualizedListProps<unknown> & React.RefAttributes<import("react-native").VirtualizedList<unknown>>, import("../types").BaseObject>;
};
declare const toStyleSheet: (rules: RuleSet<object>) => import("css-to-react-native").Style;
export { CSSKeyframes, CSSObject, CSSProperties, CSSPseudos, DefaultTheme, ExecutionContext, ExecutionProps, IStyledComponent, IStyledComponentFactory, IStyledStatics, NativeTarget, PolymorphicComponent, PolymorphicComponentProps, Runtime, StyledObject, StyledOptions, } from '../types';
export { css, styled as default, isStyledComponent, styled, ThemeConsumer, ThemeContext, ThemeProvider, toStyleSheet, useTheme, withTheme, };
```
