### PR TITLE
fix(native): animate multi-argument transform shorthands

### DIFF
--- a/.changeset/native-animated-translate-shorthand.md
+++ b/.changeset/native-animated-translate-shorthand.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+In React Native apps (both native and react-native-web), animating a multi-argument transform shorthand (`translate(x, y)`, `translate3d(x, y, z)`, or `scale(x, y)`) inside `@keyframes` or a `transition` no longer throws "Transform with key of translate must have an array as the value". These forms now animate correctly per axis. Single-axis forms and uniform `scale(n)` were already fine.

--- a/packages/native-showcase/src/widgets/KeyframeOrchestra.tsx
+++ b/packages/native-showcase/src/widgets/KeyframeOrchestra.tsx
@@ -20,6 +20,7 @@ import { theme as t } from '@/theme/tokens';
  * - animation-fill-mode: both with animation-delay (stagger)
  * - animation-play-state toggling (pause/resume)
  * - Multi-property keyframes (transform+opacity, rotateY+scaleX+color)
+ * - Multi-argument transform shorthand: translate(x, y) + scale(x, y)
  * - Theme tokens resolving inside @keyframes frames
  * - prefers-reduced-motion gating
  */
@@ -185,6 +186,36 @@ const JellyBall = styled.View<{ $play: boolean }>`
   border-radius: ${t.radius.pill}px;
   background-color: ${t.colors.fail};
   animation: jelly 1.6s infinite;
+  animation-play-state: ${p => (p.$play ? 'running' : 'paused')};
+`;
+
+// ── 3b. Drift (multi-arg translate(x, y) + scale(x, y) shorthand) ──
+//
+// The shorthand `translate(26px, -12px)` / `scale(1.4, 0.7)` forms must
+// decompose into per-axis transforms; if they leak through as a single
+// `translate` key this cell throws RN's "must have an array as the value"
+// and the failure is the demo on any platform that regresses.
+
+const DriftBox = styled.View<{ $play: boolean }>`
+  @keyframes drift {
+    0% {
+      transform: translate(0px, 0px) scale(1, 1);
+    }
+    30% {
+      transform: translate(16px, -12px) scale(1.4, 0.7);
+    }
+    60% {
+      transform: translate(-16px, 12px) scale(0.7, 1.4);
+    }
+    100% {
+      transform: translate(0px, 0px) scale(1, 1);
+    }
+  }
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  background-color: ${t.colors.accent};
+  animation: drift 2.4s ease-in-out infinite;
   animation-play-state: ${p => (p.$play ? 'running' : 'paused')};
 `;
 
