### PR TITLE
docs: modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,79 +10,44 @@
   <strong>Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅</strong>
   <br />
   <br />
-  <a href="https://www.npmjs.com/package/styled-components"><img src="https://www.styled-components.com/proxy/downloads.svg" alt="downloads: 600k/month"></a>
-  <a href="#backers" alt="sponsors on Open Collective"><img src="https://opencollective.com/styled-components/backers/badge.svg" /></a> <a href="#sponsors" alt="Sponsors on Open Collective"><img src="https://opencollective.com/styled-components/sponsors/badge.svg" /></a> 
+  <a href="https://www.npmjs.com/package/styled-components"><img src="https://img.shields.io/npm/dm/styled-components.svg" alt="npm downloads"></a>
   <a href="https://bundlephobia.com/result?p=styled-components" title="styled-components latest minified+gzip size"><img src="https://badgen.net/bundlephobia/minzip/styled-components" alt="gzip size"></a>
-  <a href="#alternative-installation-methods"><img src="https://img.shields.io/badge/module%20formats-umd%2C%20cjs%2C%20esm-green.svg" alt="module formats: umd, cjs, esm"></a>
-  <a href="https://codecov.io/gh/styled-components/styled-components"><img src="https://codecov.io/gh/styled-components/styled-components/coverage.svg?branch=main" alt="Code Coverage"></a>
 </div>
 
 ---
 
