### PR TITLE
fix(types): permissive props for un-introspectable targets, plus as-target autocomplete while typing

### DIFF
--- a/.changeset/fix-untyped-target-props.md
+++ b/.changeset/fix-untyped-target-props.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Fix a TypeScript error when wrapping a component whose props can't be statically read, such as Mantine v7's polymorphic-factory components (`Button`, `Card`, `Menu.Item`, and similar). These styled components no longer reject every prop, including `children`; arbitrary props are accepted again at the JSX call site and via `.attrs()`, while components with readable prop types stay fully type-checked.

--- a/.changeset/restore-as-target-autocomplete.md
+++ b/.changeset/restore-as-target-autocomplete.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Keep TypeScript attribute autocomplete working while you type props on a polymorphic styled component. When a component renders a different element through `as` (for example `as="video"`), beginning to type a new prop name could make the whole suggestion list vanish; the rendered element's props now keep autocompleting as you go.

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -12,6 +12,7 @@ import {
   StyledTarget,
   Styles,
   Substitute,
+  WidenUntypedProps,
 } from '../types';
 import { EMPTY_OBJECT } from '../utils/empties';
 import styledError from '../utils/error';
@@ -63,7 +64,12 @@ export interface Styled<
   attrs: <
     Props extends object = BaseObject,
     PrivateMergedProps extends object = Substitute<OuterProps, Props>,
