### PR TITLE
Fix the build by updating `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,7 +6175,7 @@ __metadata:
 "csstype@npm:3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
-  checksum: cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
+  checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Yarn was updated in c43a66cebfdb7fdaa42c0a1e4a71fa181a0e0bc3 just before pr #5618 was merged.
I think this is causing the `yarn install --immutable` command to fail due to mismatching checksums when [running the checks](https://github.com/styled-components/styled-components/actions/runs/20405357581/job/58634293229).

I updated `yarn` and re-ran `yarn install` locally to update the `yarn.lock` file and now the checksums match, which I think will fix the build.