### PR TITLE
fix: prevent createGlobalStyle style accumulation in jsdom tests

### DIFF
--- a/.changeset/fix-global-style-jsdom-perf.md
+++ b/.changeset/fix-global-style-jsdom-perf.md
@@ -2,4 +2,4 @@
 "styled-components": patch
 ---
 
-Fixed createGlobalStyle performance regression in jsdom test environments where CSS rules accumulated without cleanup on each render/unmount cycle, causing O(n²) slowdown
+Fixed createGlobalStyle performance regression in jsdom test environments where CSS rules accumulated without cleanup on each render/unmount cycle, causing O(n²) slowdown.

--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -63,7 +63,7 @@ export default function createGlobalStyle<Props extends object>(
       );
     }
 
-    // Render styles during component execution for server environments.
+    // Render styles during component execution for RSC or explicit ServerStyleSheet.
     // Gate on IS_RSC or styleSheet.server (runtime flag from ServerStyleSheet),
     // NOT on __SERVER__ alone. The server build sets __SERVER__=true and eliminates
     // useLayoutEffect, so if we rendered here without cleanup, styles would

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
@@ -985,4 +985,27 @@ describe('GlobalStyle.renderStyles (unit)', () => {
     expect(gs.instanceRules.size).toBe(0);
     expect(sheet.toString()).toBe('');
   });
+
+  it('does not accumulate style rules across render/unmount cycles (#5674)', () => {
+    const rules = css`
+      .perf-a {
+        color: red;
+      }
+      .perf-b {
+        color: blue;
+      }
+    `;
+    const gs = new GlobalStyle(rules, 'sc-global-accum-test');
+    const ctx = { theme: {} } as any;
+
+    for (let i = 1; i <= 10; i++) {
+      gs.renderStyles(i, ctx, sheet, mainStylis);
+      gs.removeStyles(i, sheet);
+    }
+
+    // After 10 render/remove cycles, all rules should be cleaned up.
+    // The bug: renderStyles without removeStyles accumulated rules unboundedly.
+    expect(gs.instanceRules.size).toBe(0);
+    expect(sheet.toString()).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary

- Removes `__SERVER__` from the server-side render guard in `createGlobalStyle`, gating only on `IS_RSC || styleSheet.server`
- Fixes O(n²) performance degradation in jsdom test environments where the server build's dead-code elimination removes `useLayoutEffect` cleanup but still renders styles unconditionally

**Root cause:** Jest resolves the `main` CJS entry (server build) where `__SERVER__=true`. This eliminates the `useLayoutEffect` cleanup path but unconditionally triggers style injection during the component body. In jsdom, CSS rules accumulate in the `<style>` element (~301 nodes per cycle) without ever being removed, causing each subsequent render to be progressively slower due to jsdom's O(n) `insertBefore`.

**Why this is safe:** On a real server without `ServerStyleSheet`, styles go into `VirtualTag` (array-backed, never flushed to HTML) and are discarded anyway. The Turbopack SSR case (where `__SERVER__` is false on the server) is already handled by the `styleSheet.server` runtime fallback.

**Benchmark (reporter's repro, 20 render/unmount cycles with 300-rule GlobalStyle):**

| Build | Before | After |
|-------|--------|-------|
| Current (`main`) | 65,000ms (O(n²): 344ms→6,276ms/cycle) | 173ms (flat ~6ms/cycle) |

Fixes #5674