-**Upgrading from v5?** See the [migration guide](https://styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v6).
+`styled-components` lets you write actual CSS in your JavaScript using tagged template literals. It removes the mapping between components and styles, making components the styling primitive.
 
-Utilizing [tagged template literals](https://www.styled-components.com/docs/advanced#tagged-template-literals) (a recent addition to JavaScript) and the [power of CSS](https://www.styled-components.com/docs/api#supported-css), `styled-components` allow you to write actual CSS code to style your components. It also removes the mapping between components and styles – using components as a low-level styling construct could not be easier!
+- Built-in TypeScript types (no `@types` package needed)
+- React Server Components (RSC) support via automatic runtime detection
+- React Native support
+- Compatible with React 16.8+, including React 19
 
-```jsx
-const Button = styled.button`
-  color: grey;
-`;
+## Installation
+
+```sh
+npm install styled-components
 ```
 
-Alternatively, you may use [style objects](https://www.styled-components.com/docs/advanced#style-objects). This allows for easy porting of CSS from inline styles, while still supporting the more advanced styled-components capabilities like component selectors and media queries.
-
-```jsx
-const Button = styled.button({
-  color: 'grey',
-});
+```sh
+pnpm add styled-components
 ```
 
-Equivalent to:
-
-```jsx
-const Button = styled.button`
-  color: grey;
-`;
+```sh
+yarn add styled-components
 ```
-
-`styled-components` is compatible with both React (for web) and React Native – meaning it's the perfect choice even for truly universal apps! It also supports React Server Components (RSC) through automatic runtime detection. See the [documentation about React Native](https://www.styled-components.com/docs/basics#react-native) for more information.
-
-_Supported by [Front End Center](https://frontend.center). Thank you for making this possible!_
-
----
-
-## [Docs](https://www.styled-components.com/docs)
-
-**See the documentation at [styled-components.com/docs](https://www.styled-components.com/docs)** for more information about using `styled-components`!
-
-Quicklinks to some of the most-visited pages:
-
-- [**Getting started**](https://www.styled-components.com/docs/basics)
-- [API Reference](https://styled-components.com/docs/api)
-- [Theming](https://www.styled-components.com/docs/advanced#theming)
-- [Server-side rendering](https://www.styled-components.com/docs/advanced#server-side-rendering)
-- [React Server Components](https://www.styled-components.com/docs/advanced#react-server-components) (RSC support)
-- [Tagged Template Literals explained](https://www.styled-components.com/docs/advanced#tagged-template-literals)
-
----
 
 ## Example
 
 ```jsx
-import React from 'react';
-
 import styled from 'styled-components';
 
-// Create a <Title> react component that renders an <h1> which is
-// centered, palevioletred and sized at 1.5em
 const Title = styled.h1`
   font-size: 1.5em;
   text-align: center;
   color: palevioletred;
 `;
 
-// Create a <Wrapper> react component that renders a <section> with
-// some padding and a papayawhip background
 const Wrapper = styled.section`
   padding: 4em;
   background: papayawhip;
@@ -90,7 +55,6 @@ const Wrapper = styled.section`
 
 function MyUI() {
   return (
-    // Use them like any other React component – except they're styled!
     <Wrapper>
       <Title>Hello World, this is my first styled component!</Title>
     </Wrapper>
@@ -98,54 +62,36 @@ function MyUI() {
 }
 ```
 
-This is what you'll see in your browser:
+Style objects are also supported:
 
-<div align="center">
-  <a href="https://styled-components.com">
-    <img alt="Screenshot of the above code ran in a browser" src="http://i.imgur.com/wUJpcjY.jpg" />
-  </a>
-</div>
+```jsx
+const Button = styled.button({
+  color: 'grey',
+});
+```
 
----
+## [Docs](https://www.styled-components.com/docs)
 
-## Looking for v5?
+See the documentation at [styled-components.com/docs](https://www.styled-components.com/docs) for full usage information.
 
-The `main` branch is for the most-current version of styled-components, currently v6. For changes targeting v5, please point your PRs at the `legacy-v5` branch.
-
----
-
-## Built with `styled-components`
-
-A lot of hard work goes into community libraries, projects, and guides. A lot of them make it easier to get started or help you with your next project! There are also a whole lot of interesting apps and sites that people have built using styled-components.
-
-Make sure to head over to [awesome-styled-components](https://github.com/styled-components/awesome-styled-components) to see them all! And please contribute and add your own work to the list so others can find it.
-
----
+- [Getting started](https://www.styled-components.com/docs/basics)
+- [API Reference](https://styled-components.com/docs/api)
+- [Theming](https://www.styled-components.com/docs/advanced#theming)
+- [Server-side rendering](https://www.styled-components.com/docs/advanced#server-side-rendering)
+- [React Server Components](https://www.styled-components.com/docs/advanced#react-server-components)
+- [React Native](https://www.styled-components.com/docs/basics#react-native)
 
 ## Contributing
 
-If you want to contribute to `styled-components` please see our [contributing and community guidelines](./CONTRIBUTING.md), they'll help you get set up locally and explain the whole process.
+See our [contributing and community guidelines](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md).
 
-Please also note that all repositories under the `styled-components` organization follow our [Code of Conduct](./CODE_OF_CONDUCT.md), make sure to review and follow it.
-
----
-
-## Badge
-
-Let everyone know you're using _styled-components_ → [![style: styled-components](https://img.shields.io/badge/style-%F0%9F%92%85%20styled--components-orange.svg?colorB=daa357&colorA=db748e)](https://github.com/styled-components/styled-components)
-
-```md
-[![style: styled-components](https://img.shields.io/badge/style-%F0%9F%92%85%20styled--components-orange.svg?colorB=daa357&colorA=db748e)](https://github.com/styled-components/styled-components)
-```
-
----
+Check out [awesome-styled-components](https://github.com/styled-components/awesome-styled-components) for community libraries, projects, and examples.
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/styled-components/styled-components/graphs/contributors"><img src="https://opencollective.com/styled-components/contributors.svg?width=890" /></a>
+This project exists thanks to all the people who contribute.
 
----
+<a href="https://github.com/styled-components/styled-components/graphs/contributors"><img src="https://opencollective.com/styled-components/contributors.svg?width=890" /></a>
 
 ## Backers
 
@@ -153,32 +99,17 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 <a href="https://opencollective.com/styled-components#backers" target="_blank"><img src="https://opencollective.com/styled-components/backers.svg?width=890"></a>
 
----
-
 ## Sponsors
 
-Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/styled-components#sponsor)]
+Support this project by becoming a sponsor. [[Become a sponsor](https://opencollective.com/styled-components#sponsor)]
 
-<a href="https://opencollective.com/styled-components/sponsor/0/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/0/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/1/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/1/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/2/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/2/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/3/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/3/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/4/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/4/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/5/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/5/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/6/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/6/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/7/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/7/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/8/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/8/avatar.svg"></a>
-<a href="https://opencollective.com/styled-components/sponsor/9/website" target="_blank"><img src="https://opencollective.com/styled-components/sponsor/9/avatar.svg"></a>
-
----
+<a href="https://opencollective.com/styled-components#sponsors" target="_blank"><img src="https://opencollective.com/styled-components/sponsors.svg?width=890"></a>
 
 ## License
 
-Licensed under the MIT License, Copyright © 2016-present Glen Maddern and Maximilian Stoiber.
+Licensed under the MIT License, Copyright © 2016-present styled-components contributors.
 
 See [LICENSE](./LICENSE) for more information.
-
----
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary
- Remove stale content: v5 migration callout, dead proxy download badge, imgur screenshot, "Front End Center" sponsor line, duplicate code example
- Add installation section with npm/pnpm/yarn
- Highlight key features: built-in TypeScript types, RSC support, React Native, React 16.8+/19
- Simplify sponsors section (single auto-updating SVG instead of 10 individual avatar links)
- Update copyright to "styled-components contributors"
- 36 lines added, 103 removed