### PR TITLE
fix: remove DOM code from React Native build

### DIFF
--- a/.changeset/fix-native-document-undefined.md
+++ b/.changeset/fix-native-document-undefined.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Fix React Native crash caused by `document` references in the native build. The native bundle no longer includes DOM code, resolving compatibility with RN 0.79+ and Hermes.

--- a/packages/styled-components/src/models/Keyframes.ts
+++ b/packages/styled-components/src/models/Keyframes.ts
@@ -1,10 +1,13 @@
 import StyleSheet from '../sheet';
 import { Keyframes as KeyframesType, Stringifier } from '../types';
 import styledError from '../utils/error';
+import { KEYFRAMES_SYMBOL } from '../utils/isKeyframes';
 import { setToString } from '../utils/setToString';
 import { mainStylis } from './StyleSheetManager';
 
 export default class Keyframes implements KeyframesType {
+  readonly [KEYFRAMES_SYMBOL] = true as const;
+
   id: string;
   name: string;
   rules: string;

--- a/packages/styled-components/src/utils/flatten.ts
+++ b/packages/styled-components/src/utils/flatten.ts
@@ -1,5 +1,4 @@
-import Keyframes from '../models/Keyframes';
-import StyleSheet from '../sheet';
+import type StyleSheet from '../sheet';
 import {
   AnyComponent,
   Dict,
@@ -14,6 +13,7 @@ import addUnitIfNeeded from './addUnitIfNeeded';
 import getComponentName from './getComponentName';
 import hyphenate from './hyphenateStyleName';
 import isFunction from './isFunction';
+import isKeyframes from './isKeyframes';
 import isPlainObject from './isPlainObject';
 import isStatelessFunction from './isStatelessFunction';
 import isStyledComponent from './isStyledComponent';
@@ -75,7 +75,7 @@ export default function flatten<Props extends object>(
         process.env.NODE_ENV !== 'production' &&
         typeof fnResult === 'object' &&
         !Array.isArray(fnResult) &&
-        !(fnResult instanceof Keyframes) &&
+        !isKeyframes(fnResult) &&
         !isPlainObject(fnResult) &&
         fnResult !== null
       ) {
@@ -93,7 +93,7 @@ export default function flatten<Props extends object>(
     }
   }
 
-  if (chunk instanceof Keyframes) {
+  if (isKeyframes(chunk)) {
     if (styleSheet) {
       chunk.inject(styleSheet, stylisInstance);
       result.push(chunk.getName(stylisInstance));

--- a/packages/styled-components/src/utils/isKeyframes.ts
+++ b/packages/styled-components/src/utils/isKeyframes.ts
@@ -1,0 +1,9 @@
+import type KeyframesClass from '../models/Keyframes';
+
+const KEYFRAMES_SYMBOL = Symbol.for('sc-keyframes');
+
+export default function isKeyframes(value: unknown): value is KeyframesClass {
+  return typeof value === 'object' && value !== null && KEYFRAMES_SYMBOL in value;
+}
+
+export { KEYFRAMES_SYMBOL };


### PR DESCRIPTION
## Summary
- Replace `instanceof Keyframes` with a branded `Symbol.for('sc-keyframes')` check in `flatten.ts`
- Convert value imports of `Keyframes` and `StyleSheet` to `import type` in `flatten.ts`, preventing rollup from bundling the DOM sheet stack into the native build
- Native bundle drops from ~44KB to ~14KB with zero `document`/`window` references

## Test plan
- [x] All 501 web tests pass
- [x] All 37 native tests pass
- [x] Build passes with bundlewatch check
- [x] Native bundle verified to contain zero `document` references
- [ ] Manual test on RN 0.79+/0.81 project

Closes #5610