### PR TITLE
fix(release-notes): announce changesets edited after the previous tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "prettier . --check",
     "size": "pnpm --filter styled-components size",
     "test": "pnpm --filter styled-components test",
-    "test:changeset-changelog": "node --test scripts/release-notes/changelog.test.ts scripts/release-notes/prerelease-aggregation.test.ts",
+    "test:changeset-changelog": "node --test \"scripts/release-notes/*.test.ts\"",
     "dry-run:prerelease-notes": "node scripts/release-notes/build-prerelease-release-notes.ts"
   },
   "author": "Glen Maddern",

--- a/scripts/release-notes/build-prerelease-release-notes.ts
+++ b/scripts/release-notes/build-prerelease-release-notes.ts
@@ -1,19 +1,20 @@
 /**
- * Emits per-package prerelease GitHub release notes (Markdown). Shallow clones need
- * full history (`fetch-depth: 0` in CI, or `git fetch --unshallow`) for tag and
- * ancestry queries to match real runs.
+ * Emits per-package prerelease GitHub release notes (Markdown). A pending changeset
+ * is announced when its last-change commit is not contained in the package's
+ * previous release tag, so editing a pending changeset re-announces it. Shallow
+ * clones need full history (`fetch-depth: 0` in CI, or `git fetch --unshallow`)
+ * for tag and ancestry queries to match real runs.
  */
 
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import * as changesetsGit from '@changesets/git';
 import readChangesets from '@changesets/read';
 
 import type { ChangelogOptions } from './changelog.ts';
 import changelog from './changelog.ts';
-import { createDefaultGitAdapter } from './default-git-adapter.ts';
+import { createDefaultGitAdapter, getLastChangesetCommits } from './default-git-adapter.ts';
 import { groupChangesetsByPackageAndType } from './prerelease-grouping.ts';
 
 type PkgJson = { name: string; private?: boolean; version: string };
