### PR TITLE
perf: fix createGlobalStyle test performance regression

### DIFF
--- a/.changeset/fix-global-style-test-perf.md
+++ b/.changeset/fix-global-style-test-perf.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Fix test performance regression in 6.3.x by eliminating double style rendering in `createGlobalStyle` and removing unnecessary DOM queries during cleanup in client/test environments.

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -4,7 +4,6 @@ import GlobalStyle from '../models/GlobalStyle';
 import { useStyleSheetContext } from '../models/StyleSheetManager';
 import { DefaultTheme, ThemeContext } from '../models/ThemeProvider';
 import StyleSheet from '../sheet';
-import { removeGlobalStyleTag } from '../sheet/dom';
 import { getGroupForId } from '../sheet/GroupIDAllocator';
 import { ExecutionContext, ExecutionProps, Interpolation, Stringifier, Styles } from '../types';
 import { checkDynamicCreation } from '../utils/checkDynamicCreation';
@@ -59,27 +58,25 @@ export default function createGlobalStyle<Props extends object>(
       );
     }
 
-    // Render styles during component execution
-    const shouldRenderStyles = typeof window === 'undefined' || !ssc.styleSheet.server;
-    if (shouldRenderStyles) {
-      renderStyles(instance, props, ssc.styleSheet, theme, ssc.stylis);
+    // Render styles during component execution for server/RSC (where effects don't run).
+    // In client mode, styles are rendered in the useLayoutEffect below to avoid double work.
+    if (__SERVER__ || IS_RSC) {
+      const shouldRenderStyles = typeof window === 'undefined' || !ssc.styleSheet.server;
+      if (shouldRenderStyles) {
+        renderStyles(instance, props, ssc.styleSheet, theme, ssc.stylis);
+      }
     }
 
     // Client-side lifecycle: render styles in effect and clean up on unmount.
     // __SERVER__ and IS_RSC are build/module-level constants, so this doesn't violate rules of hooks.
     if (!__SERVER__ && !IS_RSC) {
       React.useLayoutEffect(() => {
-        // Re-render styles on every effect run to self-heal after any cleanup
-        // (e.g. StrictMode's simulated unmount/remount, error recovery).
-        // useLayoutEffect runs synchronously before paint, so the brief
-        // remove→re-add in cleanup→mount is never visible to the user.
         if (!ssc.styleSheet.server) {
           renderStyles(instance, props, ssc.styleSheet, theme, ssc.stylis);
         }
 
         return () => {
           globalStyle.removeStyles(instance, ssc.styleSheet);
-          removeGlobalStyleTag(styledComponentId, ssc.styleSheet.options.target);
         };
       }, [instance, props, ssc.styleSheet, theme, ssc.stylis]);
     }


### PR DESCRIPTION
## Summary
- Move synchronous `renderStyles` to only execute on server/RSC paths — in client mode the `useLayoutEffect` already handles this, eliminating double work on every render
- Remove `removeGlobalStyleTag` from client cleanup — it was doing `querySelectorAll` for `data-styled-global` tags on every unmount, which only exist after SSR hydration and are a no-op DOM query in test environments
- Bundle size decreased slightly (12.08KB vs 12.14KB gzip) due to dead code elimination

## Test plan
- [x] All 501 web tests pass
- [x] Build passes with bundlewatch
- [x] Test suite runs ~20% faster (1.6s vs 2.0s)
- [ ] Manual verification with a large test suite using `createGlobalStyle`

Fixes #5674