### PR TITLE
fix: support native Node ESM default import

### DIFF
--- a/.changeset/fresh-node-default-import.md
+++ b/.changeset/fresh-node-default-import.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fix native Node.js ESM default imports so `import styled from 'styled-components'` exposes the styled factory directly.

--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -22,6 +22,13 @@ const cjs = {
   sourcemap: true,
 };
 
+// Node maps native ESM default imports from CJS to module.exports.
+const styledCJSInteropFooter = `
+Object.assign(styled, exports);
+Object.defineProperty(styled, '__esModule', { value: true });
+module.exports = styled;
+`;
+
 const esm = {
   format: 'esm',
   interop: 'auto',
@@ -179,7 +186,7 @@ const serverConfig = {
   ...configBase,
   output: [
     getESM({ file: 'dist/styled-components.esm.js' }),
-    getCJS({ file: 'dist/styled-components.cjs.js' }),
+    getCJS({ file: 'dist/styled-components.cjs.js', footer: styledCJSInteropFooter }),
   ],
   plugins: configBase.plugins.concat(
     replace({
@@ -196,7 +203,7 @@ const browserConfig = {
   ...configBase,
   output: [
     getESM({ file: 'dist/styled-components.browser.esm.js' }),
-    getCJS({ file: 'dist/styled-components.browser.cjs.js' }),
+    getCJS({ file: 'dist/styled-components.browser.cjs.js', footer: styledCJSInteropFooter }),
   ],
   plugins: configBase.plugins.concat(
     replace({

--- a/packages/styled-components/src/test/treeshake.test.ts
+++ b/packages/styled-components/src/test/treeshake.test.ts
@@ -448,4 +448,38 @@ describe('ESM tree-shakeability', () => {
       './dist/styled-components.browser.esm.js'
     );
   });
+
+  it('supports a default import from native Node ESM', () => {
+    const os = require('os');
+    const { spawnSync } = require('child_process');
+    const pkgDir = path.resolve(__dirname, '../..');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-node-esm-'));
+
+    try {
+      fs.mkdirSync(path.join(tmpDir, 'node_modules'), { recursive: true });
+      fs.symlinkSync(pkgDir, path.join(tmpDir, 'node_modules', 'styled-components'), 'dir');
+
+      const script = [
+        "import styled, { css } from 'styled-components';",
+        "if (typeof styled !== 'function') throw new Error(`default export was ${typeof styled}`);",
+        "if (typeof styled.h1 !== 'function') throw new Error('styled.h1 is unavailable');",
+        "if (styled.default !== styled) throw new Error('styled.default does not point at styled');",
+        "if (typeof css !== 'function') throw new Error('named css export is unavailable');",
+        "console.log('ok');",
+      ].join('\n');
+
+      const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+        cwd: tmpDir,
+        encoding: 'utf8',
+      });
+
+      expect({ status: result.status, stdout: result.stdout, stderr: result.stderr }).toEqual({
+        status: 0,
+        stdout: 'ok\n',
+        stderr: '',
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #5750.

Native Node.js ESM consumers can now use `import styled from 'styled-components'` directly. The default import exposes styled shorthands like `styled.h1` while `styled.default` and named imports continue to work for interop.

## Verification

- `pnpm --filter styled-components build`
- `pnpm --filter styled-components test:build`
- Manual native Node.js ESM package import repro: `function function true function`

AI assistance: Prepared with help from an AI coding assistant.