-    PrivateAttrsArg extends Attrs<PrivateMergedProps> = Attrs<PrivateMergedProps>,
+    // Widen when the merged props are un-introspectable ({}) so attrs can backfill
+    // arbitrary keys on e.g. Mantine polymorphic-factory targets, matching the
+    // permissive JSX call site. Targets with known props are unaffected.
+    PrivateAttrsArg extends Attrs<WidenUntypedProps<PrivateMergedProps>> = Attrs<
+      WidenUntypedProps<PrivateMergedProps>
+    >,
     PrivateResolvedTarget extends StyledTarget<R> = AttrsTarget<R, PrivateAttrsArg, Target>,
   >(
     attrs: PrivateAttrsArg
@@ -129,7 +135,9 @@ export default function constructWithOptions<
   templateFunction.attrs = <
     Props extends object = BaseObject,
     PrivateMergedProps extends object = Substitute<OuterProps, Props>,
-    PrivateAttrsArg extends Attrs<PrivateMergedProps> = Attrs<PrivateMergedProps>,
+    PrivateAttrsArg extends Attrs<WidenUntypedProps<PrivateMergedProps>> = Attrs<
+      WidenUntypedProps<PrivateMergedProps>
+    >,
     PrivateResolvedTarget extends StyledTarget<R> = AttrsTarget<R, PrivateAttrsArg, Target>,
   >(
     attrs: PrivateAttrsArg

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -815,3 +815,103 @@ const ToggleWithAttrs = styled(ToggleBase).attrs({ isOpen: false })``;
 <ToggleWithAttrs />;
 // @ts-expect-error isOpen is boolean, not string
 <ToggleWithAttrs isOpen="yes" onToggle={() => {}} />;
+
+/**
+ * Wrapping a component whose props can't be statically introspected -- e.g.
+ * Mantine v7's polymorphic-factory components, whose generic callable signature
+ * makes `React.ComponentPropsWithRef` resolve to `{}` -- must stay permissive at
+ * the JSX call site rather than reject every prop including `children` (#5756).
+ *
+ * The synthetic factory below mirrors Mantine's exact shape: a generic callable
+ * intersected with `FunctionComponent` statics. Verified against real
+ * `@mantine/core@7` that this collapses `ComponentPropsWithRef` to `{}`.
+ */
+type FactoryExtendedProps<Props = {}, OverrideProps = {}> = OverrideProps &
+  Omit<Props, keyof OverrideProps>;
+type FactoryElementType = keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>;
+type FactoryPropsOf<C extends FactoryElementType> = React.JSX.LibraryManagedAttributes<
+  C,
+  React.ComponentProps<C>
+>;
+type FactoryComponentProp<C> = { component?: C };
+type FactoryInheritedProps<C extends FactoryElementType, Props = {}> = FactoryExtendedProps<
+  FactoryPropsOf<C>,
+  Props
+>;
+type PolymorphicFactoryProps<C, Props = {}> = C extends React.ElementType
+  ? FactoryInheritedProps<C, Props & FactoryComponentProp<C>> & {
+      ref?: any;
+      renderRoot?: (props: any) => any;
+    }
+  : Props & { component: React.ElementType; renderRoot?: (props: Record<string, any>) => any };
+
+interface PolyButtonProps {
+  variant?: string;
+  color?: string;
+  children?: React.ReactNode;
+}
+type PolymorphicFactoryButton = (<C = 'button'>(
+  props: PolymorphicFactoryProps<C, PolyButtonProps>
+) => React.ReactElement) &
+  Omit<React.FunctionComponent<PolymorphicFactoryProps<any, PolyButtonProps>>, never> & {
+    extend: (p: any) => any;
+  };
+declare const PolyButton: PolymorphicFactoryButton;
+
+// The premise: this resolves to `{}` (no statically-known keys).
+type PolyButtonResolvedProps = React.ComponentPropsWithRef<typeof PolyButton>;
+const _polyPremise: keyof PolyButtonResolvedProps extends never ? true : false = true;
+
+const StyledPolyButton = styled(PolyButton)`
+  color: red;
+`;
+// Arbitrary props + children accepted (permissive fallback).
+<StyledPolyButton variant="filled" color="blue">
+  hi
+</StyledPolyButton>;
+<StyledPolyButton>just children</StyledPolyButton>;
+// `as` is still accepted. The fallback can't resolve the `as`-target's own props
+// though: a permissive prop bag is required to accept the unknown base props, and
+// that same bag types every key (including the target's) as the catch-all, so e.g.
+// `href` below is not anchor-checked. This is the unavoidable cost of having no
+// base type to substitute against -- an introspectable base keeps full `as` typing.
+<StyledPolyButton as="a" href="/x">
+  link
+</StyledPolyButton>;
+
+// `.attrs()` is permissive too for un-introspectable targets, so arbitrary keys
+// can be backfilled (matching the JSX call site).
+const PolyButtonWithAttrs = styled(PolyButton).attrs({ variant: 'filled', type: 'button' })``;
+<PolyButtonWithAttrs color="blue">hi</PolyButtonWithAttrs>;
+// Function-form attrs can read arbitrary props (typed `unknown`).
+styled(PolyButton).attrs(props => ({ 'data-variant': String(props.variant ?? '') }))``;
+// Introspectable targets keep strict `.attrs()` typing.
+declare const TypedAttrsComp: (props: { a: string }) => React.ReactElement;
+// @ts-expect-error -- `nope` is not a prop of the wrapped component
+styled(TypedAttrsComp).attrs({ nope: 1 })``;
+
+// A bare union of disjoint shapes is introspectable, even though `keyof` of the
+// union is `never`. It must stay strict, not fall into the permissive branch.
+type DisjointUnionProps = { a: string } | { b: string };
+declare const DisjointUnionComp: (props: DisjointUnionProps) => React.ReactElement;
+const StyledDisjointUnion = styled(DisjointUnionComp)`
+  color: red;
+`;
+<StyledDisjointUnion a="x" />;
+<StyledDisjointUnion b="y" />;
+// @ts-expect-error -- `nonsense` is on neither union member; widening must not fire
+<StyledDisjointUnion a="x" nonsense="y" />;
+
+// All-optional props have a non-`never` `keyof`, so they stay strict (the widen
+// fallback fires only when there are genuinely no known keys).
+declare const AllOptionalComp: (props: { a?: string }) => React.ReactElement;
+const StyledAllOptional = styled(AllOptionalComp)``;
+// @ts-expect-error -- unknown prop still rejected
+<StyledAllOptional nonsense="y" />;
+
+// A union with one empty member (`{} | { a }`) is still introspectable: not every
+// constituent is empty, so the distributed check must not widen it.
+declare const OneEmptyMemberComp: (props: {} | { a: string }) => React.ReactElement;
+const StyledOneEmpty = styled(OneEmptyMemberComp)``;
+// @ts-expect-error -- nonsense is on neither member
+<StyledOneEmpty nonsense="y" />;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -185,7 +185,7 @@ export interface IStyledStatics<
 export type PolymorphicComponentProps<
   R extends Runtime,
   BaseProps extends BaseObject,
-  AsTarget extends StyledTarget<R> | void,
+  AsTarget extends StyledTarget<R> | (BaseProps extends { as?: infer A } ? A : never) | void,
   ForwardedAsTarget extends StyledTarget<R> | void,
   // props extracted from "as"
   AsTargetProps extends BaseObject = AsTarget extends KnownTarget
@@ -213,6 +213,47 @@ export type PolymorphicComponentProps<
 >;
 
 /**
+ * Resolves the call-site props for one usage of a polymorphic component,
+ * branching on the supplied `as` / `forwardedAs` targets into the three prior
+ * overload shapes:
+ *  - `as` is a real render target (e.g. `as="video"`, `as={Component}`):
+ *    substitute that target's props and require `as`.
+ *  - no `as`, or `as` is the wrapped component's own non-target type (e.g.
+ *    Next.js Link's `as?: Url`): Substitute-free base props so ref callbacks
+ *    infer with spread props (#5687), the wrapped `as` type stays assignable and
+ *    optional (#5734), and BaseProps keys keep completing for plain usage (#5741).
+ *  - `forwardedAs` only: substitute the forwarded target's props.
+ *
+ * Extracted to a named alias so identical (R, BaseProps, AsTarget,
+ * ForwardedAsTarget) tuples dedupe across the many JSX call sites in an app.
+ *
+ * The target test is `string | AnyComponent`, not the broader `WebTarget`
+ * (`KnownTarget | (string & {})`): both describe the same set (any string or
+ * component), but comparing against the ~156 literal members of `KnownTarget`
+ * here costs ~6% more type instantiations across all call sites. Don't narrow it
+ * to bare `KnownTarget` -- that drops custom element strings (`as="my-element"`)
+ * out of the target branch and makes them error.
+ */
+type PolymorphicCallProps<
+  R extends Runtime,
+  BaseProps extends BaseObject,
+  AsTarget extends StyledTarget<R> | (BaseProps extends { as?: infer A } ? A : never) | void,
+  ForwardedAsTarget extends StyledTarget<R> | void,
+> = [AsTarget] extends [string | AnyComponent]
+  ? PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget> & { as: AsTarget }
+  : [ForwardedAsTarget] extends [void]
+    ? OverrideStyle<
+        NoInfer<FastOmit<BaseProps, keyof ExecutionProps>> &
+          FastOmit<ExecutionProps, 'as' | 'forwardedAs'> & {
+            as?: BaseProps extends { as?: infer A } ? A : void;
+            forwardedAs?: BaseProps extends { forwardedAs?: infer A } ? A : void;
+          }
+      >
+    : PolymorphicComponentProps<R, BaseProps, void, ForwardedAsTarget> & {
+        forwardedAs: ForwardedAsTarget;
+      };
+
+/**
  * This type forms the signature for a forwardRef-enabled component
  * that accepts the "as" prop to dynamically change the underlying
  * rendered JSX. The interface will automatically attempt to extract
@@ -233,38 +274,18 @@ export interface PolymorphicComponent<
     forwardedAs?: StyledTarget<R> | undefined;
   }
 > {
-  // Default overload (no `as`/`forwardedAs`) is listed first so TypeScript's JSX
-  // completion resolves to it for plain `<StyledComponent ... />` usage. The
-  // generic overloads below introduce unsolved type parameters that, when
-  // visited first, suppress JSX attribute name completions for keys carried by
-  // `BaseProps` (#5741). Avoids `Substitute` so ref callbacks get contextual
-  // typing even with spread props (#5687).
-  //
-  // `as` / `forwardedAs` here widen to also accept the wrapped component's own
-  // `as` / `forwardedAs` type when present (e.g. Next.js Link's `as?: Url`), so
-  // spreading the wrapped component's props onto the styled component remains
-  // assignable (#5734).
-  (
-    props: OverrideStyle<
-      NoInfer<FastOmit<BaseProps, keyof ExecutionProps>> &
-        FastOmit<ExecutionProps, 'as' | 'forwardedAs'> & {
-          as?: BaseProps extends { as?: infer A } ? A : void;
-          forwardedAs?: BaseProps extends { forwardedAs?: infer A } ? A : void;
-        }
-    >
-  ): React.JSX.Element;
-
-  // Overload for `as` polymorphism. `as` is required here to prevent TS from
-  // falling back to the constraint type (`StyledTarget<R>`) which is too wide.
-  <AsTarget extends StyledTarget<R>, ForwardedAsTarget extends StyledTarget<R> | void = void>(
-    props: PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget> & { as: AsTarget }
-  ): React.JSX.Element;
-
-  // Overload for `forwardedAs` polymorphism (without `as`).
-  <ForwardedAsTarget extends StyledTarget<R>>(
-    props: PolymorphicComponentProps<R, BaseProps, void, ForwardedAsTarget> & {
-      forwardedAs: ForwardedAsTarget;
-    }
+  // A single call signature (not several overloads) so JSX attribute completion
+  // never collapses while an attribute is mid-typed. With multiple overloads, a
+  // partially-typed or unknown attribute matches none of them, overload
+  // resolution fails, and completion drops to nothing; one signature always
+  // resolves, so the rendered target's props keep autocompleting. The branching
+  // that preserves the prior overload shapes lives in `PolymorphicCallProps`.
+  <
+    AsTarget extends StyledTarget<R> | (BaseProps extends { as?: infer A } ? A : never) | void =
+      void,
+    ForwardedAsTarget extends StyledTarget<R> | void = void,
+  >(
+    props: PolymorphicCallProps<R, BaseProps, AsTarget, ForwardedAsTarget>
   ): React.JSX.Element;
 }
 

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -268,11 +268,38 @@ export interface PolymorphicComponent<
   ): React.JSX.Element;
 }
 
+/**
+ * Some wrapped targets can't be statically introspected and their props
+ * collapse to `{}` -- most notably polymorphic-factory components (e.g. Mantine
+ * v7's `Button`, `Card`, `Menu.Item`), whose generic callable signature defeats
+ * `React.ComponentPropsWithRef`. A closed `{}` would reject every prop at the JSX
+ * call site, including `children`. Falling back to a permissive prop bag keeps
+ * these components usable; targets with introspectable props are unchanged.
+ *
+ * Applied only to the JSX call surface (`PolymorphicComponent`), never to the
+ * statics (`IStyledStatics`, `defaultProps`), so internal code keeps the real
+ * `Props` and the widening can't leak past the call site.
+ *
+ * The "no known keys" test is distributed over `Props` first. `keyof` on a union
+ * intersects each member's keys, so a bare union of disjoint shapes (e.g.
+ * `{ a: string } | { b: string }`) has `keyof` of `never` despite being fully
+ * introspectable. Checking each constituent independently widens only when every
+ * member is truly empty.
+ */
+export type WidenUntypedProps<Props extends BaseObject> = (
+  Props extends unknown ? (keyof Props extends never ? true : false) : never
+) extends true
+  ? Props & { [key: string]: unknown }
+  : Props;
+
 export interface IStyledComponentBase<
   out R extends Runtime,
   in out Props extends BaseObject = BaseObject,
 >
-  extends PolymorphicComponent<R, Props>, IStyledStatics<R, Props>, StyledComponentBrand {
+  extends
+    PolymorphicComponent<R, WidenUntypedProps<Props>>,
+    IStyledStatics<R, Props>,
+    StyledComponentBrand {
   defaultProps?: (ExecutionProps & Partial<Props>) | undefined;
   toString: () => string;
 }


### PR DESCRIPTION
This PR lands two related TypeScript fixes for polymorphic styled components.

## 1. Permissive props for un-introspectable targets (#5756)

Wrapping a component whose props can't be statically read produced a styled component that rejected every prop at the JSX call site, including `children`. This hit every `styled(X)` where `X` is a Mantine v7 polymorphic-factory component (`Button`, `Card`, `Menu.Item`, `Badge`, `SegmentedControl`, and friends), whose generic callable signature makes `React.ComponentPropsWithRef<typeof X>` resolve to `{}`.

```tsx
import styled from 'styled-components';
import { Button } from '@mantine/core';

const Styled = styled(Button)`color: red;`;

// before: TS2769, `variant` and `children` rejected
// after: accepted
const usage = <Styled variant="filled">hi</Styled>;
```

When a target's props resolve to an empty `{}`, the styled component now falls back to accepting arbitrary props instead of rejecting all of them, both at the JSX call site and via `.attrs()`. Components whose prop types can be read are unaffected and stay fully type-checked.

### Details

- The detection keys on the props having no known keys. It's distributed over unions, so a bare union of disjoint shapes (`{ a: string } | { b: string }`, whose `keyof` is `never`) stays strict rather than going permissive. All-optional shapes (`{ a?: string }`) also stay strict.
- The permissive fallback is `unknown`-typed, not `any`, so reading props back off the component (`React.ComponentProps<typeof Styled>`) doesn't disable type-checking in consumer code.
- The widening is confined to the call surface and the attrs input; component statics and `defaultProps` keep their real prop types internally.

### Known limitation

For an un-introspectable target there is no base type to substitute against, so `as` is accepted but the `as`-target's own props aren't individually type-checked (e.g. `href` on `as="a"` isn't anchor-validated). An introspectable target keeps full `as` typing. A genuinely propless component (`() => <div/>`) is indistinguishable from an un-introspectable one and also becomes permissive (both resolve to `{}`).

## 2. `as`-target autocomplete survives mid-typing

On a polymorphic styled component rendering a different element through `as` (for example `as="video"`), starting to type a new prop name could make the whole attribute suggestion list vanish, so the rendered element's props (`loop`, `controls`, and the rest) disappeared while you were typing them. They now keep autocompleting as you go.

### Details

The previous shape exposed several call overloads. A half-typed or unknown attribute matched none of them, overload resolution failed, and JSX completion dropped to nothing. A single conditional call signature always resolves, so completion stays live. The conditional preserves the prior behaviors: a real `as`-target substitutes its props; no `as`, or an `as` typed as the wrapped component's own non-target type (e.g. Next.js `Link`'s `as?: Url`), keeps base props with `as` optional and assignable; `forwardedAs` substitutes the forwarded target.

A single generic signature does a little more type work per call site than the overload set did. The cost is kept small (target test against `string | AnyComponent` rather than the literal-heavy `WebTarget`, and a shared alias for the no-target result); net is roughly +5% type instantiations across the type test suite, with check time effectively unchanged.

## Verification

Verified against real `@mantine/core@7`: `React.ComponentPropsWithRef<typeof Button>` resolves to `{}`, the wrapped styled component now accepts arbitrary props and `children` (at the call site and through `.attrs()`), and normally typed styled components still reject unknown or mistyped props. Autocomplete was confirmed via the editor language service for both the mid-typing `as`-target case and plain usage. Type tests covering the Mantine factory shape, the union edge cases, and the existing `as` / `forwardedAs` behaviors are included; the full runtime suite (924 tests) passes.

Closes #5756