@@ -396,6 +427,12 @@ export function KeyframeOrchestra() {
         <JellyStage>
           <JellyBall $play={active} />
         </JellyStage>
+      </Row>
+
+      <Row label="drift" feature="translate(x, y) + scale(x, y) shorthand · 4-stop">
+        <CellFrame>
+          <DriftBox $play={active} />
+        </CellFrame>
       </Row>
 
       <Row label="card flip" feature="rotateY + scaleX + opacity · 5-stop · alternate">

--- a/packages/styled-components/src/native/animation/index.ts
+++ b/packages/styled-components/src/native/animation/index.ts
@@ -437,21 +437,28 @@ function parseTransformString(s: string): TransformComponent[] {
  * RN accepts. parseFloat drops the unit; percentage translate stays
  * unsupported either way since RN's transforms take dp, not percentages.
  */
+function finiteOr(n: number, fallback: number): number {
+  return Number.isFinite(n) ? n : fallback;
+}
+
 function pushTransformComponents(out: TransformComponent[], kind: string, raw: string): void {
   if (kind === 'translate' || kind === 'translate3d') {
     const args = raw.split(',');
-    out.push({ kind: 'translateX', value: parseFloat(args[0]) || 0 });
-    out.push({ kind: 'translateY', value: args.length > 1 ? parseFloat(args[1]) || 0 : 0 });
+    out.push({ kind: 'translateX', value: finiteOr(parseFloat(args[0]), 0) });
+    out.push({ kind: 'translateY', value: finiteOr(parseFloat(args[1]), 0) });
     if (kind === 'translate3d' && args.length > 2) {
-      out.push({ kind: 'translateZ', value: parseFloat(args[2]) || 0 });
+      out.push({ kind: 'translateZ', value: finiteOr(parseFloat(args[2]), 0) });
     }
     return;
   }
   if (kind === 'scale' && raw.indexOf(',') !== -1) {
     const args = raw.split(',');
-    const x = parseFloat(args[0]);
+    // A missing/malformed axis falls back to the other (uniform), matching
+    // CSS `scale(n)`; an empty `scale(1,)` would otherwise yield NaN and
+    // crash RN's Animated outputRange.
+    const x = finiteOr(parseFloat(args[0]), 1);
     out.push({ kind: 'scaleX', value: x });
-    out.push({ kind: 'scaleY', value: args.length > 1 ? parseFloat(args[1]) : x });
+    out.push({ kind: 'scaleY', value: finiteOr(parseFloat(args[1]), x) });
     return;
   }
   out.push({ kind, value: parseTransformValue(kind, raw) });

--- a/packages/styled-components/src/native/animation/index.ts
+++ b/packages/styled-components/src/native/animation/index.ts
@@ -416,18 +416,45 @@ interface TransformComponent {
 // Eager `[^)]*` with no flanking `\s*`; the caller trims the captured
 // args anyway. Avoids polynomial backtracking on user-authored
 // `transform:` values like `translate(<spaces>X` (no close paren).
-const TRANSFORM_FN_RE = /([A-Za-z]+)\(([^)]*)\)/g;
+const TRANSFORM_FN_RE = /([A-Za-z][A-Za-z0-9]*)\(([^)]*)\)/g;
 
 function parseTransformString(s: string): TransformComponent[] {
   const out: TransformComponent[] = [];
   let match: RegExpExecArray | null;
   TRANSFORM_FN_RE.lastIndex = 0;
   while ((match = TRANSFORM_FN_RE.exec(s)) !== null) {
-    const kind = match[1];
-    const raw = match[2].trim();
-    out.push({ kind, value: parseTransformValue(kind, raw) });
+    pushTransformComponents(out, match[1], match[2].trim());
   }
   return out;
+}
+
+/**
+ * RN's object-array transform form (`[{ translateX: n }, …]`) has no
+ * `translate`/`translate3d` key and no 2-arg `scale`; those reject with
+ * "Transform with key of <k> must have an array as the value". CSS
+ * authors write the shorthand freely (and RN parses it fine as a static
+ * string), so the animation path decomposes them into the per-axis keys
+ * RN accepts. parseFloat drops the unit; percentage translate stays
+ * unsupported either way since RN's transforms take dp, not percentages.
+ */
+function pushTransformComponents(out: TransformComponent[], kind: string, raw: string): void {
+  if (kind === 'translate' || kind === 'translate3d') {
+    const args = raw.split(',');
+    out.push({ kind: 'translateX', value: parseFloat(args[0]) || 0 });
+    out.push({ kind: 'translateY', value: args.length > 1 ? parseFloat(args[1]) || 0 : 0 });
+    if (kind === 'translate3d' && args.length > 2) {
+      out.push({ kind: 'translateZ', value: parseFloat(args[2]) || 0 });
+    }
+    return;
+  }
+  if (kind === 'scale' && raw.indexOf(',') !== -1) {
+    const args = raw.split(',');
+    const x = parseFloat(args[0]);
+    out.push({ kind: 'scaleX', value: x });
+    out.push({ kind: 'scaleY', value: args.length > 1 ? parseFloat(args[1]) : x });
+    return;
+  }
+  out.push({ kind, value: parseTransformValue(kind, raw) });
 }
 
 function parseTransformValue(kind: string, raw: string): number | string {

--- a/packages/styled-components/src/native/animation/test/transform-interp.test.ts
+++ b/packages/styled-components/src/native/animation/test/transform-interp.test.ts
@@ -151,6 +151,38 @@ describe('parseTransformString', () => {
     `);
   });
 
+  // A malformed/omitted axis must fall back to the other axis (uniform),
+  // never NaN, since NaN in an Animated outputRange crashes RN at runtime.
+  it('falls back to uniform for a trailing-comma scale(x,)', () => {
+    expect(parseTransformString('scale(1,)')).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "scaleX",
+          "value": 1,
+        },
+        {
+          "kind": "scaleY",
+          "value": 1,
+        },
+      ]
+    `);
+  });
+
+  it('falls back to identity for a missing x in scale(,y)', () => {
+    expect(parseTransformString('scale(,2)')).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "scaleX",
+          "value": 1,
+        },
+        {
+          "kind": "scaleY",
+          "value": 2,
+        },
+      ]
+    `);
+  });
+
   // Regression guard: the previous /([A-Za-z]+)\s*\(\s*([^)]+?)\s*\)/g
   // shape exhibited polynomial backtracking. A user-authored value with
   // a long whitespace run and no closing paren — reachable from any

--- a/packages/styled-components/src/native/animation/test/transform-interp.test.ts
+++ b/packages/styled-components/src/native/animation/test/transform-interp.test.ts
@@ -83,6 +83,74 @@ describe('parseTransformString', () => {
     `);
   });
 
