### PR TITLE
build: dedupe TypeScript plugin for native Rollup config

### DIFF
--- a/.changeset/dedupe-native-ts-plugin.md
+++ b/.changeset/dedupe-native-ts-plugin.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Fix native build to avoid running the TypeScript Rollup plugin twice.

--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -212,7 +212,7 @@ const nativeConfig = {
   ],
   plugins: [
     nativeTypescriptPlugin,
-    ...commonPlugins,
+    basePlugins,
     minifierPlugin
   ],
 };


### PR DESCRIPTION
## Summary\n\nRemove the duplicate TypeScript Rollup plugin from the native bundle configuration. The native build was inadvertently running TypeScript compilation twice — once via the dedicated `nativeTypescriptPlugin` and again via `defaultTypescriptPlugin` included in `commonPlugins`.\n\n## Problem\n\n`nativeConfig.plugins` was defined as:\n\n```js\nplugins: [\n  nativeTypescriptPlugin,\n  ...commonPlugins,   // ← includes defaultTypescriptPlugin\n  minifierPlugin\n]\n```\n\nSince `commonPlugins = [defaultTypescriptPlugin, basePlugins]`, spreading it introduced **two** TypeScript plugin instances into the native build pipeline.\n\n## Fix\n\nReplace `...commonPlugins` with just `basePlugins` in `nativeConfig.plugins`:\n\n```js\nplugins: [\n  nativeTypescriptPlugin,\n  basePlugins,        // ← only non-TS base plugins\n  minifierPlugin\n]\n```\n\nThis ensures only the native-specific TypeScript plugin (with `outDir: 'native/dist'`) runs.\n\n## Why safe\n\n- **No runtime logic changes** — this is purely a build configuration cleanup.\n- Rollup [flattens nested plugin arrays](https://rollupjs.org/configuration-options/#plugins), so passing `basePlugins` (an array) directly is valid.\n- All other build targets (`standalone`, `server`, `browser`) are unaffected; they continue using `commonPlugins` via `configBase`.\n\n## Tests\n\n- [x] `pnpm --filter styled-components prettier` — all files unchanged\n- [x] `pnpm build` — all 5 bundles built successfully\n- [x] `pnpm test` — 487 web tests + 37 native tests passed\n\n## Changeset\n\n- `.changeset/dedupe-native-ts-plugin.md` — patch bump for `styled-components`"