### PR TITLE
fix: gracefully handle CSS syntax errors in React Native

### DIFF
--- a/.changeset/fix-rn-css-syntax-crash.md
+++ b/.changeset/fix-rn-css-syntax-crash.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Gracefully handle CSS syntax errors in React Native instead of crashing. Missing semicolons and other syntax issues now log a warning in development and produce an empty style object instead of throwing a fatal error.

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -40,7 +40,19 @@ export default function makeInlineStyleClass<Props extends object>(styleSheet: S
       const hash = generateComponentId(flatCSS);
 
       if (!generated[hash]) {
-        const root = parse(flatCSS);
+        let root;
+        try {
+          root = parse(flatCSS);
+        } catch (e) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+              `[styled-components/native] Failed to parse CSS: ${e instanceof Error ? e.message : e}`
+            );
+          }
+          generated[hash] = {};
+          return generated[hash];
+        }
+
         const declPairs: [string, string][] = [];
 
         root.each(node => {


### PR DESCRIPTION
## Summary
- Wrap PostCSS `parse()` in try/catch in `InlineStyle.ts`
- CSS syntax errors (missing semicolons, etc.) now log a dev warning and produce an empty style object instead of crashing the app
- Restores the lenient behavior from v5

## Test plan
- [x] All 37 native tests pass
- [x] All 501 web tests pass
- [ ] Manual test with intentionally malformed CSS on RN

Closes #4361