### PR TITLE
fix: preserve SSR styles and development diagnostics

### DIFF
--- a/.changeset/warn-unadoptable-server-styles.md
+++ b/.changeset/warn-unadoptable-server-styles.md
@@ -1,0 +1,7 @@
+---
+'styled-components': patch
+---
+
+A development warning fires when server-rendered styles reach the browser inside a `<style>` tag that React manages through its `precedence` attribute. React serves such a tag under its own attributes, so styled-components cannot recognize the styles as its own and injects every rule a second time on the client. The page still looks correct, which is why this goes unnoticed, and the warning names the fix: emit the tag from `ServerStyleSheet#getStyleElement()` and pass neither `precedence` nor `href`.
+
+The warning covers server styles found in the document or in a shadow root at the moment styles are adopted. Styles that arrive later, such as those flushed for a Suspense boundary that resolves after adoption, are outside its reach.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
+NOTE: This file is the only home for these instructions. CLAUDE.md is a one-line pointer to it, intentionally a regular file rather than a symlink; leave it that way and never move content into it.
 
 ## CSS surface
 
@@ -83,10 +83,10 @@ NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
 - `pnpm --filter sandbox dev`: Start Next.js dev server
 - `pnpm --filter styled-components test:web`: Test web build
 - `pnpm --filter styled-components test:native`: Test React Native
-- `pnpm --filter styled-components bench`: Run all benchmarks (web + native + RSC)
-- `pnpm --filter styled-components bench:web`: Run web benchmarks (`parser-pipeline`, `parser-strategies`, `responsive`, `v6-vs-v7`). The `parser-pipeline` suite measures in-house parse+emit throughput only.
+- `pnpm --filter styled-components bench`: `bench:web` then `bench:rsc`
+- `pnpm --filter styled-components bench:web`: Every suite under `src/bench/` matched by `jest.config.bench.js` (`*.bench.test.*`, `web*.test.*`, `preprocess*.test.*`). Each file's header docblock states what it measures, so a new suite joins the run by matching one of those patterns. Do not enumerate the suites here; that list has already drifted twice.
 - `pnpm --filter styled-components bench:web:stress`: Stress benchmarks only (`src/bench/web.test.js`); uses `SC_BENCH_ITER_SCALE=0.2` and `SC_BENCH_RUNS=3` for quicker runs
-- `pnpm --filter styled-components bench:rsc`: RSC benchmarks (renderToString + dedup + React baseline)
+- `pnpm --filter styled-components bench:rsc`: `src/bench/rsc.test.tsx`, matched by `jest.config.bench-rsc.js` (node environment, `IS_RSC` server path)
 - Native render perf: use `packages/ios-benchmark` (real Hermes V1 on iOS sim). The previous in-tree native React-rendering bench was retired; `react-test-renderer` 19.2 + RN preset doesn't synchronously invoke function components, and the V8 numbers wouldn't predict Hermes anyway. Algorithm-shape benches (parser, responsive, RSC) still run via `bench:web` / `bench:rsc`.
 
 ## Profiling (Bun)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+This project's instructions live in AGENTS.md. Read that file; nothing else is here.

--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -19,7 +19,10 @@ The `__DEV__` and `__*` build-constant scheme is load-bearing for both correctne
 
 Two entries are not plain literals:
 
