### PR TITLE
fix: preserve explicitly passed undefined props

### DIFF
--- a/.changeset/fix-undefined-props.md
+++ b/.changeset/fix-undefined-props.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Preserve explicitly passed `undefined` props instead of stripping them. This fixes compatibility with libraries like MUI and Radix UI that pass `undefined` to reset inherited defaults (e.g., `role={undefined}`). Props set to `undefined` via `.attrs()` are still stripped as before.

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -94,7 +94,9 @@ function resolveContext<Props extends BaseObject>(
         context.className = joinStrings(context.className, resolvedAttrDef[key] as string);
       } else if (key === 'style') {
         context.style = { ...context.style, ...(resolvedAttrDef[key] as React.CSSProperties) };
-      } else {
+      } else if (!(key in props && (props as any)[key] === undefined)) {
+        // Apply attr value unless the user explicitly passed undefined for this prop,
+        // which signals intent to reset the value.
         // @ts-expect-error attrs can dynamically add arbitrary properties
         context[key] = resolvedAttrDef[key];
       }

--- a/packages/styled-components/src/test/attrs.test.tsx
+++ b/packages/styled-components/src/test/attrs.test.tsx
@@ -353,4 +353,27 @@ describe('attrs', () => {
 
     expect(render(<Comp alternateTheme={{ foo: 'bar' }} />).asFragment()).toMatchSnapshot();
   });
+
+  it('should preserve explicitly passed undefined props', () => {
+    const Inner = (props: { role?: string; children?: React.ReactNode }) => (
+      <div role={props.role} data-has-role={String('role' in props)} />
+    );
+
+    const Comp = styled(Inner).attrs({ role: 'button' })``;
+
+    // Without explicit prop, attrs value is used
+    const withAttrs = render(<Comp />);
+    expect(withAttrs.container.querySelector('div')!.getAttribute('role')).toBe('button');
+
+    // Explicitly passing undefined should override attrs
+    const withUndefined = render(<Comp role={undefined} />);
+    expect(withUndefined.container.querySelector('div')!.getAttribute('role')).toBe(null);
+  });
+
+  it('should still strip undefined values from attrs', () => {
+    const Comp = styled.div.attrs({ 'data-removed': undefined as string | undefined })``;
+
+    const { container } = render(<Comp />);
+    expect(container.querySelector('div')!.hasAttribute('data-removed')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Only strip `undefined` values that came from `.attrs()` (to enable removing props via attrs)
- Explicitly passed `undefined` props are now preserved, fixing compatibility with libraries like MUI and Radix UI that pass `undefined` to reset inherited defaults (e.g., `role={undefined}`)

## Test plan
- [x] All 501 web tests pass (including existing attrs removal tests)
- [ ] Manual test with MUI ButtonBase `role={undefined}` pattern

Closes #4338