### PR TITLE
test: replace toContain with toMatchInlineSnapshot in RSC/SSR tests

### DIFF
--- a/packages/styled-components/src/constructors/test/createGlobalStyle.ssr.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.ssr.test.tsx
@@ -73,7 +73,11 @@ describe(`createGlobalStyle`, () => {
     // First render with a fixed instance number (simulates WeakMap caching)
     gs.renderStyles(1, executionContext, sheet, mainStylis);
     expect(gs.instanceRules.size).toBe(1);
-    expect(sheet.toString()).toContain('color');
+    expect(sheet.toString()).toMatchInlineSnapshot(`
+      "body{color:red;}/*!sc*/
+      data-styled.g3[id="sc-global-clearTag-test"]{content:"sc-global-clearTag-test1,"}/*!sc*/
+      "
+    `);
 
     // Simulate Next.js registry: collect styles, then clearTag
     sheet.clearTag();
@@ -83,7 +87,11 @@ describe(`createGlobalStyle`, () => {
     // computeRules produces identical rules. rulesEqual returns true.
     // rebuildGroup is skipped. Tag is empty. CSS is lost.
     gs.renderStyles(1, executionContext, sheet, mainStylis);
-    expect(sheet.toString()).toContain('color');
+    expect(sheet.toString()).toMatchInlineSnapshot(`
+      "body{color:red;}/*!sc*/
+      data-styled.g3[id="sc-global-clearTag-test"]{content:"sc-global-clearTag-test1,"}/*!sc*/
+      "
+    `);
   });
 });
 

--- a/packages/styled-components/src/hoc/withTheme.rsc.test.tsx
+++ b/packages/styled-components/src/hoc/withTheme.rsc.test.tsx
@@ -20,7 +20,11 @@ describe('withTheme RSC mode', () => {
 
     const html = ReactDOMServer.renderToString(React.createElement(Themed, { label: 'hello' }));
 
-    expect(html).toContain('hello');
+    expect(html).toMatchInlineSnapshot(`
+      <span>
+        hello
+      </span>
+    `);
   });
 
   it('receives undefined as theme in RSC mode', () => {

--- a/packages/styled-components/src/utils/test/checkDynamicCreation.rsc.test.tsx
+++ b/packages/styled-components/src/utils/test/checkDynamicCreation.rsc.test.tsx
@@ -35,7 +35,13 @@ describe('checkDynamicCreation RSC mode', () => {
 
     const html = ReactDOMServer.renderToString(React.createElement(App));
 
-    expect(html).toContain('color:red');
+    expect(html).toMatchInlineSnapshot(`
+      <style data-styled>
+        .YKVKw{color:red;}/*!sc*/
+      </style>
+      <div class="sc-kqxcKS YKVKw">
+      </div>
+    `);
     // In RSC mode, the dynamic creation check is skipped entirely
     expect(spy).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
- Replace 4 lossy `toContain()` assertions with `toMatchInlineSnapshot()` in RSC/SSR test files
- Covers `withTheme.rsc.test.tsx`, `checkDynamicCreation.rsc.test.tsx`, and `createGlobalStyle.ssr.test.tsx`
- Full-structure snapshots catch regressions that substring matching would miss