### PR TITLE
test: replace toContain with toMatchInlineSnapshot in RSC tests

### DIFF
--- a/packages/styled-components/src/constructors/test/createGlobalStyle.rsc.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.rsc.test.tsx
@@ -65,10 +65,14 @@ describe('createGlobalStyle RSC mode', () => {
       </>
     );
 
-    // Each instance should emit its own <style> tag
-    const styleMatches = html.match(/<style/g);
-    expect(styleMatches).toHaveLength(2);
-    expect(html).toContain('body{margin:0;}');
+    expect(html).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-yXuMc">
+        body{margin:0;}/*!sc*/
+      </style>
+      <style data-styled-global="sc-global-yXuMc">
+        body{margin:0;}/*!sc*/
+      </style>
+    `);
   });
 
   it('renders multiple instances with different dynamic props in one tree', () => {
@@ -83,11 +87,14 @@ describe('createGlobalStyle RSC mode', () => {
       </>
     );
 
-    // Each instance should emit its own <style> tag with its own CSS
-    expect(html).toContain('background:red;');
-    expect(html).toContain('background:blue;');
-    const styleMatches = html.match(/<style/g);
-    expect(styleMatches).toHaveLength(2);
+    expect(html).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-kVtqfD">
+        body{background:red;}/*!sc*/
+      </style>
+      <style data-styled-global="sc-global-kVtqfD">
+        body{background:blue;}/*!sc*/
+      </style>
+    `);
   });
 
   it('emits correct CSS across independent RSC render passes (no hydration)', () => {
@@ -100,16 +107,21 @@ describe('createGlobalStyle RSC mode', () => {
     const html2 = ReactDOMServer.renderToString(<GlobalStyle $size="16px" />);
     const html3 = ReactDOMServer.renderToString(<GlobalStyle $size="18px" />);
 
-    // Each should produce correct, independent output
-    expect(html1).toContain('font-size:14px;');
-    expect(html2).toContain('font-size:16px;');
-    expect(html3).toContain('font-size:18px;');
-
-    // No cross-contamination — each render's output should only contain its own CSS
-    expect(html1).not.toContain('16px');
-    expect(html1).not.toContain('18px');
-    expect(html2).not.toContain('14px');
-    expect(html3).not.toContain('14px');
+    expect(html1).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-fLdnMX">
+        html{font-size:14px;}/*!sc*/
+      </style>
+    `);
+    expect(html2).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-fLdnMX">
+        html{font-size:16px;}/*!sc*/
+      </style>
+    `);
+    expect(html3).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-fLdnMX">
+        html{font-size:18px;}/*!sc*/
+      </style>
+    `);
   });
 
   it('renders themed global style gracefully in RSC (theme is undefined)', () => {
@@ -119,7 +131,11 @@ describe('createGlobalStyle RSC mode', () => {
 
     // No ThemeProvider in RSC — theme is undefined, should not crash
     const html = ReactDOMServer.renderToString(<GlobalStyle />);
-    expect(html).toContain('color:black;');
+    expect(html).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-ekSA-DU">
+        body{color:black;}/*!sc*/
+      </style>
+    `);
   });
 
   it('renders global style and styled component in the same RSC tree', () => {
@@ -139,9 +155,16 @@ describe('createGlobalStyle RSC mode', () => {
       </>
     );
 
-    // Both should emit their styles — global as data-styled-global, component via precedence
-    expect(html).toContain('margin:0;');
-    expect(html).toContain('color:red;');
-    expect(html).toContain('data-styled-global');
+    expect(html).toMatchInlineSnapshot(`
+      <style data-styled-global="sc-global-yXuMc">
+        body{margin:0;}/*!sc*/
+      </style>
+      <style data-styled>
+        .eBSjvc{color:red;}/*!sc*/
+      </style>
+      <h1 class="sc-kqxcKS eBSjvc">
+        Hello
+      </h1>
+    `);
   });
 });

--- a/packages/styled-components/src/models/test/StyleSheetManager.rsc.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.rsc.test.tsx
@@ -44,7 +44,11 @@ describe('StyleSheetManager RSC mode', () => {
       React.createElement(StyleSheetManager, null, React.createElement('div', null, 'hello'))
     );
 
-    expect(html).toContain('hello');
+    expect(html).toMatchInlineSnapshot(`
+      <div>
+        hello
+      </div>
+    `);
   });
 
   it('styled components render correctly inside StyleSheetManager', () => {
@@ -57,7 +61,12 @@ describe('StyleSheetManager RSC mode', () => {
       React.createElement(StyleSheetManager, null, React.createElement(Box))
     );
 
-    expect(html).toContain('display:flex');
-    expect(html).toContain('padding:8px');
+    expect(html).toMatchInlineSnapshot(`
+      <style data-styled>
+        .bRHkvB{display:flex;padding:8px;}/*!sc*/
+      </style>
+      <div class="sc-kqxcKS bRHkvB">
+      </div>
+    `);
   });
 });


### PR DESCRIPTION
## Summary
- Converted 9 lossy `toContain()` assertions to exact `toMatchInlineSnapshot()` in RSC test files
- `createGlobalStyle.rsc.test.tsx`: 7 snapshots replace 10 `toContain`/`not.toContain` + 2 `toHaveLength` assertions
- `StyleSheetManager.rsc.test.tsx`: 2 snapshots replace 3 `toContain` assertions
- Inline snapshots catch full output regressions (extra style tags, attribute changes, cross-contamination) that partial assertions miss