### PR TITLE
fix(native): rn-web vertical-align positioning + broaden iOS warning

### DIFF
--- a/.changeset/native-vertical-align-ios-warning.md
+++ b/.changeset/native-vertical-align-ios-warning.md
@@ -1,7 +1,7 @@
 ---
-"styled-components": patch
+'styled-components': patch
 ---
 
-Development builds now warn when `vertical-align` is set on a native `<Text>` running on iOS.
+Development builds now warn when `vertical-align` is set on a native `<Text>` or `<TextInput>` running on iOS.
 
-React Native 0.85 has no platform API for vertically aligning text inside a fixed-height `<Text>` on iOS, so the declaration silently has no effect there. Android and rn-web continue to render the property as authored. The warning names the situation and points to the workaround: wrap the Text in a View and use `justify-content` for the vertical alignment.
+React Native 0.85 has no platform API for vertically aligning text content inside a fixed-height `<Text>` or `<TextInput>` on iOS, so the declaration silently has no effect there. Android and rn-web continue to render the property as authored. For `<Text>`, the warning points to the workaround: wrap the Text in a View and use `justify-content` for the vertical alignment. `<TextInput>` has no Text-level workaround on iOS today.

--- a/.changeset/native-web-vertical-align-content.md
+++ b/.changeset/native-web-vertical-align-content.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+`vertical-align: top | middle | bottom` on a styled `<Text>` now positions text content within the Text's box on `react-native-web`, matching the visual semantic of React Native's `verticalAlign` on Android (textAlignVertical). Other `vertical-align` values pass through unchanged so the browser's native baseline-shifting semantics still apply.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,10 +144,38 @@ jobs:
               }
             }
 