+  // RN's object-array transform form has no `translate`/`translate3d`
+  // key and no 2-arg `scale`; passing them through unsplit makes
+  // `processTransform` throw "must have an array as the value". The
+  // shorthands decompose into the per-axis keys RN accepts.
+  it('decomposes translate(x, y) into translateX + translateY', () => {
+    expect(parseTransformString('translate(26px, -12px)')).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "translateX",
+          "value": 26,
+        },
+        {
+          "kind": "translateY",
+          "value": -12,
+        },
+      ]
+    `);
+  });
+
+  it('defaults the y axis to 0 for single-arg translate(x)', () => {
+    expect(parseTransformString('translate(26px)')).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "translateX",
+          "value": 26,
+        },
+        {
+          "kind": "translateY",
+          "value": 0,
+        },
+      ]
+    `);
+  });
+
+  it('decomposes translate3d(x, y, z) into all three axes', () => {
+    expect(parseTransformString('translate3d(4px, 8px, 12px)')).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "translateX",
+          "value": 4,
+        },
+        {
+          "kind": "translateY",
+          "value": 8,
+        },
+        {
+          "kind": "translateZ",
+          "value": 12,
+        },
+      ]
+    `);
+  });
+
+  it('decomposes 2-arg scale(x, y) into scaleX + scaleY', () => {
+    expect(parseTransformString('scale(2, 3)')).toMatchInlineSnapshot(`
+      [
+        {
+          "kind": "scaleX",
+          "value": 2,
+        },
+        {
+          "kind": "scaleY",
+          "value": 3,
+        },
+      ]
+    `);
+  });
+
   // Regression guard: the previous /([A-Za-z]+)\s*\(\s*([^)]+?)\s*\)/g
   // shape exhibited polynomial backtracking. A user-authored value with
   // a long whitespace run and no closing paren — reachable from any
@@ -143,6 +211,26 @@ describe('interpolateTransform', () => {
     expect((out![1].translateY as FakeInterp).outputRange).toEqual([-12, 0]);
     expect((out![2].rotate as FakeInterp).outputRange).toEqual(['0deg', '18deg']);
     expect((out![3].scale as FakeInterp).outputRange).toEqual([1, 0.85]);
+  });
+
+  // End-to-end guard for the reported RN crash: a keyframe authored with
+  // the `translate(x, y)` shorthand must assemble into a per-axis array
+  // (`translateX`/`translateY`), never the bare `translate` key RN rejects
+  // with "must have an array as the value".
+  it('assembles translate(x, y) shorthand into per-axis interpolations', () => {
+    const out = interpolateTransform(
+      fakeProgress as any,
+      'translate(26px, -12px)',
+      'translate(-30px, 16px)',
+      ['translateX', 'translateY'],
+      LINEAR,
+      300
+    );
+    expect(out).not.toBeNull();
+    expect(out!.map(readKind)).toEqual(['translateX', 'translateY']);
+    expect(out!.some(e => 'translate' in e)).toBe(false);
+    expect((out![0].translateX as FakeInterp).outputRange).toEqual([26, -30]);
+    expect((out![1].translateY as FakeInterp).outputRange).toEqual([-12, 16]);
   });
 
   it('morphs matched-kind transforms (translateX only)', () => {


### PR DESCRIPTION
In React Native apps (both native and react-native-web), animating a multi-argument transform shorthand inside `@keyframes` or a `transition` previously threw `Transform with key of translate must have an array as the value` and broke the component. This covers the shorthand forms `translate(x, y)`, `translate3d(x, y, z)`, and the two-argument `scale(x, y)`.

These now animate correctly, interpolating each axis independently. Single-axis forms (`translateX`, `translateY`, `scaleX`, `scaleY`) and uniform `scale(n)` were already fine and are unchanged.

```js
const Drift = styled.View`
  @keyframes drift {
    0%   { transform: translate(0px, 0px)    scale(1, 1); }
    50%  { transform: translate(26px, -12px) scale(1.4, 0.7); }
    100% { transform: translate(0px, 0px)    scale(1, 1); }
  }
  animation: drift 2.4s ease-in-out infinite;
`;
```

A matching "drift" cell was added to the native showcase's keyframe examples so the behavior is verifiable across iOS, Android, and react-native-web.
