### PR TITLE
perf: skip effect re-runs for static createGlobalStyle

### DIFF
--- a/.changeset/perf-static-global-style.md
+++ b/.changeset/perf-static-global-style.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Skip unnecessary effect re-runs for static `createGlobalStyle` components. Static global styles now only inject once and clean up on unmount, instead of re-running the effect on every render.

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -70,6 +70,15 @@ export default function createGlobalStyle<Props extends object>(
     // Client-side lifecycle: render styles in effect and clean up on unmount.
     // __SERVER__ and IS_RSC are build/module-level constants, so this doesn't violate rules of hooks.
     if (!__SERVER__ && !IS_RSC) {
+      // For static global styles, renderStyles exits early after the first injection
+      // (via hasNameForId check in GlobalStyle.renderStyles). We still need the effect
+      // for initial injection and unmount cleanup, but we use a narrow deps array
+      // to avoid unnecessary effect re-runs on every render.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const effectDeps = globalStyle.isStatic
+        ? [instance, ssc.styleSheet]
+        : [instance, props, ssc.styleSheet, theme, ssc.stylis];
+
       React.useLayoutEffect(() => {
         if (!ssc.styleSheet.server) {
           renderStyles(instance, props, ssc.styleSheet, theme, ssc.stylis);
@@ -78,7 +87,7 @@ export default function createGlobalStyle<Props extends object>(
         return () => {
           globalStyle.removeStyles(instance, ssc.styleSheet);
         };
-      }, [instance, props, ssc.styleSheet, theme, ssc.stylis]);
+      }, effectDeps);
     }
 
     // RSC mode: output style tag.


### PR DESCRIPTION
## Summary
Static `createGlobalStyle` components (no interpolations) now use a narrow deps array `[instance, styleSheet]` instead of `[instance, props, styleSheet, theme, stylis]`. This prevents the effect from re-running on every render, eliminating the `removeStyles`+`renderStyles` cycle that was causing ~25% test performance degradation.

Dynamic global styles (with interpolations) retain the full deps array.

## Why the previous fix (#5679) wasn't enough
PR #5679 eliminated double `renderStyles` (component body + effect), but the effect still fired on every render because `props` is a new object reference each time. For static global styles, `renderStyles` exits early via `hasNameForId`, but the effect setup/teardown overhead and `removeStyles` cleanup still ran unnecessarily.

## Ref
#5674 — user confirmed 6.4.0-prerelease.0 still showed 27% delta