### PR TITLE
fix: export Keyframes type from public API

### DIFF
--- a/packages/styled-components/src/base.ts
+++ b/packages/styled-components/src/base.ts
@@ -54,7 +54,7 @@ if (
 
 /* Export everything */
 export * from './secretInternals';
-export { Attrs, DefaultTheme, ShouldForwardProp } from './types';
+export { Attrs, DefaultTheme, Keyframes, ShouldForwardProp } from './types';
 export {
   IStyleSheetContext,
   IStyleSheetManager,


### PR DESCRIPTION
## Summary
- Re-export the `Keyframes` interface from `base.ts` so users can import it from `styled-components`

One-line fix.

Closes #4335