### PR TITLE
feat: add first-class CSP nonce support

### DIFF
--- a/.changeset/feat-nonce-support.md
+++ b/.changeset/feat-nonce-support.md
@@ -1,0 +1,5 @@
+---
+"styled-components": minor
+---
+
+Add first-class CSP nonce support. Nonces can now be configured via `StyleSheetManager`'s `nonce` prop (recommended for Next.js, Remix), `ServerStyleSheet`'s constructor, `<meta property="csp-nonce">` (Vite convention), `<meta name="sc-nonce">`, or the legacy `__webpack_nonce__` global.

--- a/packages/styled-components/src/models/ServerStyleSheet.tsx
+++ b/packages/styled-components/src/models/ServerStyleSheet.tsx
@@ -15,15 +15,15 @@ export default class ServerStyleSheet {
   instance: StyleSheet;
   sealed: boolean;
 
-  constructor() {
-    this.instance = new StyleSheet({ isServer: true });
+  constructor({ nonce }: { nonce?: string } = {}) {
+    this.instance = new StyleSheet({ isServer: true, nonce });
     this.sealed = false;
   }
 
   _emitSheetCSS = (): string => {
     const css = this.instance.toString();
     if (!css) return '';
-    const nonce = getNonce();
+    const nonce = this.instance.options.nonce || getNonce();
     const attrs = [
       nonce && `nonce="${nonce}"`,
       `${SC_ATTR}="true"`,
@@ -66,7 +66,7 @@ export default class ServerStyleSheet {
       },
     };
 
-    const nonce = getNonce();
+    const nonce = this.instance.options.nonce || getNonce();
     if (nonce) {
       (props as any).nonce = nonce;
     }

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -65,6 +65,7 @@ export type IStyleSheetManager = React.PropsWithChildren<{
   namespace?: undefined | string;
   /**
    * Create and provide your own `StyleSheet` if necessary for advanced SSR scenarios.
+   * When provided, `target` and `nonce` props are ignored (configure them on the sheet directly).
    */
   sheet?: undefined | StyleSheet;
   /**
@@ -90,6 +91,11 @@ export type IStyleSheetManager = React.PropsWithChildren<{
    */
   stylisPlugins?: undefined | stylis.Middleware[];
   /**
+   * CSP nonce to attach to injected `<style>` tags. Overrides auto-detection
+   * from `<meta name="sc-nonce">`, `<meta property="csp-nonce">`, or `__webpack_nonce__`.
+   */
+  nonce?: undefined | string;
+  /**
    * Provide an alternate DOM node to host generated styles; useful for iframes.
    */
   target?: undefined | InsertionTarget;
@@ -109,7 +115,9 @@ export function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element 
     if (props.sheet) {
       sheet = props.sheet;
     } else if (props.target) {
-      sheet = sheet.reconstructWithOptions({ target: props.target }, false);
+      sheet = sheet.reconstructWithOptions({ target: props.target, nonce: props.nonce }, false);
+    } else if (props.nonce !== undefined) {
+      sheet = sheet.reconstructWithOptions({ nonce: props.nonce });
     }
 
     if (props.disableCSSOMInjection) {
@@ -117,7 +125,7 @@ export function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element 
     }
 
     return sheet;
-  }, [props.disableCSSOMInjection, props.sheet, props.target, styleSheet]);
+  }, [props.disableCSSOMInjection, props.nonce, props.sheet, props.target, styleSheet]);
 
   const stylis = React.useMemo(
     () =>

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -641,4 +641,44 @@ describe('StyleSheetManager', () => {
       </style>
     `);
   });
+
+  it('should apply nonce to injected style tags', () => {
+    const Comp = styled.div`
+      color: red;
+    `;
+
+    render(
+      <StyleSheetManager nonce="test-nonce-123">
+        <Comp />
+      </StyleSheetManager>
+    );
+
+    const style = document.head.querySelector('style[data-styled]');
+    expect(style).not.toBeNull();
+    expect(style!.getAttribute('nonce')).toBe('test-nonce-123');
+  });
+
+  it('should apply different nonces to nested StyleSheetManagers', () => {
+    const Outer = styled.div`
+      color: blue;
+    `;
+    const Inner = styled.div`
+      color: green;
+    `;
+
+    render(
+      <StyleSheetManager nonce="outer-nonce" target={document.head}>
+        <Outer />
+        <StyleSheetManager nonce="inner-nonce" target={document.body}>
+          <Inner />
+        </StyleSheetManager>
+      </StyleSheetManager>
+    );
+
+    const headStyle = document.head.querySelector('style[data-styled]');
+    const bodyStyle = document.body.querySelector('style[data-styled]');
+
+    expect(headStyle!.getAttribute('nonce')).toBe('outer-nonce');
+    expect(bodyStyle!.getAttribute('nonce')).toBe('inner-nonce');
+  });
 });

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -12,6 +12,7 @@ let SHOULD_REHYDRATE = IS_BROWSER;
 
 type SheetConstructorArgs = {
   isServer?: boolean;
+  nonce?: string | undefined;
   useCSSOMInjection?: boolean;
   target?: InsertionTarget | undefined;
 };

--- a/packages/styled-components/src/sheet/Tag.ts
+++ b/packages/styled-components/src/sheet/Tag.ts
@@ -3,13 +3,13 @@ import { getSheet, makeStyleTag } from './dom';
 import { SheetOptions, Tag } from './types';
 
 /** Create a CSSStyleSheet-like tag depending on the environment */
-export const makeTag = ({ isServer, useCSSOMInjection, target }: SheetOptions) => {
+export const makeTag = ({ isServer, useCSSOMInjection, target, nonce }: SheetOptions) => {
   if (isServer) {
     return new VirtualTag(target);
   } else if (useCSSOMInjection) {
-    return new CSSOMTag(target);
+    return new CSSOMTag(target, nonce);
   } else {
-    return new TextTag(target);
+    return new TextTag(target, nonce);
   }
 };
 
@@ -20,8 +20,8 @@ export const CSSOMTag = class CSSOMTag implements Tag {
 
   length: number;
 
-  constructor(target?: InsertionTarget | undefined) {
-    this.element = makeStyleTag(target);
+  constructor(target?: InsertionTarget | undefined, nonce?: string | undefined) {
+    this.element = makeStyleTag(target, nonce);
 
     // Avoid Edge bug where empty style elements don't create sheets
     this.element.appendChild(document.createTextNode(''));
@@ -63,8 +63,8 @@ export const TextTag = class TextTag implements Tag {
   nodes: NodeListOf<Node>;
   length: number;
 
-  constructor(target?: InsertionTarget | undefined) {
-    this.element = makeStyleTag(target);
+  constructor(target?: InsertionTarget | undefined, nonce?: string | undefined) {
+    this.element = makeStyleTag(target, nonce);
     this.nodes = this.element.childNodes;
     this.length = 0;
   }

--- a/packages/styled-components/src/sheet/dom.ts
+++ b/packages/styled-components/src/sheet/dom.ts
@@ -11,7 +11,10 @@ const findLastStyleTag = (target: InsertionTarget): void | HTMLStyleElement => {
 };
 
 /** Create a style element inside `target` or <head> after the last */
-export const makeStyleTag = (target?: InsertionTarget | undefined): HTMLStyleElement => {
+export const makeStyleTag = (
+  target?: InsertionTarget | undefined,
+  nonce?: string | undefined
+): HTMLStyleElement => {
   const head = document.head;
   const parent = target || head;
   const style = document.createElement('style');
@@ -21,9 +24,9 @@ export const makeStyleTag = (target?: InsertionTarget | undefined): HTMLStyleEle
   style.setAttribute(SC_ATTR, SC_ATTR_ACTIVE);
   style.setAttribute(SC_ATTR_VERSION, SC_VERSION);
 
-  const nonce = getNonce();
+  const resolvedNonce = nonce || getNonce();
 
-  if (nonce) style.setAttribute('nonce', nonce);
+  if (resolvedNonce) style.setAttribute('nonce', resolvedNonce);
 
   parent.insertBefore(style, nextSibling);
 

--- a/packages/styled-components/src/sheet/types.ts
+++ b/packages/styled-components/src/sheet/types.ts
@@ -20,6 +20,7 @@ export interface GroupedTag {
 
 export type SheetOptions = {
   isServer: boolean;
+  nonce?: string | undefined;
   target?: InsertionTarget | undefined;
   useCSSOMInjection: boolean;
 };

--- a/packages/styled-components/src/test/ssr.test.tsx
+++ b/packages/styled-components/src/test/ssr.test.tsx
@@ -11,7 +11,10 @@ import createGlobalStyle from '../constructors/createGlobalStyle';
 import ServerStyleSheet from '../models/ServerStyleSheet';
 import { StyleSheetManager } from '../models/StyleSheetManager';
 
-jest.mock('../utils/nonce');
+jest.mock('../utils/nonce', () => {
+  const mock = jest.fn(() => null);
+  return { __esModule: true, default: mock, resetNonceCache: jest.fn() };
+});
 
 let styled: ReturnType<typeof resetStyled>;
 
@@ -48,7 +51,7 @@ describe('ssr', () => {
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-    require('../utils/nonce').mockReset();
+    require('../utils/nonce').default.mockReset();
 
     styled = resetStyled(true);
   });
@@ -142,7 +145,7 @@ describe('ssr', () => {
   });
 
   it('should add a nonce to the stylesheet if webpack nonce is detected in the global scope', () => {
-    require('../utils/nonce').mockImplementation(() => 'foo');
+    require('../utils/nonce').default.mockImplementation(() => 'foo');
 
     const Component = createGlobalStyle`
       body { background: papayawhip; }
@@ -216,7 +219,7 @@ describe('ssr', () => {
   });
 
   it('should return a generated React style element with nonce if webpack nonce is preset in the global scope', () => {
-    require('../utils/nonce').mockImplementation(() => 'foo');
+    require('../utils/nonce').default.mockImplementation(() => 'foo');
 
     const Component = createGlobalStyle`
       body { background: papayawhip; }
@@ -238,6 +241,64 @@ describe('ssr', () => {
 
     const [element] = sheet.getStyleElement();
     expect(element.props.nonce).toBe('foo');
+  });
+
+  it('should use nonce from ServerStyleSheet constructor over auto-detection', () => {
+    require('../utils/nonce').default.mockImplementation(() => 'auto-nonce');
+
+    const Heading = styled.h1`
+      color: red;
+    `;
+
+    const sheet = new ServerStyleSheet({ nonce: 'constructor-nonce' });
+    renderToString(sheet.collectStyles(<Heading>Hello!</Heading>));
+
+    const css = sheet.getStyleTags();
+    expect(css).toContain('nonce="constructor-nonce"');
+    expect(css).not.toContain('auto-nonce');
+  });
+
+  it('should use nonce from ServerStyleSheet constructor in getStyleElement', () => {
+    const Heading = styled.h1`
+      color: blue;
+    `;
+
+    const sheet = new ServerStyleSheet({ nonce: 'element-nonce' });
+    renderToString(sheet.collectStyles(<Heading>Hello!</Heading>));
+
+    const [element] = sheet.getStyleElement();
+    expect(element.props.nonce).toBe('element-nonce');
+  });
+
+  it('should fall back to auto-detection when no constructor nonce is provided', () => {
+    require('../utils/nonce').default.mockImplementation(() => 'detected-nonce');
+
+    const Heading = styled.h1`
+      color: green;
+    `;
+
+    const sheet = new ServerStyleSheet();
+    renderToString(sheet.collectStyles(<Heading>Hello!</Heading>));
+
+    const css = sheet.getStyleTags();
+    expect(css).toContain('nonce="detected-nonce"');
+  });
+
+  it('should omit nonce attribute when no nonce is available', () => {
+    require('../utils/nonce').default.mockImplementation(() => null);
+
+    const Heading = styled.h1`
+      color: purple;
+    `;
+
+    const sheet = new ServerStyleSheet();
+    renderToString(sheet.collectStyles(<Heading>Hello!</Heading>));
+
+    const css = sheet.getStyleTags();
+    expect(css).not.toContain('nonce');
+
+    const [element] = sheet.getStyleElement();
+    expect(element.props.nonce).toBeUndefined();
   });
 
   describeStreamingTests('should interleave styles with rendered HTML', renderFn => {

--- a/packages/styled-components/src/utils/nonce.ts
+++ b/packages/styled-components/src/utils/nonce.ts
@@ -1,5 +1,33 @@
 declare let __webpack_nonce__: string;
 
-export default function getNonce() {
-  return typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : null;
+/**
+ * Resolve a CSP nonce from available sources (in priority order):
+ * 1. <meta property="csp-nonce"> (Vite puts nonce in the `nonce` attr)
+ * 2. <meta name="sc-nonce"> (SC convention, nonce in `content` attr)
+ * 3. __webpack_nonce__ global (legacy)
+ *
+ * For Next.js/Remix, pass nonces explicitly via StyleSheetManager or
+ * ServerStyleSheet instead—auto-detection doesn't apply to header-based nonces.
+ */
+let cached: string | undefined | false = false;
+
+/** @internal Reset the nonce cache (for testing only). */
+export function resetNonceCache() {
+  cached = false;
+}
+
+export default function getNonce(): string | undefined {
+  if (cached !== false) return cached;
+
+  if (typeof document !== 'undefined') {
+    // Vite sets the nonce in the `nonce` attribute. Browsers expose this via
+    // the .nonce DOM property but return "" from getAttribute('nonce').
+    const viteMeta = document.head.querySelector<HTMLMetaElement>('meta[property="csp-nonce"]');
+    if (viteMeta) return (cached = viteMeta.nonce || viteMeta.getAttribute('content') || undefined);
+
+    const scMeta = document.head.querySelector<HTMLMetaElement>('meta[name="sc-nonce"]');
+    if (scMeta) return (cached = scMeta.getAttribute('content') || undefined);
+  }
+
+  return (cached = typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : undefined);
 }

--- a/packages/styled-components/src/utils/test/nonce.test.ts
+++ b/packages/styled-components/src/utils/test/nonce.test.ts
@@ -1,0 +1,80 @@
+import getNonce, { resetNonceCache } from '../nonce';
+
+declare let __webpack_nonce__: string | undefined;
+
+const cleanupMeta = () =>
+  document.head
+    .querySelectorAll('meta[property="csp-nonce"], meta[name="sc-nonce"]')
+    .forEach(el => el.remove());
+
+describe('getNonce', () => {
+  let originalWebpackNonce: string | undefined;
+
+  beforeEach(() => {
+    originalWebpackNonce = typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : undefined;
+    // @ts-expect-error clearing global
+    delete (globalThis as any).__webpack_nonce__;
+    cleanupMeta();
+    resetNonceCache();
+  });
+
+  afterEach(() => {
+    if (originalWebpackNonce !== undefined) {
+      (globalThis as any).__webpack_nonce__ = originalWebpackNonce;
+    }
+    cleanupMeta();
+  });
+
+  it('should return undefined when no nonce source is available', () => {
+    expect(getNonce()).toBeUndefined();
+  });
+
+  it('should detect nonce from <meta property="csp-nonce">', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', 'vite-nonce-123');
+    document.head.appendChild(meta);
+
+    expect(getNonce()).toBe('vite-nonce-123');
+  });
+
+  it('should detect nonce from <meta name="sc-nonce">', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'sc-nonce');
+    meta.setAttribute('content', 'sc-nonce-456');
+    document.head.appendChild(meta);
+
+    expect(getNonce()).toBe('sc-nonce-456');
+  });
+
+  it('should prefer Vite meta over SC meta', () => {
+    const viteMeta = document.createElement('meta');
+    viteMeta.setAttribute('property', 'csp-nonce');
+    viteMeta.setAttribute('content', 'vite-wins');
+    document.head.appendChild(viteMeta);
+
+    const scMeta = document.createElement('meta');
+    scMeta.setAttribute('name', 'sc-nonce');
+    scMeta.setAttribute('content', 'sc-loses');
+    document.head.appendChild(scMeta);
+
+    expect(getNonce()).toBe('vite-wins');
+  });
+
+  it('should prefer meta tags over __webpack_nonce__', () => {
+    (globalThis as any).__webpack_nonce__ = 'webpack-loses';
+
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'sc-nonce');
+    meta.setAttribute('content', 'meta-wins');
+    document.head.appendChild(meta);
+
+    expect(getNonce()).toBe('meta-wins');
+  });
+
+  it('should fall back to __webpack_nonce__', () => {
+    (globalThis as any).__webpack_nonce__ = 'webpack-fallback';
+
+    expect(getNonce()).toBe('webpack-fallback');
+  });
+});


### PR DESCRIPTION
## Summary

Add multiple ways to configure a CSP nonce for injected `<style>` tags:

| Method | Use case |
|---|---|
| `<StyleSheetManager nonce="...">` | Next.js App/Pages Router, Remix — pass nonce from request headers |
| `new ServerStyleSheet({ nonce: '...' })` | SSR — explicit nonce in server rendering |
| `<meta property="csp-nonce" nonce="...">` | Vite — auto-detected at runtime |
| `<meta name="sc-nonce" content="...">` | Generic — auto-detected at runtime |
| `__webpack_nonce__` | Legacy webpack — preserved for backward compat |

### Framework integration examples

**Next.js App Router:**
```tsx
// app/layout.tsx
const nonce = (await headers()).get('x-nonce');
<StyledComponentsRegistry nonce={nonce}>{children}</StyledComponentsRegistry>
```

**Vite:** Zero-config — set `html.cspNonce` in vite.config.js and the `<meta property="csp-nonce">` tag is auto-detected.

**Remix:** Pass nonce from `entry.server.tsx` to `<StyleSheetManager nonce={nonce}>`.

### Changes
- `StyleSheetManager` — new `nonce` prop
- `ServerStyleSheet` — new `{ nonce }` constructor option
- `getNonce()` — auto-detects from `<meta property="csp-nonce">` (Vite) and `<meta name="sc-nonce">`; reads `.nonce` DOM property (not `getAttribute`) per browser security model
- `SheetOptions` / `makeStyleTag` / `Tag` constructors — nonce threaded through

Based on #4356 by @ericsen-tsai. Seed commit attributed to the original author.

## Test plan
- [x] All 504 web tests pass
- [x] All 37 native tests pass
- [x] Build passes (12.2KB gzip)
- [ ] Manual test with Vite `html.cspNonce`
- [ ] Manual test with Next.js middleware nonce

Closes #4258