-- `__DEV__` "deferred" means the bundle substitutes the string `process.env.NODE_ENV !== 'production'` rather than a literal. The consumer's bundler then folds `NODE_ENV` and DCEs the dead branch on the consumer side. Only the two standalone bundles ship a hard `true` / `false`, since they are prebuilt and minified here with no downstream bundler to defer to.
+- `__DEV__` "deferred" means the bundle substitutes the string `(process.env.NODE_ENV !== 'production')` rather than a literal. The consumer's bundler then folds `NODE_ENV` and DCEs the dead branch on the consumer side. Only the two standalone bundles ship a hard `true` / `false`, since they are prebuilt and minified here with no downstream bundler to defer to.
+
+  The parentheses are load-bearing, because substitution is textual and the replacement is an expression, not a value. Without them `if (!__DEV__) return;` emits `if (!process.env.NODE_ENV !== 'production') return;`, which parses as `(!process.env.NODE_ENV) !== 'production'` and is therefore always true. Every such guard in the library inverts: warnings never fire and errors serve their terse production text in development. Nothing catches it upstream, since Jest defines `__DEV__` as a real boolean and source-level tests never see the substituted form. `treeshake.test.ts` locks it from the other end, asserting no emitted bundle contains `!process.env.NODE_ENV` and that a built bundle really does warn and throw readable errors.
+
 - `IS_RSC` is defined in `utils/isRsc.ts` as `typeof React.createContext === 'undefined'`. Every bundle except `server` replaces that exact expression with `false` (via a zero-delimiter `replace`), which DCEs both the branch and the `import React` in that file. The `server` bundle leaves the expression as a genuine runtime check, because a server build must detect an RSC environment at request time rather than at build time.
 
 ### Build-time `__*` versus runtime `IS_BROWSER`

--- a/packages/sandbox/app/lib/registry.tsx
+++ b/packages/sandbox/app/lib/registry.tsx
@@ -1,34 +1,21 @@
 'use client';
 
 import { useServerInsertedHTML } from 'next/navigation';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 
 export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
   const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
-  const chunkRef = useRef(0);
 
   useServerInsertedHTML(() => {
-    const css = styledComponentsStyleSheet.instance.toString();
+    const styles = styledComponentsStyleSheet.getStyleElement();
     styledComponentsStyleSheet.instance.clearTag();
-    if (!css) return null;
-
-    const chunk = chunkRef.current++;
-
-    return (
-      <style
-        precedence="styled-components"
-        href={`sc-registry-${chunk}`}
-        dangerouslySetInnerHTML={{ __html: css }}
-      />
-    );
+    return <>{styles}</>;
   });
 
   if (typeof window !== 'undefined') return <>{children}</>;
 
   return (
-    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
-      {children as any}
-    </StyleSheetManager>
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>{children}</StyleSheetManager>
   );
 }

--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -38,6 +38,14 @@ const esm = {
 const getCJS = override => ({ ...cjs, ...override });
 const getESM = override => ({ ...esm, ...override });
 
+/**
+ * `__DEV__` for the bundles that leave the decision to the consumer's bundler.
+ * The parentheses are load-bearing: substitution is textual, so a bare
+ * comparison rebinds under any tighter operator and silently inverts
+ * `!__DEV__`.
+ */
+const DEFERRED_DEV = "(process.env.NODE_ENV !== 'production')";
+
 const defaultTypescriptPlugin = typescript({
   // The build breaks if the tests are included by the typescript plugin.
   // Since un-excluding them in tsconfig.json, we must explicitly exclude them
@@ -193,7 +201,7 @@ const serverConfig = {
       __SERVER__: JSON.stringify(true),
       __NATIVE__: JSON.stringify(false),
       __NATIVE_WEB__: JSON.stringify(false),
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: DEFERRED_DEV,
     }),
     minifierPlugin
   ),
@@ -210,7 +218,7 @@ const browserConfig = {
       __SERVER__: JSON.stringify(false),
       __NATIVE__: JSON.stringify(false),
       __NATIVE_WEB__: JSON.stringify(false),
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: DEFERRED_DEV,
     }),
     replace({
       delimiters: ['', ''],
@@ -259,7 +267,7 @@ const nativeConfig = {
       __SERVER__: JSON.stringify(false),
       __NATIVE__: JSON.stringify(true),
       __NATIVE_WEB__: JSON.stringify(false),
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: DEFERRED_DEV,
     }),
     minifierPlugin,
   ],
@@ -274,7 +282,7 @@ const pluginsConfig = {
       __SERVER__: JSON.stringify(false),
       __NATIVE__: JSON.stringify(false),
       __NATIVE_WEB__: JSON.stringify(false),
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: DEFERRED_DEV,
     }),
     replace({
       delimiters: ['', ''],
@@ -303,7 +311,7 @@ const reanimatedConfig = {
       __SERVER__: JSON.stringify(false),
       __NATIVE__: JSON.stringify(true),
       __NATIVE_WEB__: JSON.stringify(false),
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: DEFERRED_DEV,
     }),
     minifierPlugin,
   ],
