### PR TITLE
build: suppress mixed exports warning in standalone bundle

### DIFF
--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -136,6 +136,7 @@ const standaloneBaseConfig = {
     globals,
     name: 'styled',
     sourcemap: true,
+    exports: 'named',
   },
   external: Object.keys(globals),
   plugins: configBase.plugins.concat(


### PR DESCRIPTION
## Summary
- Explicitly set `exports: 'named'` on the standalone UMD output config to suppress the Rollup warning about mixing named and default exports

## Test plan
- [x] `pnpm build` passes with no warnings
- [x] Bundle size check passes (12.15KB < 12.35KB gzip)