### PR TITLE
Add exports to package.json

### DIFF
--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -13,6 +13,31 @@
     "./dist/styled-components.cjs.js": "./dist/styled-components.browser.cjs.js",
     "./dist/styled-components.esm.js": "./dist/styled-components.browser.esm.js"
   },
+  "exports": {
+    ".": {
+      "react-native": {
+        "types": "./native/dist/native/index.d.ts",
+        "import": "./native/dist/styled-components.native.esm.js",
+        "require": "./native/dist/styled-components.native.cjs.js",
+        "default": "./native/dist/styled-components.native.cjs.js"
+      },
+      "types": "./dist/index.d.ts",
+      "browser": {
+        "import": "./dist/styled-components.browser.esm.js",
+        "require": "./dist/styled-components.browser.cjs.js"
+      },
+      "import": "./dist/styled-components.esm.js",
+      "require": "./dist/styled-components.cjs.js",
+      "default": "./dist/styled-components.cjs.js"
+    },
+    "./native": {
+      "types": "./native/dist/native/index.d.ts",
+      "import": "./native/dist/styled-components.native.esm.js",
+      "require": "./native/dist/styled-components.native.cjs.js",
+      "default": "./native/dist/styled-components.native.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
     "generateErrors": "node scripts/generateErrorMap.js",


### PR DESCRIPTION
It is a redo for [this PR](https://github.com/styled-components/styled-components/pull/5644)

I have updated to the latest release, and my Vitest setup is failing again after this commit:
https://github.com/styled-components/styled-components/commit/788e8c05606a621dae748e2a5b36bdbb6a0c8045

I have tried to reproduce the bug, which is described in the commit, but I have no results
Maybe only the second part of the fix is really necessary?

Also, I want to add that if we talk about these issue:
https://github.com/styled-components/styled-components/issues/5648
We can see that the issue has been present since 6.3.7.
But exports were added in 6.3.8