@@ -340,7 +348,7 @@ const webBridgeConfig = {
       __SERVER__: JSON.stringify(false),
       __NATIVE__: JSON.stringify(false),
       __NATIVE_WEB__: JSON.stringify(true),
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: DEFERRED_DEV,
     }),
     minifierPlugin,
   ],

--- a/packages/styled-components/src/bench/web.test.js
+++ b/packages/styled-components/src/bench/web.test.js
@@ -4,7 +4,7 @@
  * Run this file only (with reduced iterations for faster / CI-friendly runs):
  *   pnpm --filter styled-components bench:web:stress
  *
- * Full web bench suite (parser, preprocess, v6 vs v7, responsive, etc.):
+ * Full web bench suite:
  *   pnpm --filter styled-components bench:web
  *
  * Optional env (see bench-utils.ts): SC_BENCH_ITER_SCALE, SC_BENCH_RUNS

--- a/packages/styled-components/src/sheet/Rehydration.ts
+++ b/packages/styled-components/src/sheet/Rehydration.ts
@@ -1,5 +1,6 @@
 import { SC_ATTR, SC_ATTR_ACTIVE, SC_ATTR_VERSION, SC_VERSION, SPLITTER } from '../constants';
 import { InsertionTarget } from '../types';
+import { warnOnce } from '../utils/warnOnce';
 import { idForGroup, setGroupForId } from './GroupIDAllocator';
 import { Sheet } from './types';
 
@@ -108,6 +109,27 @@ const rehydrateSheetFromTag = (sheet: Sheet, style: HTMLStyleElement) => {
   }
 };
 
+/**
+ * A `<style>` that opts into React's `precedence` hoisting reaches the DOM
+ * under React's own attributes, without the ones {@link SELECTOR} keys on, so
+ * the rules it carries can never be adopted and get injected a second time on
+ * the client. The group markers survive inside the CSS text, which is what
+ * distinguishes our stripped styles from another library's hoisted ones.
+ */
+const warnOnUnadoptableStyles = (container: Document | ShadowRoot) => {
+  const nodes = container.querySelectorAll<HTMLStyleElement>('style[data-precedence]');
+
+  for (let i = 0, l = nodes.length; i < l; i++) {
+    if ((nodes[i].textContent ?? '').indexOf(SC_ATTR + '.g') > -1) {
+      warnOnce(
+        'rehydration-precedence-style',
+        'server-rendered styles arrived in a <style> tag React manages through `precedence`, which strips the attributes needed to adopt them, so every rule is injected again on the client. Render the tag from `ServerStyleSheet#getStyleElement()` with no `precedence` or `href` prop.'
+      );
+      return;
+    }
+  }
+};
+
 export const rehydrateSheet = (sheet: Sheet) => {
   const container = getRehydrationContainer(sheet.options.target);
   const nodes = container.querySelectorAll<HTMLStyleElement>(SELECTOR);
@@ -121,5 +143,9 @@ export const rehydrateSheet = (sheet: Sheet) => {
         node.parentNode.removeChild(node);
       }
     }
+  }
+
+  if (__DEV__) {
+    warnOnUnadoptableStyles(container);
   }
 };

--- a/packages/styled-components/src/sheet/test/Rehydration.test.tsx
+++ b/packages/styled-components/src/sheet/test/Rehydration.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { ServerStyleSheet, StyleSheetManager } from '../../base';
 import { SC_ATTR, SC_ATTR_ACTIVE, SC_ATTR_VERSION, SC_VERSION } from '../../constants';
 import { resetStyled } from '../../test/utils';
+import { resetWarnOnce } from '../../utils/warnOnce';
 import * as GroupIDAllocator from '../GroupIDAllocator';
 import { outputSheet, rehydrateSheet } from '../Rehydration';
 import StyleSheet from '../Sheet';