@@ -119,13 +120,9 @@ export async function buildPrereleaseReleaseNotes(options: {
 
   const changesets = await readChangesets(cwd);
   if (changesets.length) {
-    const paths = changesets.map(c => `.changeset/${c.id}.md`);
-    const shaList = await changesetsGit.getCommitsThatAddFiles(paths, {
-      cwd,
-      short: true,
-    });
-    for (let i = 0; i < changesets.length; i++) {
-      changesets[i].commit = shaList[i] || undefined;
+    const lastCommits = getLastChangesetCommits(cwd);
+    for (const cs of changesets) {
+      cs.commit = lastCommits.get(`.changeset/${cs.id}.md`) || undefined;
     }
   }
 
@@ -192,8 +189,10 @@ async function main(): Promise<void> {
   console.error(`Wrote prerelease notes to ${out} (RELEASE_NOTES_OUTPUT_DIR overrides path).`);
 }
 
-const invoked = typeof process.argv[1] === 'string' ? resolve(process.argv[1]) : '';
-const script = resolve(fileURLToPath(import.meta.url));
+// realpath both sides: invoking through a symlinked path (macOS /tmp -> /private/tmp)
+// otherwise compares unequal and main() never runs.
+const invoked = typeof process.argv[1] === 'string' ? realpathSync(resolve(process.argv[1])) : '';
+const script = realpathSync(resolve(fileURLToPath(import.meta.url)));
 if (invoked === script) {
   main().catch(err => {
     console.error(err);

--- a/scripts/release-notes/default-git-adapter.ts
+++ b/scripts/release-notes/default-git-adapter.ts
@@ -1,6 +1,36 @@
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 import type { GitPrereleaseAdapter } from './prerelease-grouping.ts';
+
+/**
+ * Most recent commit touching each `.changeset/*.md`, keyed by repo-relative path.
+ * One `git log` walk, newest first, so a path's first occurrence wins. Gating on
+ * the last-change commit (rather than the add commit) re-announces a pending
+ * changeset whose content was edited after the previous release tag.
+ */
+export function getLastChangesetCommits(cwd: string): Map<string, string> {
+  let out: string;
+  try {
+    out = execFileSync(
+      'git',
+      ['log', '--format=%x1e%h', '--name-only', '--first-parent', '-m', '--', '.changeset/'],
+      { cwd, encoding: 'utf8' }
+    );
+  } catch {
+    return new Map();
+  }
+
+  const byPath = new Map<string, string>();
+  let sha = '';
+  for (const line of out.split('\n')) {
+    if (line.startsWith('\x1e')) {
+      sha = line.slice(1);
+    } else if (line && !byPath.has(line)) {
+      byPath.set(line, sha);
+    }
+  }
+  return byPath;
+}
 
 /** Full git history (`fetch-depth: 0`) is needed for accurate tag ancestry. */
 export function createDefaultGitAdapter(cwd: string): GitPrereleaseAdapter {

--- a/scripts/release-notes/last-change-commits.test.ts
+++ b/scripts/release-notes/last-change-commits.test.ts
@@ -1,0 +1,63 @@
+import { execFileSync } from 'node:child_process';
+import assert from 'node:assert';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { createDefaultGitAdapter, getLastChangesetCommits } from './default-git-adapter.ts';
+
+/**
+ * Builds a scratch git repo exercising the release-notes gate the way CI hits it:
+ * a changeset added before the previous tag, then edited after it. The edit must
+ * re-announce the changeset; the old add-commit gating dropped it silently.
+ */
+function initRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sc-release-notes-'));
+  const git = (args: string[]): string =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim();
+  git(['init', '-b', 'main']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+  mkdirSync(join(dir, '.changeset'));
+  return dir;
+}
+
+test('last-change commits: edited changeset resolves its edit commit, not its add commit', () => {
+  const dir = initRepo();
+  const git = (args: string[]): string =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim();
+
+  writeFileSync(join(dir, '.changeset/edited-later.md'), "---\n'pkg-a': patch\n---\nv1\n");
+  writeFileSync(join(dir, '.changeset/untouched.md'), "---\n'pkg-a': patch\n---\nstable\n");
+  git(['add', '.changeset']);
+  git(['commit', '-m', 'add changesets']);
+  const addSha = git(['rev-parse', '--short', 'HEAD']);
+  const prevTag = 'pkg-a@1.0.0-prerelease-1';
+  git(['tag', prevTag]);
+
+  writeFileSync(join(dir, '.changeset/edited-later.md'), "---\n'pkg-a': minor\n---\nv2\n");
+  git(['add', '.changeset']);
+  git(['commit', '-m', 'edit changeset']);
+  const editSha = git(['rev-parse', '--short', 'HEAD']);
+
+  writeFileSync(join(dir, '.changeset/uncommitted.md'), "---\n'pkg-a': patch\n---\nnew\n");
+
+  const commits = getLastChangesetCommits(dir);
+  assert.strictEqual(commits.get('.changeset/edited-later.md'), editSha);
+  assert.strictEqual(commits.get('.changeset/untouched.md'), addSha);
+  assert.strictEqual(commits.get('.changeset/uncommitted.md'), undefined);
+
+  const adapter = createDefaultGitAdapter(dir);
+  assert.strictEqual(adapter.getLatestPackageTag('pkg-a'), prevTag);
+  assert.strictEqual(adapter.isCommitAncestorOfTag(editSha, prevTag), false);
+  assert.strictEqual(adapter.isCommitAncestorOfTag(addSha, prevTag), true);
+});
+
+test('last-change commits: repo without changeset history yields an empty map', () => {
+  const dir = initRepo();
+  writeFileSync(join(dir, 'README.md'), 'hi\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: dir });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd: dir });
+  assert.deepStrictEqual([...getLastChangesetCommits(dir).entries()], []);
+});

--- a/scripts/release-notes/prerelease-grouping.ts
+++ b/scripts/release-notes/prerelease-grouping.ts
@@ -9,6 +9,7 @@ export interface ReleaseEntry {
 
 export interface ChangesetWithCommit {
   id: string;
+  /** Last commit that touched the changeset file; undefined when uncommitted. */
   commit?: string;
   summary: string;
   releases: ReleaseEntry[];


### PR DESCRIPTION
## Summary

- Prerelease notes gated on the commit that first added each changeset file, so a pending changeset edited after the previous release read as already announced and was silently dropped. `styled-components@7.0.0-prerelease-20260730182544` shipped "No new changes" while landing the prefix-plugin changesets; the same bug under-reported the 2026-05-19 and 2026-06-11 prereleases (33 and 63 edited changesets omitted).
- Gate on each changeset's last-change commit instead: a pending changeset is announced when its content changed since the package's previous tag, and untouched ones still announce exactly once. Resolution is one `git log --name-only` walk instead of a per-file query.
- The invoked-as-script guard compared `argv[1]` literally, so the builder exited silently when run from a symlinked path (macOS `/tmp` -> `/private/tmp`); both sides now go through `realpathSync`.
- `test:changeset-changelog` now globs `scripts/release-notes/*.test.ts` so a new test file can't be left out of the suite.

## Test plan

- [x] New `last-change-commits.test.ts` reproduces the failure in a scratch git repo (add -> tag -> edit -> the edit commit must resolve); full suite 13/13 green
- [x] Reproduced the 18:25 release locally against a pinned clone: old code emits "No new changes", fixed code emits exactly the two edited changesets
- [x] Regenerated and repaired the three affected release bodies on GitHub with the fixed builder (originals backed up under /tmp)