### PR TITLE
fix: prevent attrs callback from receiving mutable context object

### DIFF
--- a/.changeset/fix-attrs-mutation.md
+++ b/.changeset/fix-attrs-mutation.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Fix `.attrs()` callback receiving a mutable props object that could be changed by subsequent attrs processing. The callback now receives an immutable snapshot.

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -87,7 +87,9 @@ function resolveContext<Props extends BaseObject>(
 
   for (let i = 0; i < attrs.length; i += 1) {
     attrDef = attrs[i];
-    const resolvedAttrDef = isFunction(attrDef) ? attrDef(context) : attrDef;
+    // Pass a shallow copy to function attrs so the callback's captured
+    // reference isn't mutated by subsequent attrs processing (#3336).
+    const resolvedAttrDef = isFunction(attrDef) ? attrDef({ ...context }) : attrDef;
 
     for (const key in resolvedAttrDef) {
       if (key === 'className') {

--- a/packages/styled-components/src/test/attrs.test.tsx
+++ b/packages/styled-components/src/test/attrs.test.tsx
@@ -376,4 +376,34 @@ describe('attrs', () => {
     const { container } = render(<Comp />);
     expect(container.querySelector('div')!.hasAttribute('data-removed')).toBe(false);
   });
+
+  it('should not mutate the props object passed to attrs callbacks', () => {
+    const Comp = styled.div
+      .attrs(props => {
+        // Attempt to mutate the received props — this should not affect
+        // the internal context or the rendered output.
+        (props as any).id = 'mutated';
+        (props as any).injected = 'bad';
+        return { 'data-first': 'yes' };
+      })
+      .attrs(props => {
+        // The second callback should see the original id, not the mutation
+        // from the first callback, plus the first callback's returned attrs.
+        return { 'data-saw-id': props.id, 'data-saw-first': (props as any)['data-first'] };
+      })``;
+
+    const { container } = render(<Comp id="original" />);
+    const el = container.firstChild as HTMLElement;
+
+    // The mutation in the first callback should not leak anywhere
+    expect(el.getAttribute('id')).toBe('original');
+    expect(el.hasAttribute('injected')).toBe(false);
+
+    // The second callback should see the original id (not 'mutated')
+    expect(el.getAttribute('data-saw-id')).toBe('original');
+
+    // The second callback should see the first callback's returned attrs
+    // (these are applied to context after the first callback returns)
+    expect(el.getAttribute('data-saw-first')).toBe('yes');
+  });
 });


### PR DESCRIPTION
## Summary
Pass a shallow copy of the context to function `.attrs()` callbacks so the captured reference isn't mutated by subsequent attrs processing. The context object is still mutated internally for chaining—only the snapshot passed to callbacks is frozen at the point of invocation.

## Before
```tsx
let captured: any;
const Comp = styled.div
  .attrs(props => { captured = props; return { 'data-first': 'yes' }; })
  .attrs(() => ({ 'data-second': 'yes' }))``;

render(<Comp id="test" />);
captured['data-first']  // 'yes' — mutated after callback returned!
captured['data-second'] // 'yes' — mutated by second attrs!
```

## After
```tsx
captured['data-first']  // undefined — snapshot was taken before mutation
captured['data-second'] // undefined
```

Performance note: `{ ...context }` spread is 4x faster than `Object.assign` (validated in AGENTS.md). One extra allocation per attrs level per render is negligible for the typical 1-2 attrs chain.

## Test plan
- [x] 504 tests pass (503 existing + 1 new)
- [x] Red/green verified (test fails without fix, passes with)

Closes #3336