@@ -143,6 +144,118 @@ describe('rehydrateSheet', () => {
 
     const sheet = new StyleSheet({ isServer: true });
     rehydrateSheet(sheet);
+  });
+
+  /**
+   * A `<style>` given both `precedence` and `href` becomes a React hoistable
+   * resource. React re-emits it from a fixed `data-precedence` + `data-href`
+   * template and reads only `children` / `dangerouslySetInnerHTML` off the
+   * props, so `data-styled` and `data-styled-version` cannot survive however
+   * they were spelled. Shape confirmed against react-dom 19.2.3.
+   */
+  describe('server styles React hoisted via precedence', () => {
+    let warn: jest.SpyInstance;
+
+    const emitHoistedTag = () => {
+      document.head.innerHTML = `
+        <style data-precedence="styled-components" data-href="sc-registry-0">
+          .a {}/*!sc*/
+          ${SC_ATTR}.g11[id="idA"]{content:"nameA,"}/*!sc*/
+        </style>
+      `;
+      return document.head.querySelector('style')!;
+    };
+
+    beforeEach(() => {
+      resetWarnOnce();
+      warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    it('leaves the rules unadopted and the tag in place', () => {
+      const node = emitHoistedTag();
+      const sheet = new StyleSheet({ isServer: true });
+
+      rehydrateSheet(sheet);
+
+      expect(GroupIDAllocator.idForGroup(11)).toBe(undefined);
+      expect(sheet.hasNameForId('idA', 'nameA')).toBe(false);
+      expect(sheet.getTag().tag.length).toBe(0);
+      // React owns the tag as a permanent resource, so the rules it holds
+      // stay in the document alongside whatever the client injects.
+      expect(node.parentElement).toBe(document.head);
+    });
+
+    it('warns and names the alternative', () => {
+      emitHoistedTag();
+
+      rehydrateSheet(new StyleSheet({ isServer: true }));
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"[sc] server-rendered styles arrived in a <style> tag React manages through \`precedence\`, which strips the attributes needed to adopt them, so every rule is injected again on the client. Render the tag from \`ServerStyleSheet#getStyleElement()\` with no \`precedence\` or \`href\` prop."`
+      );
+    });
+
+    it('warns once however many sheets rehydrate', () => {
+      emitHoistedTag();
+
+      rehydrateSheet(new StyleSheet({ isServer: true }));
+      rehydrateSheet(new StyleSheet({ isServer: true }));
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays silent when the marker attributes survived', () => {
+      document.head.innerHTML = `
+        <style ${SC_ATTR} ${SC_ATTR_VERSION}="${SC_VERSION}">
+          .a {}/*!sc*/
+          ${SC_ATTR}.g11[id="idA"]{content:"nameA,"}/*!sc*/
+        </style>
+      `;
+      const sheet = new StyleSheet({ isServer: true });
+
+      rehydrateSheet(sheet);
+
+      expect(sheet.hasNameForId('idA', 'nameA')).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('stays silent for another library\u2019s precedence styles', () => {
+      document.head.innerHTML = `
+        <style data-precedence="high" data-href="some-other-library">
+          .not-ours { color: red; }
+        </style>
+      `;
+
+      rehydrateSheet(new StyleSheet({ isServer: true }));
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when there are no server styles at all', () => {
+      document.head.innerHTML = '';
+
+      rehydrateSheet(new StyleSheet({ isServer: true }));
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn in a production build', () => {
+      emitHoistedTag();
+      (global as { __DEV__: boolean }).__DEV__ = false;
+
+      try {
+        rehydrateSheet(new StyleSheet({ isServer: true }));
+      } finally {
+        (global as { __DEV__: boolean }).__DEV__ = true;
+      }
+
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 
   describe('Shadow DOM support', () => {

--- a/packages/styled-components/src/test/rehydration.test.tsx
+++ b/packages/styled-components/src/test/rehydration.test.tsx
@@ -215,6 +215,50 @@ describe('rehydration', () => {
     });
   });
 
+  describe('with server styles React hoisted via precedence', () => {
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+      /* Same CSS as the adoptable case, but a `<style>` carrying `precedence`
+       * and `href` reaches the browser under React's own
+       * `data-precedence` / `data-href` attributes, so the markers we key on
+       * are gone. */
+      document.head.innerHTML = `
+        <style data-precedence="styled-components" data-href="sc-registry-0">
+          .b { color: red; }/*!sc*/
+          ${SC_ATTR}.g2[id="TWO"]{content: "b,"}/*!sc*/
+        </style>
+      `;
+
+      warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      rehydrateTestStyles();
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    it('injects a second copy of a rule the server already sent', () => {
+      seedNextClassnames(['b']);
+      const Comp = styled.div.withConfig({ componentId: 'TWO' })`
+        color: red;
+        ${() => ''}
+      `;
+      render(<Comp />);
+      expect(getRenderedCSS()).toMatchInlineSnapshot(`
+        ".b {
+          color: red;
+        }
+        data-styled.g2[id="TWO"] {
+          content: "b,";
+        }
+        .b {
+          color: red;
+        }"
+      `);
+    });
+  });
+
   describe('with global styles', () => {
     beforeEach(() => {
       /* Adding a non-local stylesheet with a hash 557410406 which is

--- a/packages/styled-components/src/test/treeshake.test.ts
+++ b/packages/styled-components/src/test/treeshake.test.ts
@@ -88,6 +88,55 @@ describe('dead-code elimination: standalone production build', () => {
   });
 });
 
+/**
+ * `__DEV__` is substituted textually, so the replacement has to be
+ * parenthesized. A bare `process.env.NODE_ENV !== 'production'` rebinds under
+ * any tighter operator: `!__DEV__` becomes `(!process.env.NODE_ENV) !==
+ * 'production'`, which is always true, so every `if (!__DEV__) return;` guard
+ * in the library inverts. That silences every warning and serves production
+ * error text in development, and neither the build nor the source-level tests
+ * can see it, because Jest defines `__DEV__` as a real boolean.
+ */
+describe('__DEV__ substitution in built output', () => {
+  const jsFiles = (dir: string) =>
+    fs
+      .readdirSync(dir)
+      .filter(file => file.endsWith('.js'))
+      .sort();
+
+  it.each(jsFiles(distDir))('leaves no rebound negation in %s', file => {
+    expect(read(file)).not.toContain('!process.env.NODE_ENV');
+  });
+
+  it.each(jsFiles(nativeDistDir))('leaves no rebound negation in native/%s', file => {
+    expect(readNative(file)).not.toContain('!process.env.NODE_ENV');
+  });
+
+  it('throws readable errors outside production', () => {
+    const { ServerStyleSheet } = require(path.join(distDir, 'styled-components.cjs.js'));
+    const sheet = new ServerStyleSheet();
+    sheet.seal();
+
+    // The catalog text, not the terse production form that only links to it.
+    expect(() => sheet.getStyleTags()).toThrow(/one off instance for each server-side render/);
+    expect(() => sheet.getStyleTags()).not.toThrow(/An error occurred\. See https/);
+  });
+
+  it('emits warnings outside production', () => {
+    const { createTheme } = require(path.join(distDir, 'styled-components.cjs.js'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      createTheme({ shadow: 'drop-shadow(0 0 2px' });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('unbalanced parentheses');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
 describe('native build isolation', () => {
   let nativeCJS: string;
   let nativeESM: string;


### PR DESCRIPTION
## Summary
- Emit sandbox SSR styles with the supported `ServerStyleSheet` output so hydration adopts each rule once.
- Warn when React-managed `precedence` styles have lost the markers needed for adoption.
- Preserve development warnings and readable errors in built bundles by making the deferred `__DEV__` expression safe for textual substitution.
- Replace the agent-instruction symlink with a plain-text pointer and derive benchmark documentation from the owning Jest matchers.
- Add a patch changeset and regression coverage for rehydration and emitted bundles.

Related to #5607.

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter styled-components test:web`
- [x] `pnpm --filter styled-components test:native`
- [x] `pnpm exec tsc --noEmit -p packages/sandbox/tsconfig.json`
- [x] Load the sandbox and exercise its SSR pages in a browser