+            // Per-package previous tag. Snapshot publishes don't consume
+            // `.changeset/*.md`, so without this filter every prerelease
+            // re-emits the full pending pile — including changesets that
+            // were already announced in earlier prereleases.
+            const prevTagByPkg = new Map();
+            for (const pkg of packages) {
+              let prevTag = '';
+              try {
+                prevTag = execSync(`git tag --list '${pkg.name}@*' --sort=-v:refname`, { encoding: 'utf8' })
+                  .split('\n').filter(Boolean)[0] || '';
+              } catch {}
+              prevTagByPkg.set(pkg.name, prevTag);
+            }
+
+            // True when `commit` is reachable from `tag` (i.e. already
+            // shipped in that release). Conservatively returns false on
+            // any error so unknown commits surface in the next release.
+            function isCommitInTag(commit, tag) {
+              if (!commit || !tag) return false;
+              try {
+                execSync(`git merge-base --is-ancestor ${commit} ${tag}`, { stdio: 'ignore' });
+                return true;
+              } catch {
+                return false;
+              }
+            }
+
             const byPkg = new Map();
             for (const cs of changesets) {
               for (const release of cs.releases) {
                 if (release.type === 'none') continue;
+                if (isCommitInTag(cs.commit, prevTagByPkg.get(release.name))) continue;
                 let groups = byPkg.get(release.name);
                 if (!groups) {
                   groups = { major: [], minor: [], patch: [] };
@@ -171,13 +199,9 @@ jobs:
                   parts.push('');
                 }
               }
-              if (parts.length === 0) parts.push('Internal changes only.', '');
+              if (parts.length === 0) parts.push('No new changes since the previous release.', '');
 
-              let prevTag = '';
-              try {
-                prevTag = execSync(`git tag --list '${pkg.name}@*' --sort=-v:refname`, { encoding: 'utf8' })
-                  .split('\n').filter(Boolean)[0] || '';
-              } catch {}
+              const prevTag = prevTagByPkg.get(pkg.name);
               if (prevTag) {
                 const currentTag = `${pkg.name}@${pkg.version}`;
                 const compareUrl = `https://github.com/${repo}/compare/${encodeURIComponent(prevTag)}...${encodeURIComponent(currentTag)}`;

--- a/packages/native-showcase/src/widgets/TextInputAlignment.tsx
+++ b/packages/native-showcase/src/widgets/TextInputAlignment.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { TextInput } from 'react-native';
+import styled from 'styled-components/native';
+import { theme as t } from '@/theme/tokens';
+
+const Stack = styled.View`
+  gap: ${t.space.sm}px;
+`;
+
+const Tag = styled.Text`
+  font-family: ${t.fontFamily.monoStrong};
+  font-size: ${t.fontSize.monoSm}px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: ${t.colors.fgFaint};
+`;
+
+const Field = styled(TextInput)<{ $align: 'top' | 'middle' | 'bottom' }>`
+  height: 120px;
+  background-color: ${t.colors.surfaceMuted};
+  color: ${t.colors.fg};
+  font-size: 20px;
+  padding: ${t.space.sm}px;
+  vertical-align: ${p => p.$align};
+`;
+
+const ROWS: ReadonlyArray<'top' | 'middle' | 'bottom'> = ['top', 'middle', 'bottom'];
+
+export function TextInputAlignment() {
+  return (
+    <Stack>
+      {ROWS.map(align => (
+        <React.Fragment key={align}>
+          <Tag>multiline TextInput · {align}</Tag>
+          <Field $align={align} multiline defaultValue="Type here" />
+        </React.Fragment>
+      ))}
+    </Stack>
+  );
+}

--- a/packages/native-showcase/src/widgets/registry.ts
+++ b/packages/native-showcase/src/widgets/registry.ts
@@ -21,6 +21,7 @@ import { SafeAreaInsetsBadge } from './SafeAreaInsetsBadge';
 import { ShadowComposer } from './ShadowComposer';
 import { StandaloneTransforms } from './StandaloneTransforms';
 import { TextDecorationAlignment } from './TextDecorationAlignment';
+import { TextInputAlignment } from './TextInputAlignment';
 import { TextWrapShelf } from './TextWrapShelf';
 import { ThemeOverrides } from './ThemeOverrides';
 import { TransformPlayground } from './TransformPlayground';
@@ -229,6 +230,15 @@ export const fidgets: ReadonlyArray<FidgetEntry> = [
     feature: 'textDecoration + textAlignVertical',
     category: 'Typography',
     Widget: TextDecorationAlignment,
+  },
+  {
+    slug: 'text-input-alignment',
+    title: 'TextInput vertical alignment',
+    summary:
+      'Tall multiline `TextInput` fields with `vertical-align` `top` / `middle` / `bottom`. iOS historically ignores `textAlignVertical` on TextInput; the caret and placeholder should sit at the requested position before any text is typed, and follow the content once the user starts typing.',
+    feature: 'TextInput + textAlignVertical',
+    category: 'Typography',
+    Widget: TextInputAlignment,
   },
   {
     slug: 'safe-area-insets-badge',

--- a/packages/native-showcase/src/widgets/registry.ts
+++ b/packages/native-showcase/src/widgets/registry.ts
@@ -235,7 +235,7 @@ export const fidgets: ReadonlyArray<FidgetEntry> = [
     slug: 'text-input-alignment',
     title: 'TextInput vertical alignment',
     summary:
-      'Tall multiline `TextInput` fields with `vertical-align` `top` / `middle` / `bottom`. iOS historically ignores `textAlignVertical` on TextInput; the caret and placeholder should sit at the requested position before any text is typed, and follow the content once the user starts typing.',
+      'Tall multiline `TextInput` fields with `vertical-align` `top` / `middle` / `bottom`. On Android and rn-web the caret and placeholder should sit at the requested position before any text is typed, and follow the content once the user starts typing. iOS has no `textAlignVertical` API for TextInput in RN 0.85 and the declaration has no effect.',
     feature: 'TextInput + textAlignVertical',
     category: 'Typography',
     Widget: TextInputAlignment,

--- a/packages/styled-components/src/native/transform/dev.ts
+++ b/packages/styled-components/src/native/transform/dev.ts
@@ -144,14 +144,12 @@ export function warnIfAndroidSkew(value: unknown): void {
 }
 
 /**
- * Warn once if `vertical-align` is set on iOS. RN's `Text.js` translates
- * `verticalAlign` to `textAlignVertical` at the JS layer, but iOS Fabric
- * has no `textAlignVertical` handler (the prop only registers on Android
- * via `ReactTextViewManager`). So on iOS the declaration looks like it
- * works but never repositions the glyphs. There is no Text-level
- * workaround in RN 0.85; wrap the Text in a View and use flex
- * justification to vertically align the content within a fixed-height
- * container.
+ * Warn once if `vertical-align` is set on iOS. RN's `Text.js` and
+ * `TextInput.js` both translate `verticalAlign` to `textAlignVertical`
+ * at the JS layer, but iOS Fabric exposes no `textAlignVertical`
+ * handler (`ReactTextViewManager` / `ReactTextInputManager` only
+ * register the prop on Android). On iOS the declaration looks like it
+ * works but never repositions the glyphs or the caret.
  *
  * No-op outside iOS. Callers must wrap in `if (__DEV__)`.
  */
@@ -166,7 +164,7 @@ export function warnIfIosVerticalAlign(value: string): void {
   if (os !== 'ios') return;
   warnOnce(
     'native-vertical-align-ios',
-    `\`vertical-align: ${value}\` has no effect on iOS \`<Text>\` in React Native 0.85 (no platform API; the prop only renders on Android and rn-web). To vertically align text within a fixed-height container on iOS, wrap the Text in a View with \`justify-content: <flex-start | center | flex-end>\`.`,
+    `\`vertical-align: ${value}\` has no effect on iOS \`<Text>\` or \`<TextInput>\` in React Native 0.85 (no platform API; the prop only renders on Android and rn-web). For \`<Text>\`, wrap it in a View with \`justify-content: <flex-start | center | flex-end>\` to align glyphs within a fixed-height container. \`<TextInput>\` has no Text-level workaround; iOS positions the caret and content at the platform default.`,
     value
   );
 }

--- a/packages/styled-components/src/native/transform/index.ts
+++ b/packages/styled-components/src/native/transform/index.ts
@@ -59,6 +59,12 @@ export function camelize(prop: string): string {
 // full shorthand set).
 import './shorthands.register';
 
+const VERTICAL_ALIGN_TO_ALIGN_CONTENT: Record<string, 'start' | 'center' | 'end' | undefined> = {
+  top: 'start',
+  middle: 'center',
+  bottom: 'end',
+};
+
 /**
  * Transform a single CSS declaration into an RN style partial.
  *
@@ -87,6 +93,16 @@ export function transformDecl(prop: string, rawValue: string): Dict<any> {
     }
     const value = isLayeredCommaProp(camel) ? collapseIdenticalCommas(rawValue) : rawValue;
     if (passthroughKeys.length === 1) {
+      // rn-web's `vertical-align` is baseline-only; emit `align-content`
+      // for the box-positioning keywords so they reposition content
+      // like Android's `textAlignVertical`. Other values fall through
+      // to the browser's native baseline-shifting semantics.
+      if (__NATIVE_WEB__ && camel === 'verticalAlign') {
+        const alignContent = VERTICAL_ALIGN_TO_ALIGN_CONTENT[rawValue];
+        if (alignContent !== undefined) {
+          return { verticalAlign: value, alignContent };
+        }
+      }
       return { [passthroughKeys[0]]: value };
     }
     // Dual-emit (background props): write every key in order so the

--- a/packages/styled-components/src/native/transform/index.ts
+++ b/packages/styled-components/src/native/transform/index.ts
@@ -59,10 +59,13 @@ export function camelize(prop: string): string {
 // full shorthand set).
 import './shorthands.register';
 
-const VERTICAL_ALIGN_TO_ALIGN_CONTENT: Record<string, 'start' | 'center' | 'end' | undefined> = {
-  top: 'start',
+const VERTICAL_ALIGN_TO_ALIGN_CONTENT: Record<
+  string,
+  'flex-start' | 'center' | 'flex-end' | undefined
+> = {
+  top: 'flex-start',
   middle: 'center',
-  bottom: 'end',
+  bottom: 'flex-end',
 };
 
 /**

--- a/packages/styled-components/src/native/transform/test/devWarn.test.ts
+++ b/packages/styled-components/src/native/transform/test/devWarn.test.ts
@@ -191,7 +191,9 @@ describe('warnIfIosVerticalAlign', () => {
     warnIfIosVerticalAlign('middle');
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toMatch(/`vertical-align: middle` has no effect on iOS/);
-    expect(warnSpy.mock.calls[0][0]).toMatch(/wrap the Text in a View with `justify-content/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/`<Text>` or `<TextInput>`/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/wrap it in a View with `justify-content/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/`<TextInput>` has no Text-level workaround/);
   });
 
   it('warns for top and bottom too', () => {

--- a/packages/styled-components/src/native/transform/test/passthrough.test.ts
+++ b/packages/styled-components/src/native/transform/test/passthrough.test.ts
@@ -124,6 +124,36 @@ describe('passthrough mapping', () => {
     });
   });
 
+  describe('vertical-align align-content polyfill on rn-web', () => {
+    // CSS Box Alignment L3 §5.3.
+    const g = global as { __NATIVE_WEB__?: boolean };
+    const originalNativeWeb = g.__NATIVE_WEB__;
+    beforeAll(() => {
+      g.__NATIVE_WEB__ = true;
+    });
+    afterAll(() => {
+      g.__NATIVE_WEB__ = originalNativeWeb;
+    });
+
+    it.each([
+      ['top', 'start'],
+      ['middle', 'center'],
+      ['bottom', 'end'],
+    ])('vertical-align: %s also emits align-content: %s', (value, alignContent) => {
+      expect(transformDecl('vertical-align', value)).toEqual({
+        verticalAlign: value,
+        alignContent,
+      });
+    });
+
+    it.each([['baseline'], ['sub'], ['super'], ['text-top'], ['text-bottom'], ['auto']])(
+      'vertical-align: %s passes through unchanged',
+      value => {
+        expect(transformDecl('vertical-align', value)).toEqual({ verticalAlign: value });
+      }
+    );
+  });
+
   describe('helpers', () => {
     it('getPassthroughKeys returns the array form', () => {
       expect(getPassthroughKeys('backgroundImage')).toEqual([

--- a/packages/styled-components/src/native/transform/test/passthrough.test.ts
+++ b/packages/styled-components/src/native/transform/test/passthrough.test.ts
@@ -136,9 +136,9 @@ describe('passthrough mapping', () => {
     });
 
     it.each([
-      ['top', 'start'],
+      ['top', 'flex-start'],
       ['middle', 'center'],
-      ['bottom', 'end'],
+      ['bottom', 'flex-end'],
     ])('vertical-align: %s also emits align-content: %s', (value, alignContent) => {
       expect(transformDecl('vertical-align', value)).toEqual({
         verticalAlign: value,


### PR DESCRIPTION
## Summary

- **rn-web `vertical-align: top | middle | bottom`** now positions text content inside the Text's box, matching the visual semantic of React Native's `verticalAlign` on Android (`textAlignVertical`). Other values (`baseline`, `sub`, `super`, `text-top`, `text-bottom`, lengths, percentages, `auto`) pass through to the browser's native baseline-shifting semantics.

- **iOS dev warning** for `vertical-align` now covers `<TextInput>` as well as `<Text>`. RN 0.85 has no platform API to vertically align text content on iOS for either component; the declaration silently has no effect. The warning names the situation and (for `<Text>`) points to the View + `justify-content` workaround.

Also bundled:

- **CI:** prerelease release notes now skip changesets already shipped in earlier prereleases (the existing logic was re-emitting the full pending pile every snapshot publish).

- **Showcase:** new `TextInputAlignment` widget for visual QA of multiline `<TextInput>` vertical alignment across iOS, Android, and rn-web.

## Test plan

- [x] `pnpm --filter styled-components test:web` (1311 passed)
- [x] `pnpm --filter styled-components test:native` (1025 passed)
- [x] `pnpm --filter styled-components typecheck` + `test:types` clean
- [ ] Showcase QA on iOS sim, Android emulator, and rn-web for the three keyword variants