### PR TITLE
Allow access to all types from types.d.ts

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -36,6 +36,7 @@
       "require": "./native/dist/styled-components.native.cjs.js",
       "default": "./native/dist/styled-components.native.cjs.js"
     },
+    "./internal-types": "./dist/types.d.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,


### PR DESCRIPTION
https://github.com/styled-components/styled-components/issues/5648

The internal types may need to be available to be accessed to avoid TS2742 errors.