### PR TITLE
fix: domElements-missing-search-tag

### DIFF
--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -186,7 +186,7 @@ function useStyledComponentImpl<Props extends BaseObject>(
   propsForElement[
     // handle custom elements which React doesn't properly alias
     isTag(elementToBeCreated) &&
-    !domElements.has(elementToBeCreated as Extract<typeof domElements, string>)
+    elementToBeCreated.includes('-')
       ? 'class'
       : 'className'
   ] = classString;

--- a/packages/styled-components/src/utils/domElements.ts
+++ b/packages/styled-components/src/utils/domElements.ts
@@ -87,6 +87,7 @@ const elements = [
   's',
   'samp',
   'script',
+  'search',
   'section',
   'select',
   'small',


### PR DESCRIPTION
fix: #5608
Added search to here:
[styled-components/packages/styled-components/src/utils/domElements.ts](https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/utils/domElements.ts#L87-L99)

And 

Changed the logic for determining whether it is a custom element.

[styled-components/packages/styled-components/src/models/StyledComponent.ts](https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/models/StyledComponent.ts#L186-L192)
