### PR TITLE
fix: add named styled export to standalone build

### DIFF
--- a/packages/styled-components/src/index-standalone.ts
+++ b/packages/styled-components/src/index-standalone.ts
@@ -12,3 +12,4 @@ for (const key in secondary) {
 }
 
 export default styled;
+export { styled };


### PR DESCRIPTION
## Summary
- Add `export { styled }` to `index-standalone.ts` alongside the existing `export default styled`
- Matches the main entry point's export pattern

One-line fix.

Closes #5558