### PR TITLE
fix: call useDebugValue unconditionally past the render-cache branch

### DIFF
--- a/.changeset/hooks-cache-hit-debug-value.md
+++ b/.changeset/hooks-cache-hit-debug-value.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fixed a rules-of-hooks violation that could crash components triggering an immediate re-render with unchanged style props.

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -113,13 +113,7 @@ function useInjectedStyle<T extends ExecutionContext>(
   styleSheet: StyleSheet,
   compiler: Compiler
 ): string {
-  const className = webStyle.flush(resolvedAttrs, styleSheet, compiler);
-
-  if (__DEV__ && React.useDebugValue) {
-    React.useDebugValue(className);
-  }
-
-  return className;
+  return webStyle.flush(resolvedAttrs, styleSheet, compiler);
 }
 
 /**
@@ -572,12 +566,13 @@ function useImpl<Props extends BaseObject>(
     if (IS_RSC) {
       generatedStyle = rscFlush(webStyle, context, ssc.styleSheet, ssc.compiler);
       generatedClassName = generatedStyle.className;
-      if (__DEV__ && React.useDebugValue) {
-        React.useDebugValue(generatedClassName);
-      }
     } else {
       generatedClassName = useInjectedStyle(webStyle, context, ssc.styleSheet, ssc.compiler);
     }
+  }
+
+  if (__DEV__ && React.useDebugValue) {
+    React.useDebugValue(generatedClassName);
   }
 
   if (__DEV__ && forwardedComponent.warnTooManyClasses) {


### PR DESCRIPTION
Fixes a rules-of-hooks violation introduced in #5704. `useDebugValue(generatedClassName)` was inside `useInjectedStyle`, which is only called on a cache miss. On a cache-hit re-render the call was skipped, producing an inconsistent hook count between renders. Moved it unconditionally after the cache if/else block in `useStyledComponentImpl`.