### PR TITLE
Make react-dom optional

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -135,5 +135,10 @@
   },
   "engines": {
     "node": ">= 16"
+  },
+  "peerDependenciesMeta": {
+      "react-dom": {
+        "optional": true
+      }
   }
 }


### PR DESCRIPTION
Solves the npm install problem on react-native enviroments. npm warn Could not resolve dependency:
npm warn peer react@"^19.1.1" from react-dom@19.1.1 npm warn node_modules/react-dom
npm warn   peer react-dom@">= 16.8.0" from styled-components@6.1.19
npm warn   node_modules/styled-components