### PR TITLE
fix(types): cut type-instantiation cost for polymorphic styled components

### DIFF
--- a/.changeset/polymorphic-callprops-type-perf.md
+++ b/.changeset/polymorphic-callprops-type-perf.md
@@ -1,0 +1,5 @@
+---
+"styled-components": patch
+---
+
+Reduce TypeScript type-checking cost for styled components, most noticeably `styled(Component)` wrappers and polymorphic `as` usage. Large codebases that saw elevated `tsc` memory and type-instantiation counts get lower type-check memory and time, with no change to the emitted types or runtime behavior.

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -179,6 +179,11 @@ export interface IStyledStatics<
     | undefined;
 }
 
+/** ExecutionProps sans as/forwardedAs, pre-resolved so call sites relate against a concrete interface. */
+interface ThemedExecutionProps {
+  theme?: DefaultTheme | undefined;
+}
+
 /**
  * Used by PolymorphicComponent to define prop override cascading order.
  */
@@ -206,7 +211,7 @@ export type PolymorphicComponentProps<
       keyof ExecutionProps
     >
   > &
-    FastOmit<ExecutionProps, 'as' | 'forwardedAs'> & {
+    ThemedExecutionProps & {
       as?: AsTarget;
       forwardedAs?: ForwardedAsTarget;
     }
@@ -233,25 +238,46 @@ export type PolymorphicComponentProps<
  * here costs ~6% more type instantiations across all call sites. Don't narrow it
  * to bare `KnownTarget` -- that drops custom element strings (`as="my-element"`)
  * out of the target branch and makes them error.
+ *
+ * Structure notes (perf + inference; measured, do not "simplify"):
+ *  - The branching is split into TWO intersected conditionals whose other side
+ *    is `unknown` instead of one three-way conditional. While `AsTarget` /
+ *    `ForwardedAsTarget` are still uninferred, the checker probes a deferred
+ *    conditional through its default constraint, the union of both branches.
+ *    `union(Branch, unknown)` absorbs to `unknown`, so every probe against the
+ *    untaken side is free; a single three-way conditional instead walks the
+ *    heavy `as` branch at every plain call site (~45K extra instantiations per
+ *    1K call sites). Resolution after inference is identical to the three-way
+ *    form because `X & unknown` reduces to `X`.
+ *  - The leading `{ as?; forwardedAs? }` member exists because the absorbed
+ *    `unknown` constraint would otherwise leave `as="video"` with no contextual
+ *    type mid-inference, widening the literal to `string` and losing the target
+ *    branch. A flat object member restores per-attribute contextual typing and
+ *    literal preservation.
+ *  - Both discriminants are POSITIVE (`extends [string | AnyComponent]`), never
+ *    `[ForwardedAsTarget] extends [void]`. Spreading a styled component's own
+ *    props feeds `as?/forwardedAs?: WebTarget | undefined` back in as inference
+ *    candidates via the flat member; a positive test routes that wide shape to
+ *    the plain branch, keeping `ref` concrete for callback inference (#5687).
+ *    A negative void-test would route it to a target branch and defer `ref`.
  */
 type PolymorphicCallProps<
   R extends Runtime,
   BaseProps extends BaseObject,
   AsTarget extends StyledTarget<R> | (BaseProps extends { as?: infer A } ? A : never) | void,
   ForwardedAsTarget extends StyledTarget<R> | void,
-> = [AsTarget] extends [string | AnyComponent]
+> = { as?: AsTarget | undefined; forwardedAs?: ForwardedAsTarget | undefined } & ([
+  AsTarget,
+] extends [string | AnyComponent]
   ? PolymorphicComponentProps<R, BaseProps, AsTarget, ForwardedAsTarget> & { as: AsTarget }
-  : [ForwardedAsTarget] extends [void]
-    ? OverrideStyle<
-        NoInfer<FastOmit<BaseProps, keyof ExecutionProps>> &
-          FastOmit<ExecutionProps, 'as' | 'forwardedAs'> & {
-            as?: BaseProps extends { as?: infer A } ? A : void;
-            forwardedAs?: BaseProps extends { forwardedAs?: infer A } ? A : void;
-          }
-      >
-    : PolymorphicComponentProps<R, BaseProps, void, ForwardedAsTarget> & {
-        forwardedAs: ForwardedAsTarget;
-      };
+  : unknown) &
+  ([AsTarget] extends [string | AnyComponent]
+    ? unknown
+    : [ForwardedAsTarget] extends [string | AnyComponent]
+      ? PolymorphicComponentProps<R, BaseProps, void, ForwardedAsTarget> & {
+          forwardedAs: ForwardedAsTarget;
+        }
+      : OverrideStyle<NoInfer<FastOmit<BaseProps, keyof ExecutionProps>> & ThemedExecutionProps>);
 
 /**
  * This type forms the signature for a forwardRef-enabled component

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -218,48 +218,23 @@ export type PolymorphicComponentProps<
 >;
 
 /**
- * Resolves the call-site props for one usage of a polymorphic component,
- * branching on the supplied `as` / `forwardedAs` targets into the three prior
- * overload shapes:
- *  - `as` is a real render target (e.g. `as="video"`, `as={Component}`):
- *    substitute that target's props and require `as`.
- *  - no `as`, or `as` is the wrapped component's own non-target type (e.g.
- *    Next.js Link's `as?: Url`): Substitute-free base props so ref callbacks
- *    infer with spread props (#5687), the wrapped `as` type stays assignable and
- *    optional (#5734), and BaseProps keys keep completing for plain usage (#5741).
- *  - `forwardedAs` only: substitute the forwarded target's props.
+ * Resolves the call-site props for one usage of a polymorphic component from its
+ * `as` / `forwardedAs` targets. An `as` render target substitutes that target's
+ * props and requires `as`; plain usage (or `as` being the wrapped component's own
+ * non-target type, e.g. Next.js Link's `as?: Url`) keeps Substitute-free base
+ * props so ref callbacks infer with spread props (#5687), the wrapped `as` stays
+ * assignable (#5734), and BaseProps keys keep completing (#5741); `forwardedAs`
+ * substitutes the forwarded target's props.
  *
- * Extracted to a named alias so identical (R, BaseProps, AsTarget,
- * ForwardedAsTarget) tuples dedupe across the many JSX call sites in an app.
+ * The target test is `string | AnyComponent`, not `KnownTarget`: narrowing it
+ * drops custom element strings (`as="my-element"`) out of the target branch.
  *
- * The target test is `string | AnyComponent`, not the broader `WebTarget`
- * (`KnownTarget | (string & {})`): both describe the same set (any string or
- * component), but comparing against the ~156 literal members of `KnownTarget`
- * here costs ~6% more type instantiations across all call sites. Don't narrow it
- * to bare `KnownTarget` -- that drops custom element strings (`as="my-element"`)
- * out of the target branch and makes them error.
- *
- * Structure notes (perf + inference; measured, do not "simplify"):
- *  - The branching is split into TWO intersected conditionals whose other side
- *    is `unknown` instead of one three-way conditional. While `AsTarget` /
- *    `ForwardedAsTarget` are still uninferred, the checker probes a deferred
- *    conditional through its default constraint, the union of both branches.
- *    `union(Branch, unknown)` absorbs to `unknown`, so every probe against the
- *    untaken side is free; a single three-way conditional instead walks the
- *    heavy `as` branch at every plain call site (~45K extra instantiations per
- *    1K call sites). Resolution after inference is identical to the three-way
- *    form because `X & unknown` reduces to `X`.
- *  - The leading `{ as?; forwardedAs? }` member exists because the absorbed
- *    `unknown` constraint would otherwise leave `as="video"` with no contextual
- *    type mid-inference, widening the literal to `string` and losing the target
- *    branch. A flat object member restores per-attribute contextual typing and
- *    literal preservation.
- *  - Both discriminants are POSITIVE (`extends [string | AnyComponent]`), never
- *    `[ForwardedAsTarget] extends [void]`. Spreading a styled component's own
- *    props feeds `as?/forwardedAs?: WebTarget | undefined` back in as inference
- *    candidates via the flat member; a positive test routes that wide shape to
- *    the plain branch, keeping `ref` concrete for callback inference (#5687).
- *    A negative void-test would route it to a target branch and defer `ref`.
+ * Load-bearing shape, do not simplify: two conditionals with `unknown` sibling
+ * branches (not one three-way conditional), a leading flat `{ as?; forwardedAs? }`
+ * member, and positive `extends [string | AnyComponent]` discriminants. Collapsing
+ * the conditionals, dropping the flat member, or using a `[void]` discriminant
+ * each regress plain-call-site cost, `as`-target completion, or ref-callback
+ * inference (#5687) respectively.
  */
 type PolymorphicCallProps<
   R extends Runtime,
@@ -300,12 +275,9 @@ export interface PolymorphicComponent<
     forwardedAs?: StyledTarget<R> | undefined;
   }
 > {
-  // A single call signature (not several overloads) so JSX attribute completion
-  // never collapses while an attribute is mid-typed. With multiple overloads, a
-  // partially-typed or unknown attribute matches none of them, overload
-  // resolution fails, and completion drops to nothing; one signature always
-  // resolves, so the rendered target's props keep autocompleting. The branching
-  // that preserves the prior overload shapes lives in `PolymorphicCallProps`.
+  // A single call signature, not overloads: with overloads a mid-typed JSX
+  // attribute matches none, resolution fails, and attribute completion drops. The
+  // prop-shape branching lives in `PolymorphicCallProps`.
   <
     AsTarget extends StyledTarget<R> | (BaseProps extends { as?: infer A } ? A : never) | void =
       void,


### PR DESCRIPTION
Fixes #5767.

6.4.3 introduced a TypeScript type-checking regression: every `styled(...)` call site began routing through a single three-way conditional whose `as`-target branch is instantiated even for plain, non-polymorphic usage. In codebases heavy on `styled(Component)` wrappers and polymorphic `as`, this inflated `tsc` instantiation counts and memory, up to out-of-memory in the worst cases.

This restructures the polymorphic call-props resolution so plain call sites stop paying for the `as`-target branch, with no change to the emitted types, the public API, or runtime behavior.

## Impact (synthetic fixtures, TS 5.9.3)

On a workload representative of the report (reused `styled(Component)` over wide discriminated-union props, plus `as` usage):

| | Instantiations | Memory |
| --- | --- | --- |
| 6.4.3 | 4.36M | 1022 MB |
| this PR | 3.05M (-30%) | 940 MB |
| 6.4.2 (pre-regression) | 2.96M | 782 MB |

That recovers ~94% of the regression on that shape. A plain-`styled.tag`-heavy workload shows a smaller -4.4%, since those sites barely regressed to begin with.

## How

The three-way conditional is split into two intersected conditionals whose untaken side is `unknown`. While the `as`/`forwardedAs` type parameters are still uninferred, the checker probes each conditional through its constraint union, and `union(branch, unknown)` absorbs to `unknown`, so plain sites no longer instantiate the heavy `as`-target branch on every probe. After inference the result is identical, because `X & unknown` reduces to `X`. A flat `{ as?; forwardedAs? }` member preserves per-attribute contextual typing (literal `as="video"` inference), and both discriminants are kept positive so spreading a styled component's own props stays branch-safe for ref-callback inference. The structure is load-bearing and documented inline so it is not "simplified" back into the slower form.

## Verification

No test changes were needed: behavior is identical. The full `test:types` suite, the ref-callback and polymorphic `as` type contracts, and JSX attribute autocompletion (including mid-typing `as`-target completion) all pass unchanged. The package's own type-check is clean.
