### PR TITLE
feat: buffered client injection and lazy element shorthands

### DIFF
--- a/.changeset/buffered-injection-default.md
+++ b/.changeset/buffered-injection-default.md
@@ -1,0 +1,9 @@
+---
+'styled-components': minor
+---
+
+Client styles inject through `useInsertionEffect`.
+
+Class names are still resolved during render so elements get the right `class` on the first paint, but the stylesheet write runs in the insertion effect after React commits. Discarded concurrent renders no longer leave rules in the document, and a committed update still gets its rules even when an earlier concurrent attempt for the same styles was discarded. Blocking updates (concurrent features off) behave the same: styles apply on commit, not mid-render.
+
+`ServerStyleSheet` SSR and React Server Components still flush during render, where insertion effects do not run.

--- a/.changeset/lazy-element-shorthands.md
+++ b/.changeset/lazy-element-shorthands.md
@@ -1,0 +1,9 @@
+---
+'styled-components': minor
+---
+
+Smaller bundles: `styled.div` and every other element shorthand is built the first time it is read, so an app ships no table of element names and pays only for the tags it uses.
+
+`styled.div`, `styled.feBlend` and the rest behave exactly as before, including returning the same component factory on repeated reads, and `'div' in styled` still answers `true`. Two things differ if you inspect `styled` itself: `Object.keys(styled)` no longer lists every tag, and reading a lowercase name that is not a standard element (`styled.blink`) now hands back a working factory rather than `undefined`, matching what `styled('blink')` has always done. CamelCase probes such as `toJSON` stay undefined.
+
+Published bundles are also emitted as ES2020 rather than ES2015. Every supported peer (React 19, React Native 0.85, Node 16) runs that syntax natively.

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ packages/styled-components/src/parser/wpt-corpus/raw/
 # Local prerelease release-notes dry-run (see scripts/release-notes)
 .dry-run-release-notes/
 
+# Concurrent responsiveness headless matrix JSON dumps
+packages/benchmarks/headless/out/
+

--- a/docs/rendering-flow.md
+++ b/docs/rendering-flow.md
@@ -31,12 +31,13 @@ sequenceDiagram
     useImpl->>StyleSheetManager: useStyleSheetContext()
     StyleSheetManager-->>useImpl: styleSheet, compiler, shouldForwardProp
 
-    Note over useImpl,WebStyle: 3. STYLE PROCESSING
+    Note over useImpl,WebStyle: 3. STYLE PROCESSING (render)
     useImpl->>useImpl: render-cache check (fast skip on shallow-equal props/theme)
     useImpl->>useImpl: resolveContext(attrs, props, theme)
-    useImpl->>WebStyle: flush(context, styleSheet, compiler)
+    useImpl->>WebStyle: generate(context, styleSheet, compiler)
     WebStyle->>WebStyle: evaluateForFastPath (fill sentinels in pre-built AST)
     WebStyle->>WebStyle: buildInterpKey -> interpKeyCache lookup
+    WebStyle->>StyleSheet: claimNameForId (turn-scoped; stash rules for siblings)
     Note over WebStyle: Cache hit returns prior class name<br/>without re-emitting CSS
 
     alt cache miss
@@ -46,38 +47,28 @@ sequenceDiagram
         WebStyle->>WebStyle: compiler.emit (AST-direct)
     end
 
-    Note over WebStyle,DOM: 4. STYLE INJECTION
-    WebStyle->>StyleSheet: insertRules(componentId, className, rules)
-    StyleSheet->>StyleSheet: registerName(componentId, className)
-    StyleSheet->>GroupedTag: getTag().insertRules(groupId, rules)
-    GroupedTag->>GroupedTag: indexOfGroup(groupId)
-    Note over GroupedTag: Calculate insertion index<br/>based on group priority
+    WebStyle-->>useImpl: GeneratedStyle (className + rules)
 
-    GroupedTag->>Tag: insertRule(index, rule)
-
-    alt Browser
+    Note over useImpl,DOM: 4. STYLE INJECTION
+    alt Browser client (buffered)
+        useImpl->>useImpl: mount StyleInjector when rules are unwritten
+        Note over useImpl,React: commit: useInsertionEffect
+        useImpl->>WebStyle: inject(styleSheet, generated)
+        WebStyle->>StyleSheet: insertRules (hasNameForId dedupes)
+        StyleSheet->>GroupedTag: getTag().insertRules(groupId, rules)
+        GroupedTag->>Tag: insertRule(index, rule)
         Tag->>DOM: CSSStyleSheet.insertRule(rule, index)
-    else Server (Virtual)
-        Tag->>Tag: rules.push(rule)
-    end
-
-    Tag-->>GroupedTag: success
-    GroupedTag-->>StyleSheet: complete
-    StyleSheet-->>WebStyle: complete
-
-    WebStyle-->>useImpl: className
-
-    Note over useImpl,DOM: 5. ELEMENT CREATION
-    useImpl->>useImpl: buildClassName(foldedIds + styledId + generated + props)
-    useImpl->>useImpl: rawElement(type, props, ref)
-    Note over useImpl: Bypasses React.createElement<br/>overhead (~60-120x faster)
-
-    alt RSC Mode
-        useImpl->>GroupedTag: getGroup() for inheritance chain + keyframes
-        useImpl->>useImpl: wrap base CSS in :where() for zero specificity
-        useImpl->>useImpl: emit Fragment with inline style tag + element
+    else ServerStyleSheet / sync server path
+        useImpl->>WebStyle: flush (generate + inject in one call)
+        WebStyle->>StyleSheet: insertRules
+        StyleSheet->>Tag: rules.push(rule)
+    else RSC Mode
+        useImpl->>useImpl: rscFlush + emit Fragment with inline style tag
         Note over useImpl: No precedence attr,<br/>avoids React 19 Float hoisting
     end
 
+    Note over useImpl,DOM: 5. ELEMENT CREATION
+    useImpl->>useImpl: buildClassName(foldedIds + styledId + generated + props)
+    useImpl->>useImpl: createElement(type, props)
     React-->>User: DOM element with injected styles
 ```

--- a/docs/typescript-performance.md
+++ b/docs/typescript-performance.md
@@ -68,13 +68,16 @@ type-check.
 
 `out` / `in out` on `Styled`, `PolymorphicComponent`, `IStyledComponentBase`, etc. reduce variance computation (-72%) and memory (-16%).
 
-### `domElements.forEach`
+### Element shorthands
 
-Uses `(styled as any)` cast; types are already declared via mapped type on the styled const, avoiding 120 redundant `Styled<>` instantiations.
+`styled.div` and friends are synthesized at runtime by a `Proxy`, and their types
+come from a single mapped type over `SupportedHTMLElements` asserted onto the
+`styled` const. Declaring them any other way (a per-element assignment, or typing
+the proxy target as the mapped type) instantiates `Styled<>` once per element.
 
 ### `KnownTarget` shape (don't re-narrow)
 
-The 153-element `SupportedHTMLElements | AnyComponent` union looks like an obvious
+The `SupportedHTMLElements | AnyComponent` union looks like an obvious
 target for narrowing. Don't. `ExecutionProps['as']: KnownTarget | undefined` is
 load-bearing for the contextual typing of `.attrs({ as: 'label' })`: the literal
 `'label'` only narrows against a union that includes `SupportedHTMLElements`. If

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -43,6 +43,24 @@ whereas others choose to use inline styles. Libraries without built-in support
 for dynamic styles (i.e., they rely on user-authored inline styles) are not
 included.
 
+### Concurrent CSS responsiveness
+
+Self-timed styled-components case that pits urgent input against a large
+transition-rendered tree (client injection uses `useInsertionEffect`). Reports
+Event Timing, CSSOM writes, and discarded renders rather than cycle throughput.
+
+Headed: pick `Concurrent CSS responsiveness`, then Run. Axes default to the
+adversarial cell (`unique` / `forced` / `interrupted`, ≥2500 cells) so
+interruption shows up without CPU throttle. Override via URL (`card`, `sel`,
+`layout`, `sched`, `cells`). Event Timing still needs the headless runner
+(`driver=external`).
+
+Headless matrix (serve `packages/benchmarks` on `127.0.0.1:8899` first):
+
+```sh
+node --expose-gc headless/concurrent.mjs --runs 3 --warmup 1 --throttle 2
+```
+
 ## Example results
 
 ### MacBook Pro (2011)

--- a/packages/benchmarks/headless/concurrent.mjs
+++ b/packages/benchmarks/headless/concurrent.mjs
@@ -1,0 +1,439 @@
+/**
+ * Controlled matrix runner for the concurrent CSS responsiveness case.
+ *
+ * Launches headless Chrome, throttles the CPU, and drives the case with
+ * trusted keystrokes over raw CDP (no puppeteer dependency; Node's built-in
+ * WebSocket). Each run gets a fresh page so sheet and class caches cannot
+ * leak across runs. Warmups are discarded.
+ *
+ * Usage:
+ *   node --expose-gc headless/concurrent.mjs [--runs 8] [--warmup 1] [--throttle 4]
+ *
+ * The benchmarks app must already be served on 127.0.0.1:8899
+ * (devctl `benchmarks` on this worktree, or any static server of packages/benchmarks).
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getMedian } from '../src/app/Benchmark/math.js';
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const BASE = 'http://127.0.0.1:8899/index.html';
+const KEYS = 24;
+const KEY_INTERVAL_MS = 60;
+const PROBE_KEYS = 6;
+const PROBE_KEY_INTERVAL_MS = 400;
+const SETTLE_MS = 700;
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((v, i, a) => [v.replace(/^--/, ''), a[i + 1]])
+);
+const RUNS = Number(args.runs ?? 8); // per cell, excluding warmups
+const WARMUP = Number(args.warmup ?? 1); // per cell
+const THROTTLE = Number(args.throttle ?? 4);
+
+const CELLS = [
+  // Adversarial: every discarded render would have written distinct rules.
+  { name: 'unique-forced', card: 'unique', sel: 'narrow', layout: 'forced', sched: 'interrupted' },
+  // Realistic dynamic: bounded cardinality, no forced reads. Prediction: parity.
+  { name: 'bounded-plain', card: 'bounded', sel: 'narrow', layout: 'none', sched: 'interrupted' },
+  // Fully cached control: no new classes at all. Prediction: parity, zero writes.
+  { name: 'zero-cached', card: 'zero', sel: 'narrow', layout: 'none', sched: 'interrupted' },
+];
+
+/* ---------------------------------------------------------------- *
+ * Minimal CDP client over the browser-level WebSocket.
+ * ---------------------------------------------------------------- */
+
+class CDP {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.pending = new Map();
+    ws.addEventListener('message', ev => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id !== undefined && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(msg.error.message));
+        else resolve(msg.result);
+      }
+    });
+  }
+
+  static async connect(url) {
+    const ws = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+      ws.addEventListener('open', resolve, { once: true });
+      ws.addEventListener('error', reject, { once: true });
+    });
+    return new CDP(ws);
+  }
+
+  send(method, params = {}, sessionId) {
+    const id = ++this.id;
+    const payload = { id, method, params };
+    if (sessionId) payload.sessionId = sessionId;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify(payload));
+    });
+  }
+
+  async evaluate(sessionId, expression, awaitPromise = false) {
+    const res = await this.send(
+      'Runtime.evaluate',
+      { expression, awaitPromise, returnByValue: true },
+      sessionId
+    );
+    if (res.exceptionDetails) {
+      throw new Error('page exception: ' + JSON.stringify(res.exceptionDetails).slice(0, 400));
+    }
+    return res.result ? res.result.value : undefined;
+  }
+}
+
+/* ---------------------------------------------------------------- *
+ * Chrome lifecycle.
+ * ---------------------------------------------------------------- */
+
+async function launchChrome() {
+  const profile = join(
+    tmpdir(),
+    `sc-concurrent-${process.pid}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  const proc = spawn(
+    CHROME,
+    [
+      '--headless=new',
+      '--remote-debugging-port=0',
+      `--user-data-dir=${profile}`,
+      '--no-first-run',
+      '--disable-extensions',
+      '--window-size=1200,800',
+      'about:blank',
+    ],
+    { stdio: ['ignore', 'ignore', 'pipe'] }
+  );
+
+  const wsUrl = await new Promise((resolve, reject) => {
+    let buf = '';
+    proc.stderr.on('data', d => {
+      buf += d;
+      const m = buf.match(/DevTools listening on (ws:\/\/\S+)/);
+      if (m) resolve(m[1]);
+    });
+    proc.on('exit', () =>
+      reject(new Error('chrome exited before DevTools URL: ' + buf.slice(0, 300)))
+    );
+    setTimeout(() => reject(new Error('timed out waiting for DevTools URL')), 15000);
+  });
+
+  return { proc, wsUrl, profile };
+}
+
+/** SIGTERM, then SIGKILL if the instance is still alive after the grace
+ *  period; wedged renderers can shrug off SIGTERM and spin at full CPU, and
+ *  a few of those accumulate into a machine-wide slowdown that wedges every
+ *  subsequent run. */
+async function killChrome(proc) {
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
+  proc.kill('SIGTERM');
+  const dead = await Promise.race([
+    new Promise(r => proc.once('exit', () => r(true))),
+    sleep(2500).then(() => false),
+  ]);
+  if (!dead) {
+    proc.kill('SIGKILL');
+    await Promise.race([new Promise(r => proc.once('exit', () => r(true))), sleep(1500)]);
+  }
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Positive control: prove trusted CDP keystrokes populate Event Timing on a
+ * trivial page before believing zeros from the real workload. Exits the
+ * matrix loudly if the instrument itself is blind.
+ */
+async function positiveControl(cdp, sessionId) {
+  await cdp.send(
+    'Page.navigate',
+    {
+      url:
+        'data:text/html,<input id=i autofocus><script>window.__n=-1;' +
+        'new PerformanceObserver(l=>{window.__n=l.getEntries().length}).observe({type:"event",durationThreshold:1});' +
+        'document.getElementById("i").focus();</script>',
+    },
+    sessionId
+  );
+  await sleep(500);
+  await cdp.evaluate(sessionId, `document.getElementById('i').focus()`);
+  await cdp.send(
+    'Input.dispatchKeyEvent',
+    {
+      type: 'rawKeyDown',
+      key: 'z',
+      code: 'KeyZ',
+      windowsVirtualKeyCode: 90,
+      nativeVirtualKeyCode: 90,
+    },
+    sessionId
+  );
+  await cdp.send(
+    'Input.dispatchKeyEvent',
+    { type: 'char', key: 'z', code: 'KeyZ', text: 'z' },
+    sessionId
+  );
+  await cdp.send(
+    'Input.dispatchKeyEvent',
+    { type: 'keyUp', key: 'z', code: 'KeyZ', windowsVirtualKeyCode: 90, nativeVirtualKeyCode: 90 },
+    sessionId
+  );
+  await sleep(500);
+  const probe = await cdp.evaluate(
+    sessionId,
+    `({obs: window.__n, buf: performance.getEntriesByType('event').length})`
+  );
+  process.stdout.write(
+    `[control] trusted key -> observer entries=${probe.obs} buffered entries=${probe.buf}\n`
+  );
+  if (probe.obs <= 0 && probe.buf <= 0) {
+    throw new Error('control failed: trusted keystroke produced no Event Timing entries');
+  }
+}
+
+/* ---------------------------------------------------------------- *
+ * One run: fresh page, trusted keystrokes, drained instrumentation.
+ * ---------------------------------------------------------------- */
+
+const RUN_WATCHDOG_MS = 120000;
+
+async function runOnce(cdp, sessionId, cell) {
+  const t0 = Date.now();
+  const step = name =>
+    process.stdout.write(`    [${((Date.now() - t0) / 1000).toFixed(1)}s] ${name}\n`);
+
+  const benchName = 'Concurrent CSS responsiveness';
+  const url =
+    `${BASE}?bench=${encodeURIComponent(benchName)}` +
+    `&card=${cell.card}&sel=${cell.sel}&layout=${cell.layout}` +
+    `&sched=${cell.sched}&driver=external`;
+  await cdp.send('Page.navigate', { url }, sessionId);
+  step('navigated');
+
+  // Poll for the runner API; the bench= param mounts the case directly.
+  const ready = await cdp.evaluate(
+    sessionId,
+    `(async () => {
+      for (let i = 0; i < 60; i++) {
+        if (window.__scBench) return true;
+        await new Promise(r => setTimeout(r, 100));
+      }
+      return false;
+    })()`,
+    true
+  );
+  if (!ready) throw new Error('case never mounted (__scBench absent after 6s)');
+  step('case mounted');
+
+  await cdp.evaluate(sessionId, `window.__scBench.start()`);
+  step('started');
+
+  // Two lanes, by design. The churn lane drives urgent + transition updates
+  // in-page at the fixed cadence. Latency evidence comes from sparse trusted
+  // CDP keys into the UNFOCUSED document: focusing the text field makes each
+  // trusted keystroke run native text-insertion machinery alongside the churn
+  // and wedges the renderer outright (reproduced in isolation, controlled and
+  // uncontrolled inputs alike), while unfocused keys record complete Event
+  // Timing entries (queue delay + processing + presentation) without it.
+  const churn = cdp.evaluate(
+    sessionId,
+    `(async () => {
+      for (let i = 1; i <= ${KEYS}; i++) {
+        window.__scBench.drive('q' + i);
+        await new Promise(r => setTimeout(r, ${KEY_INTERVAL_MS}));
+      }
+      return true;
+    })()`,
+    true
+  );
+
+  for (let k = 0; k < PROBE_KEYS; k++) {
+    const ch = String.fromCharCode(97 + k);
+    const code = 65 + k;
+    const events = [
+      {
+        type: 'rawKeyDown',
+        key: ch,
+        code: 'Key' + ch.toUpperCase(),
+        windowsVirtualKeyCode: code,
+        nativeVirtualKeyCode: code,
+      },
+      { type: 'char', key: ch, code: 'Key' + ch.toUpperCase(), text: ch },
+      {
+        type: 'keyUp',
+        key: ch,
+        code: 'Key' + ch.toUpperCase(),
+        windowsVirtualKeyCode: code,
+        nativeVirtualKeyCode: code,
+      },
+    ];
+    for (const params of events) {
+      cdp.send('Input.dispatchKeyEvent', params, sessionId).catch(() => {});
+    }
+    await sleep(PROBE_KEY_INTERVAL_MS);
+  }
+  step('probe keys sent');
+
+  await churn;
+  step('churn done');
+
+  await sleep(SETTLE_MS);
+  step('settled');
+  const report = await cdp.evaluate(sessionId, `window.__scBench.finish()`);
+  step('finished');
+  return report;
+}
+
+function withWatchdog(promise, label, capture) {
+  return Promise.race([
+    promise,
+    sleep(RUN_WATCHDOG_MS).then(async () => {
+      let evidence = 'no evidence (capture failed)';
+      try {
+        evidence = await Promise.race([capture(), sleep(8000).then(() => 'capture timed out')]);
+      } catch (e) {
+        evidence = 'capture threw: ' + String(e).slice(0, 200);
+      }
+      throw new Error(`watchdog: run exceeded ${RUN_WATCHDOG_MS / 1000}s (${label})\n${evidence}`);
+    }),
+  ]);
+}
+
+/* ---------------------------------------------------------------- *
+ * Matrix + reporting.
+ * ---------------------------------------------------------------- */
+
+const p90 = xs => {
+  const s = xs.slice().sort((a, b) => a - b);
+  return s.length ? s[Math.min(s.length - 1, Math.floor(s.length * 0.9))] : 0;
+};
+
+async function main() {
+  const all = [];
+
+  // One browser for the positive control.
+  {
+    const chrome = await launchChrome();
+    try {
+      const cdp = await CDP.connect(chrome.wsUrl);
+      const { targetId } = await cdp.send('Target.createTarget', { url: 'about:blank' });
+      const { sessionId } = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
+      await cdp.send('Runtime.enable', {}, sessionId);
+      await cdp.send('Page.enable', {}, sessionId);
+      await positiveControl(cdp, sessionId);
+    } finally {
+      await killChrome(chrome.proc);
+    }
+  }
+
+  // Fresh Chrome per run. Same-site navigations reuse the renderer process,
+  // and long-lived headless instances degrade measurably across successive
+  // targets (page mounts went 0.6s -> 7.4s -> 14.1s, then wedged past the
+  // watchdog entirely). A fresh instance per run removes all cross-run state.
+  const withSession = async fn => {
+    const chrome = await launchChrome();
+    try {
+      const cdp = await CDP.connect(chrome.wsUrl);
+      const { targetId } = await cdp.send('Target.createTarget', { url: 'about:blank' });
+      const { sessionId } = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
+      await cdp.send('Runtime.enable', {}, sessionId);
+      await cdp.send('Page.enable', {}, sessionId);
+      if (THROTTLE > 1) {
+        await cdp.send('Emulation.setCPUThrottlingRate', { rate: THROTTLE }, sessionId);
+      }
+      return await fn(cdp, sessionId);
+    } finally {
+      await killChrome(chrome.proc);
+    }
+  };
+
+  for (const cell of CELLS) {
+    for (let r = 0; r < WARMUP + RUNS; r++) {
+      const warmup = r < WARMUP;
+      process.stdout.write(`[${cell.name}] navigating + running…\n`);
+      let sessionForCapture = null;
+      const report = await withWatchdog(
+        withSession((cdp, sessionId) => {
+          sessionForCapture = { cdp, sessionId };
+          return runOnce(cdp, sessionId, cell);
+        }),
+        cell.name,
+        async () => {
+          if (!sessionForCapture) return 'no session';
+          const { cdp, sessionId } = sessionForCapture;
+          // The V8 profiler samples out of band: it answers even when the
+          // renderer main thread never yields, which is exactly when a
+          // Runtime.evaluate capture cannot run.
+          await cdp.send('Profiler.enable', {}, sessionId);
+          await cdp.send('Profiler.start', {}, sessionId);
+          await sleep(3000);
+          const { profile } = await cdp.send('Profiler.stop', {}, sessionId);
+          const profPath = `/tmp/sc-watchdog-${Date.now()}.cpuprofile`;
+          writeFileSync(profPath, JSON.stringify(profile));
+          const hits = new Map();
+          for (const s of profile.samples || []) hits.set(s, (hits.get(s) || 0) + 1);
+          const byId = new Map((profile.nodes || []).map(n => [n.id, n]));
+          const top = [...hits.entries()]
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 12)
+            .map(([id, n]) => {
+              const f = byId.get(id);
+              const fn = f ? f.callFrame : {};
+              return `${n}x ${fn.functionName || '(anon)'} ${(fn.url || '').split('/').pop()}:${fn.lineNumber}`;
+            });
+          return 'profile: ' + profPath + '\ntop frames:\n  ' + top.join('\n  ');
+        }
+      );
+      all.push({ cell: cell.name, warmup, report });
+      const tag = warmup ? 'warmup' : 'run';
+      process.stdout.write(
+        `[${cell.name} ${tag}] discQ=${report.discardedQueries} ` +
+          `ins=${report.insertRuleCalls} durMed=${report.eventDurationMedianMs.toFixed(0)}ms ` +
+          `delayMed=${report.inputDelayMedianMs.toFixed(1)}ms procMed=${report.processingMedianMs.toFixed(1)}ms ` +
+          `${report.failed.length ? 'FAILED: ' + report.failed.join('; ') : ''}\n`
+      );
+    }
+  }
+
+  const outDir = join(new URL('.', import.meta.url).pathname, 'out');
+  mkdirSync(outDir, { recursive: true });
+  const outFile = join(outDir, `concurrent-${Date.now()}.json`);
+  writeFileSync(outFile, JSON.stringify({ throttle: THROTTLE, runs: RUNS, results: all }, null, 2));
+
+  // Summary table over non-warmup runs.
+  console.log('\n=== summary (median across runs; throttle ' + THROTTLE + 'x) ===');
+  for (const cell of CELLS) {
+    const rs = all.filter(x => x.cell === cell.name && !x.warmup);
+    const get = k => rs.map(x => x.report[k]);
+    console.log(
+      `${cell.name.padEnd(14)} ` +
+        `durMed=${getMedian(get('eventDurationMedianMs')).toFixed(0)}ms ` +
+        `durP90=${p90(get('eventDurationMedianMs')).toFixed(0)}ms ` +
+        `delayMed=${getMedian(get('inputDelayMedianMs')).toFixed(1)}ms ` +
+        `procMed=${getMedian(get('processingMedianMs')).toFixed(1)}ms ` +
+        `discQ=${getMedian(get('discardedQueries')).toFixed(1)} ` +
+        `insMed=${getMedian(get('insertRuleCalls')).toFixed(0)} ` +
+        `fails=${rs.filter(x => x.report.failed.length).length}/${rs.length}`
+    );
+  }
+  console.log('\nwrote ' + outFile);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/benchmarks/src/app/App.js
+++ b/packages/benchmarks/src/app/App.js
@@ -101,6 +101,13 @@ export default class App extends Component {
     const { Component, Provider, getComponentProps, sampleCount } = currentImplementation;
     const isRunning = status === 'running';
     const isAutoRunning = isRunning && autoQueue !== null;
+    // Self-timed cases own a live demo in the view panel; the cycle Overlay
+    // would hide the workload, and centered overflow:hidden clips the fill.
+    const isSelfTimed = !!currentImplementation.selfTimed;
+    // Union of every library that appears in any suite. Suites that omit a
+    // library (e.g. concurrent injection A/B is styled-components only) still
+    // list it in the picker as a disabled option so the gap is visible.
+    const allLibraryNames = this._allLibraryNames();
 
     return (
       <React.Fragment>
@@ -113,16 +120,27 @@ export default class App extends Component {
                   <div data-bench-picker="" style={actionStyles.pickerSelect}>
                     <div style={actionStyles.pickerValue}>{currentLibraryName}</div>
                     <Chevron />
-                    <Picker
-                      enabled={!isRunning}
-                      onValueChange={this._handleChangeLibrary}
-                      selectedValue={currentLibraryName}
+                    {/*
+                      Native <select>: RNW Picker.Item cannot disable individual
+                      options, and unsupported libraries for this suite must stay
+                      visible but unselectable.
+                    */}
+                    <select
+                      disabled={isRunning}
+                      onChange={e => this._handleChangeLibrary(e.target.value)}
+                      value={currentLibraryName}
                       style={pickerOverlayStyle}
+                      aria-label="Library"
                     >
-                      {Object.keys(tests[currentBenchmarkName]).map(libraryName => (
-                        <Picker.Item key={libraryName} label={libraryName} value={libraryName} />
-                      ))}
-                    </Picker>
+                      {allLibraryNames.map(libraryName => {
+                        const supported = !!tests[currentBenchmarkName][libraryName];
+                        return (
+                          <option key={libraryName} value={libraryName} disabled={!supported}>
+                            {supported ? libraryName : libraryName + ' (n/a)'}
+                          </option>
+                        );
+                      })}
+                    </select>
                   </div>
                 </div>
                 <div style={actionStyles.pickerGroup}>
@@ -233,11 +251,11 @@ export default class App extends Component {
                   ) : null}
                 </ScrollView>
               </View>
-              {isRunning ? <Overlay /> : null}
+              {isRunning && !isSelfTimed ? <Overlay /> : null}
             </View>
           }
           viewPanel={
-            <View style={styles.viewPanel}>
+            <View style={[styles.viewPanel, isSelfTimed && styles.viewPanelFill]}>
               <View style={styles.iconEyeContainer}>
                 <TouchableOpacity onPress={this._handleVisuallyHideBenchmark}>
                   <IconEye style={styles.iconEye} />
@@ -245,8 +263,11 @@ export default class App extends Component {
               </View>
 
               <Provider key={currentLibraryName + ':' + currentBenchmarkName}>
-                {isRunning ? (
-                  <View ref={this._setBenchWrapperRef}>
+                {isRunning || (isSelfTimed && status === 'complete') ? (
+                  <View
+                    ref={this._setBenchWrapperRef}
+                    style={isSelfTimed ? styles.benchFill : undefined}
+                  >
                     <Benchmark
                       component={Component}
                       forceLayout
@@ -258,6 +279,7 @@ export default class App extends Component {
                       })}
                       ref={this._setBenchRef}
                       sampleCount={sampleCount}
+                      selfTimed={currentImplementation.selfTimed}
                       timeout={20000}
                       type={Component.benchmarkType}
                     />
@@ -267,7 +289,7 @@ export default class App extends Component {
                 )}
               </Provider>
 
-              {isRunning ? <Overlay /> : null}
+              {isRunning && !isSelfTimed ? <Overlay /> : null}
             </View>
           }
         />
@@ -276,32 +298,84 @@ export default class App extends Component {
     );
   }
 
+  _allLibraryNames() {
+    if (this._libraryNamesTests === this.props.tests && this._libraryNamesCache) {
+      return this._libraryNamesCache;
+    }
+    const names = new Set();
+    for (const bench of Object.keys(this.props.tests)) {
+      for (const lib of Object.keys(this.props.tests[bench])) names.add(lib);
+    }
+    // Array.from: `[...set]` is compiled to `[].concat(set)` by this bundle
+    // toolchain, which keeps the Set as one element (`[object Set]` in the UI).
+    this._libraryNamesTests = this.props.tests;
+    this._libraryNamesCache = Array.from(names).sort();
+    return this._libraryNamesCache;
+  }
+
+  /** Libraries that can run the given benchmark (or any selected suite bench). */
+  _librariesSupportedFor(benchmarkNames) {
+    const supported = new Set();
+    for (const bench of benchmarkNames) {
+      for (const lib of Object.keys(this.props.tests[bench] || {})) supported.add(lib);
+    }
+    return supported;
+  }
+
+  _getValidAutoRuns(benchmarks, selectedLibraries) {
+    const { tests } = this.props;
+    const queue = [];
+    for (const benchmarkName of benchmarks) {
+      for (const libraryName of selectedLibraries) {
+        if (tests[benchmarkName][libraryName]) {
+          queue.push({ benchmarkName, libraryName });
+        }
+      }
+    }
+    return queue;
+  }
+
   _renderAutoDialog() {
     const { tests } = this.props;
     const { dialogMode, autoSelectedLibraries, autoSelectedBenchmarks, currentBenchmarkName } =
       this.state;
     const allBenchmarks = Object.keys(tests);
-    const allLibraries = Object.keys(tests[allBenchmarks[0]]);
-    const selectedLibCount = allLibraries.filter(l => autoSelectedLibraries[l]).length;
-    const selectedBenchCount = allBenchmarks.filter(b => autoSelectedBenchmarks[b]).length;
+    const allLibraries = this._allLibraryNames();
     const isSuite = dialogMode === 'suite';
-    const totalRuns = isSuite ? selectedBenchCount * selectedLibCount : selectedLibCount;
-    const canRun = isSuite ? selectedBenchCount > 0 && selectedLibCount > 0 : selectedLibCount > 0;
+    const selectedBenchmarks = isSuite
+      ? allBenchmarks.filter(b => autoSelectedBenchmarks[b])
+      : [currentBenchmarkName];
+    // In Auto Benchmark, grey out libraries this suite does not implement. In
+    // Auto Suite, a library stays enabled if any selected benchmark supports it.
+    const supportedLibraries = this._librariesSupportedFor(
+      selectedBenchmarks.length ? selectedBenchmarks : allBenchmarks
+    );
+    const selectedLibraries = allLibraries.filter(
+      l => autoSelectedLibraries[l] && supportedLibraries.has(l)
+    );
+    const totalRuns = this._getValidAutoRuns(selectedBenchmarks, selectedLibraries).length;
+    const canRun = totalRuns > 0;
 
-    const renderCheckRow = (key, label, checked, onToggle) => (
+    const renderCheckRow = (key, label, checked, onToggle, disabled) => (
       <div
         key={key}
         data-bench-check=""
-        style={dialogStyles.checkRow}
-        onClick={() => onToggle(key)}
+        data-disabled={disabled ? 'true' : undefined}
+        style={{
+          ...dialogStyles.checkRow,
+          ...(disabled ? dialogStyles.checkRowDisabled : null),
+        }}
+        onClick={disabled ? undefined : () => onToggle(key)}
+        aria-disabled={disabled || undefined}
       >
         <div
           style={{
             ...dialogStyles.checkbox,
-            ...(checked ? dialogStyles.checkboxChecked : {}),
+            ...(checked && !disabled ? dialogStyles.checkboxChecked : {}),
+            ...(disabled ? dialogStyles.checkboxDisabled : null),
           }}
         >
-          {checked ? (
+          {checked && !disabled ? (
             <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
               <path
                 d="M1 4l2.5 2.5L9 1"
@@ -313,11 +387,23 @@ export default class App extends Component {
             </svg>
           ) : null}
         </div>
-        <div style={dialogStyles.checkLabel}>{label}</div>
+        <div style={dialogStyles.checkLabel}>
+          {label}
+          {disabled ? <span style={dialogStyles.naHint}> n/a</span> : null}
+        </div>
       </div>
     );
 
-    const renderColumn = (title, items, selected, onToggle, onAll, onNone, withDivider) => (
+    const renderColumn = (
+      title,
+      items,
+      selected,
+      onToggle,
+      onAll,
+      onNone,
+      withDivider,
+      isItemDisabled
+    ) => (
       <div
         style={{
           ...dialogStyles.column,
@@ -337,7 +423,10 @@ export default class App extends Component {
           </div>
         </div>
         <div style={dialogStyles.columnList}>
-          {items.map(item => renderCheckRow(item, item, !!selected[item], onToggle))}
+          {items.map(item => {
+            const disabled = isItemDisabled ? isItemDisabled(item) : false;
+            return renderCheckRow(item, item, !!selected[item] && !disabled, onToggle, disabled);
+          })}
         </div>
       </div>
     );
@@ -369,7 +458,8 @@ export default class App extends Component {
                   this._handleToggleAutoBenchmark,
                   () => this._setAllAuto('benchmarks', true),
                   () => this._setAllAuto('benchmarks', false),
-                  true
+                  true,
+                  null
                 )
               : null}
             {renderColumn(
@@ -379,7 +469,8 @@ export default class App extends Component {
               this._handleToggleAutoLibrary,
               () => this._setAllAuto('libraries', true),
               () => this._setAllAuto('libraries', false),
-              false
+              false,
+              lib => !supportedLibraries.has(lib)
             )}
           </div>
 
@@ -404,14 +495,23 @@ export default class App extends Component {
 
   _handleChangeBenchmark = value => {
     this.setState(
-      () => ({ currentBenchmarkName: value }),
+      state => {
+        const libraries = Object.keys(this.props.tests[value] || {});
+        const currentLibraryName = libraries.includes(state.currentLibraryName)
+          ? state.currentLibraryName
+          : libraries[0];
+        return { currentBenchmarkName: value, currentLibraryName, status: 'idle' };
+      },
       () => saveSettings(this.state)
     );
   };
 
   _handleChangeLibrary = value => {
+    const { tests } = this.props;
+    const { currentBenchmarkName } = this.state;
+    if (!tests[currentBenchmarkName][value]) return;
     this.setState(
-      () => ({ currentLibraryName: value }),
+      () => ({ currentLibraryName: value, status: 'idle' }),
       () => saveSettings(this.state)
     );
   };
@@ -468,9 +568,16 @@ export default class App extends Component {
   _setAllAuto = (kind, value) => {
     const { tests } = this.props;
     if (kind === 'libraries') {
-      const allLibraries = Object.keys(tests[Object.keys(tests)[0]]);
-      const next = {};
-      for (const lib of allLibraries) next[lib] = value;
+      const { dialogMode, autoSelectedBenchmarks, currentBenchmarkName } = this.state;
+      const benches =
+        dialogMode === 'suite'
+          ? Object.keys(tests).filter(b => autoSelectedBenchmarks[b])
+          : [currentBenchmarkName];
+      const supported = this._librariesSupportedFor(benches.length ? benches : Object.keys(tests));
+      const next = { ...this.state.autoSelectedLibraries };
+      for (const lib of this._allLibraryNames()) {
+        if (supported.has(lib)) next[lib] = value;
+      }
       this.setState({ autoSelectedLibraries: next }, () => saveSettings(this.state));
     } else if (kind === 'benchmarks') {
       const allBenchmarks = Object.keys(tests);
@@ -486,10 +593,6 @@ export default class App extends Component {
       this.state;
 
     const allBenchmarks = Object.keys(tests);
-    const allLibraries = Object.keys(tests[allBenchmarks[0]]);
-    const selectedLibraries = allLibraries.filter(lib => autoSelectedLibraries[lib]);
-    if (selectedLibraries.length === 0) return;
-
     let benchmarks;
     if (dialogMode === 'suite') {
       benchmarks = allBenchmarks.filter(b => autoSelectedBenchmarks[b]);
@@ -498,12 +601,14 @@ export default class App extends Component {
       benchmarks = [currentBenchmarkName];
     }
 
-    const queue = [];
-    for (const benchmarkName of benchmarks) {
-      for (const libraryName of selectedLibraries) {
-        queue.push({ benchmarkName, libraryName });
-      }
-    }
+    const supported = this._librariesSupportedFor(benchmarks);
+    const selectedLibraries = this._allLibraryNames().filter(
+      lib => autoSelectedLibraries[lib] && supported.has(lib)
+    );
+    if (selectedLibraries.length === 0) return;
+
+    const queue = this._getValidAutoRuns(benchmarks, selectedLibraries);
+    if (queue.length === 0) return;
 
     const [first, ...rest] = queue;
     this.setState({ dialogMode: null });
@@ -714,6 +819,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     overflow: 'hidden',
     backgroundColor: 'var(--bench-view-bg)',
+  },
+  viewPanelFill: {
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+    overflow: 'auto',
+  },
+  benchFill: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+    alignSelf: 'stretch',
   },
   iconEye: {
     color: 'rgba(255,255,255,0.7)',
@@ -1030,6 +1146,18 @@ const dialogStyles = {
   checkboxChecked: {
     backgroundColor: 'var(--bench-accent)',
     borderColor: 'var(--bench-accent)',
+  },
+  checkRowDisabled: {
+    opacity: 0.45,
+    cursor: 'not-allowed',
+  },
+  checkboxDisabled: {
+    backgroundColor: 'transparent',
+    borderColor: 'var(--bench-border)',
+  },
+  naHint: {
+    color: 'var(--bench-text-muted)',
+    fontWeight: 400,
   },
   checkLabel: {
     fontSize: 13,

--- a/packages/benchmarks/src/app/Benchmark/index.js
+++ b/packages/benchmarks/src/app/Benchmark/index.js
@@ -92,6 +92,9 @@ export default class Benchmark extends React.Component {
     };
     this._startTime = 0;
     this._samples = [];
+    /** After a self-timed run finishes, keep rendering so the case can show
+     *  its own report until App replaces this Benchmark instance. */
+    this._selfTimedDone = false;
   }
 
   // Replaces the deprecated `componentWillReceiveProps` lifecycle. Recomputes
@@ -113,6 +116,10 @@ export default class Benchmark extends React.Component {
     if (this.state.running && !prevState.running) {
       this._startTime = Timing.now();
     }
+
+    // Self-timed components own their run loop and signal completion through
+    // onBenchmarkComplete; the cycle machinery cannot see their work.
+    if (this.props.selfTimed) return;
 
     const { forceLayout, sampleCount, timeout, type } = this.props;
     const { cycle, running } = this.state;
@@ -158,16 +165,28 @@ export default class Benchmark extends React.Component {
   }
 
   render() {
-    const { component: Component, type } = this.props;
+    const { component: Component, selfTimed, type } = this.props;
     const { componentProps, cycle, running } = this.state;
     if (running && shouldRecord(cycle, type)) {
       this._samples[cycle] = { scriptingStart: Timing.now() };
     }
-    return running && shouldRender(cycle, type) ? <Component {...componentProps} /> : null;
+    if (selfTimed) {
+      if (!running && !this._selfTimedDone) return null;
+      return (
+        <Component
+          {...componentProps}
+          benchmarkRunning={running}
+          onBenchmarkComplete={this._handleSelfComplete}
+        />
+      );
+    }
+    if (!(running && shouldRender(cycle, type))) return null;
+    return <Component {...componentProps} />;
   }
 
   start() {
     this._samples = [];
+    this._selfTimedDone = false;
     this.setState(() => ({ running: true, cycle: 0 }));
   }
 
@@ -211,13 +230,39 @@ export default class Benchmark extends React.Component {
     );
   }
 
-  _handleComplete(endTime) {
+  _handleSelfComplete = payload => {
+    this._selfTimedDone = true;
+    this._handleComplete(Timing.now(), payload);
+  };
+
+  _handleComplete(endTime, payload) {
     const { onComplete } = this.props;
     const samples = this.getSamples();
 
     this.setState(() => ({ running: false, cycle: 0 }));
 
     const runTime = endTime - this._startTime;
+
+    if (payload) {
+      // Self-timed: the component measured its own workload; surface its
+      // duration and sample count rather than per-cycle statistics.
+      onComplete({
+        startTime: this._startTime,
+        endTime,
+        runTime,
+        sampleCount: payload.inputCount,
+        samples: [],
+        max: runTime,
+        min: runTime,
+        median: runTime,
+        mean: runTime,
+        stdDev: 0,
+        meanLayout: 0,
+        meanScripting: payload.durationMs,
+      });
+      return;
+    }
+
     const sortedElapsedTimes = samples.map(({ start, end }) => end - start).sort(sortNumbers);
     const sortedScriptingElapsedTimes = samples
       .map(({ scriptingStart, scriptingEnd }) => scriptingEnd - scriptingStart)

--- a/packages/benchmarks/src/app/Benchmark/math.js
+++ b/packages/benchmarks/src/app/Benchmark/math.js
@@ -15,10 +15,9 @@ export const getMean = values => {
 };
 
 export const getMedian = values => {
-  if (values.length === 1) {
-    return values[0];
-  }
+  if (values.length === 0) return 0;
+  if (values.length === 1) return values[0];
 
-  const numbers = values.sort((a, b) => a - b);
+  const numbers = values.slice().sort((a, b) => a - b);
   return (numbers[(numbers.length - 1) >> 1] + numbers[numbers.length >> 1]) / 2;
 };

--- a/packages/benchmarks/src/app/Layout.js
+++ b/packages/benchmarks/src/app/Layout.js
@@ -4,18 +4,20 @@ import { StyleSheet, View } from 'react-native';
 export default class Layout extends Component {
   state = {
     widescreen: false,
+    rootHeight: 0,
   };
 
   render() {
     const { viewPanel, actionPanel, listPanel } = this.props;
-    const { widescreen } = this.state;
+    const { widescreen, rootHeight } = this.state;
+    // Stacked (narrow) mode: cap the results list at a quarter of the root so
+    // the case view keeps the rest.
+    const narrowList = !widescreen && rootHeight > 0 ? { height: rootHeight / 4 } : null;
     return (
       <View onLayout={this._handleLayout} style={[styles.root, widescreen && styles.row]}>
-        <View style={[widescreen ? styles.grow : styles.stackPanel, styles.layer]}>
-          {viewPanel}
-        </View>
-        <View style={[styles.grow, styles.controlSide]}>
-          <View style={[styles.grow, styles.layer]}>{listPanel}</View>
+        <View style={[styles.grow, styles.layer]}>{viewPanel}</View>
+        <View style={[widescreen && styles.grow, styles.controlSide]}>
+          <View style={[widescreen ? styles.grow : narrowList, styles.layer]}>{listPanel}</View>
           <View style={styles.divider} />
           <View style={styles.layer}>{actionPanel}</View>
         </View>
@@ -25,11 +27,10 @@ export default class Layout extends Component {
 
   _handleLayout = ({ nativeEvent }) => {
     const { layout } = nativeEvent;
-    const { width } = layout;
-    if (width >= 740) {
-      this.setState(() => ({ widescreen: true }));
-    } else {
-      this.setState(() => ({ widescreen: false }));
+    const { width, height } = layout;
+    const widescreen = width >= 740;
+    if (widescreen !== this.state.widescreen || height !== this.state.rootHeight) {
+      this.setState(() => ({ widescreen, rootHeight: height }));
     }
   };
 }
@@ -51,9 +52,6 @@ const styles = StyleSheet.create({
   },
   grow: {
     flex: 1,
-  },
-  stackPanel: {
-    height: '33.33%',
   },
   layer: {
     transform: [{ translateZ: '0' }],

--- a/packages/benchmarks/src/cases/ConcurrentResponsiveness.tsx
+++ b/packages/benchmarks/src/cases/ConcurrentResponsiveness.tsx
@@ -1,0 +1,667 @@
+/**
+ * Concurrent CSS responsiveness.
+ *
+ * An always-urgent controlled input competes with a large transition-rendered
+ * result tree that injects styled-components rules via `useInsertionEffect`.
+ * Measures whether input stays responsive while the background tree renders,
+ * suspends, restarts, and discards work.
+ *
+ * This case reports interaction evidence (Event Timing, CSSOM writes, render
+ * attempts vs commits, discarded renders) rather than the generic cycle
+ * throughput that `app/Benchmark` computes, so it owns its own run loop.
+ * See `headless/concurrent.mjs`.
+ */
+import React from 'react';
+import styled from 'styled-components';
+import { getMedian } from '../app/Benchmark/math.js';
+
+/* ------------------------------------------------------------------ *
+ * Deterministic data: stable across runs so results are comparable.
+ * ------------------------------------------------------------------ */
+
+/** Deterministic pseudo-random in [0,1) from an integer seed (mulberry32). */
+const rand = (seed: number) => {
+  let t = (seed + 0x6d2b79f5) | 0;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+/** Bounded palette; "unique" mode derives a fresh hex per cell. */
+const PALETTE = ['#E0245E', '#FFAD1F', '#F45D22', '#17BF63', '#1DA1F2', '#794BC4'];
+
+/**
+ * Content hash of the query string. Colors key off this so every committed
+ * query visibly repaints the grid; keying off query length (or nothing)
+ * leaves the squares static across a run, which reads as "nothing happened".
+ */
+const qhash = (q: string) => {
+  let h = 0;
+  for (let i = 0; i < q.length; i++) h = (h * 33 + q.charCodeAt(i)) | 0;
+  return h >>> 0;
+};
+
+type Axis = {
+  /** new class cardinality: 0 (cached), bounded, or unique-per-render */
+  cardinality: 'zero' | 'bounded' | 'unique';
+  /** selector invalidation breadth */
+  selector: 'narrow' | 'descendant' | 'has';
+  /** forced style/layout reads during render */
+  layoutReads: 'none' | 'forced';
+  /** scheduling: blocking, transition, transition interrupted by urgent input */
+  scheduling: 'blocking' | 'transition' | 'interrupted';
+};
+
+export type InstrumentReport = {
+  cell: string;
+  inputCount: number;
+  /** INP-style keydown duration: queue delay + processing + presentation. */
+  eventDurationMedianMs: number;
+  eventDurationMaxMs: number;
+  /** Queue wait before the handler starts (processingStart - startTime). */
+  inputDelayMedianMs: number;
+  /** Handler execution time (processingEnd - processingStart). */
+  processingMedianMs: number;
+  renderAttempts: number;
+  commits: number;
+  /** Query values rendered but never committed. */
+  discardedQueries: number;
+  /** Cell renders against discarded queries (the wasted work). */
+  discardedRenders: number;
+  insertRuleCalls: number;
+  failed: string[];
+};
+
+/* ------------------------------------------------------------------ *
+ * Instrumentation: module-level counters, fail-loud preconditions.
+ * ------------------------------------------------------------------ */
+
+export const Instrument = {
+  renderAttempts: 0,
+  commits: 0,
+  insertRuleCalls: 0,
+  /** performance.now() at run start; Event Timing entries are drained at finish. */
+  runStart: 0,
+  /** Event Timing key entries captured by the live observer. */
+  events: [] as PerformanceEventTiming[],
+  /** name → count over every observed entry (diagnostics). */
+  eventNameCounts: {} as Record<string, number>,
+  /** Entries dropped after the cap (diagnostics). */
+  observerDropped: 0,
+  /** Distinct query values that reached a render body. */
+  renderedQueries: new Set<string>(),
+  /** Distinct query values whose tree actually committed. */
+  committedQueries: new Set<string>(),
+  reset() {
+    this.renderAttempts = 0;
+    this.commits = 0;
+    this.insertRuleCalls = 0;
+    this.runStart = performance.now();
+    this.events = [];
+    this.eventNameCounts = {};
+    this.observerDropped = 0;
+    this.renderedQueries = new Set();
+    this.committedQueries = new Set();
+  },
+};
+
+// Hook the CSSOM insertion point at module load so no injection happens
+// before the counter is live.
+(function hookInsertRuleCounter() {
+  const proto = CSSStyleSheet.prototype as any;
+  const real = proto.insertRule;
+  proto.insertRule = function (rule: string, index?: number) {
+    Instrument.insertRuleCalls++;
+    return real.call(this, rule, index);
+  };
+})();
+
+// Buffer Event Timing entries from page load. Without a registered observer
+// the UA drops events under the default 104ms duration threshold, which is
+// exactly where healthy input latency lives. Only discrete key events are
+// buffered: continuous event streams (pointermove, wheel, rawupdate) would
+// drown them by the thousand under a saturated main thread. A drop count is
+// recorded so a truncated tail is visible rather than silent.
+const MAX_EVENT_ENTRIES = 4000;
+
+function collectEventEntries(list: PerformanceObserverEntryList) {
+  for (const entry of list.getEntries()) {
+    Instrument.eventNameCounts[entry.name] = (Instrument.eventNameCounts[entry.name] || 0) + 1;
+    if (entry.name !== 'keydown' && entry.name !== 'keyup') continue;
+    if (Instrument.events.length >= MAX_EVENT_ENTRIES) {
+      Instrument.observerDropped++;
+      continue;
+    }
+    Instrument.events.push(entry as PerformanceEventTiming);
+  }
+}
+
+try {
+  if (typeof PerformanceObserver !== 'undefined') {
+    new PerformanceObserver(collectEventEntries).observe({
+      type: 'event',
+      durationThreshold: 0,
+    } as PerformanceObserverInit);
+  }
+} catch {
+  try {
+    new PerformanceObserver(collectEventEntries).observe({
+      type: 'event',
+      durationThreshold: 1,
+    } as PerformanceObserverInit);
+  } catch {
+    // Event Timing unsupported; finishRun's failure message will say so.
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * The tree. A grid of cells whose color derives from the query. The
+ * styled component is created inside the case (per run) so each axis can
+ * vary cardinality / selector breadth / layout reads independently.
+ * ------------------------------------------------------------------ */
+
+/**
+ * Tree sizes. Headed self-drive has no CPU throttle, so it needs a larger
+ * tree (and a tighter tick) than the external runner for a unique-class pass
+ * to outlast the input cadence on a desktop. Below SELF_CELLS_FLOOR the
+ * interrupted axis silently completes every pass.
+ */
+const CELLS_EXTERNAL = 1500;
+const CELLS_SELF = 4000;
+const SELF_CELLS_FLOOR = 2500;
+/** Self-drive: enough ticks to watch, cadence shorter than one unique pass. */
+const SELF_STEPS = 40;
+const SELF_INTERVAL_MS = 48;
+
+function CellView({
+  Cell,
+  seed,
+  query,
+  axis,
+}: {
+  Cell: any;
+  seed: number;
+  query: string;
+  axis: Axis;
+}) {
+  Instrument.renderAttempts++;
+
+  // Optional forced style/layout read during render (worst case). Sparse on
+  // purpose: per-cell reads interleaved with per-cell stylesheet invalidation
+  // is O(n^2) on the document and wedges the renderer for minutes. Every 20th
+  // is enough, with CELLS_SELF, for a unique pass to outrun SELF_INTERVAL_MS
+  // without throttle.
+  if (
+    axis.layoutReads === 'forced' &&
+    seed % 20 === 0 &&
+    typeof document !== 'undefined' &&
+    document.body
+  ) {
+    // Reading offsetWidth forces style recalc + layout synchronously.
+    void document.body.offsetWidth;
+  }
+
+  Instrument.renderedQueries.add(query);
+
+  const qh = qhash(query);
+  const colorIndex =
+    axis.cardinality === 'zero'
+      ? seed % 2 // reuse cached classes
+      : axis.cardinality === 'bounded'
+        ? // Rotate assignment per query: the same bounded class set cycles
+          // across cells each commit, so the repaint is visible while the
+          // stylesheet stays at six rules.
+          (seed + qh) % PALETTE.length
+        : seed; // unique: distinct class per cell
+
+  const bg =
+    axis.cardinality === 'unique'
+      ? '#' +
+        Math.floor(rand(seed * 7 + qh) * 0xffffff)
+          .toString(16)
+          .padStart(6, '0')
+      : PALETTE[colorIndex];
+
+  return <Cell $bg={bg} $q={query} data-seed={seed} />;
+}
+
+const MemoCellView = React.memo(CellView);
+
+const ResultTree = React.memo(function ResultTree({
+  Cell,
+  query,
+  axis,
+  onCommit,
+}: {
+  Cell: any;
+  query: string;
+  axis: Axis & { cells: number };
+  onCommit: () => void;
+}) {
+  const cells = [];
+  for (let i = 0; i < axis.cells; i++) {
+    cells.push(<MemoCellView key={i} Cell={Cell} seed={i} query={query} axis={axis} />);
+  }
+
+  // Commit counter: fires only when the committed query value changes, so
+  // parent re-renders (telemetry updates) do not re-fire it into a loop.
+  // Skip the idle empty query: it would otherwise commit after startRun's
+  // Instrument.reset and pollute discard accounting.
+  React.useEffect(() => {
+    if (!query) return;
+    Instrument.commits++;
+    Instrument.committedQueries.add(query);
+    onCommit();
+  }, [query]);
+
+  return <div data-tree="">{cells}</div>;
+});
+
+/* ------------------------------------------------------------------ *
+ * The case component. Owns its own run loop and input instrumentation.
+ * ------------------------------------------------------------------ */
+
+export default function ConcurrentResponsiveness({
+  benchmarkRunning,
+  onBenchmarkComplete,
+}: {
+  /** The harness's Run button state; a false→true edge starts the workload. */
+  benchmarkRunning?: boolean;
+  /** Called with the finished report so the harness can close its own run. */
+  onBenchmarkComplete?: (payload: {
+    sampleCount: number;
+    mean: number;
+    stdDev: number;
+    report: InstrumentReport;
+  }) => void;
+}) {
+  const [axis] = React.useState(() => readAxis());
+  const [running, setRunning] = React.useState(false);
+  const [report, setReport] = React.useState<InstrumentReport | null>(null);
+  const [query, setQuery] = React.useState('');
+  const [deferredQuery, setDeferredQuery] = React.useState('');
+  const [isPending, startTransition] = React.useTransition();
+  /**
+   * Demo telemetry for the self-drive run, refreshed per tick and per commit.
+   * Self-drive is the interactive demo; its own UI updates slightly perturb
+   * the workload, so measurement-grade numbers come from the external runner.
+   */
+  const [live, setLive] = React.useState<{
+    attempts: number;
+    commits: number;
+    discarded: number;
+    insertRuleCalls: number;
+    step: number;
+  }>({ attempts: 0, commits: 0, discarded: 0, insertRuleCalls: 0, step: 0 });
+  /** Background wash for the tree container, flooded on each commit. */
+  const [treeWash, setTreeWash] = React.useState('transparent');
+
+  const runState = React.useRef<{ inputs: number; done: boolean; timer: number | null }>({
+    inputs: 0,
+    done: false,
+    timer: null,
+  });
+
+  // The styled cell, created once per axis so selector breadth is fixed per run.
+  const Cell = React.useMemo(() => makeCell(axis), [axis]);
+
+  function readAxis(): Axis & { driver: 'self' | 'external'; cells: number } {
+    const p = new URLSearchParams(window.location.search);
+    const driver: 'self' | 'external' = p.get('driver') === 'external' ? 'external' : 'self';
+    // Default to the adversarial unique/forced/interrupted cell.
+    const cardinality = (p.get('card') as Axis['cardinality']) || 'unique';
+    const layoutReads = (p.get('layout') as Axis['layoutReads']) || 'forced';
+    const scheduling = (p.get('sched') as Axis['scheduling']) || 'interrupted';
+    const requested = Number(p.get('cells'));
+    const fallback = driver === 'self' ? CELLS_SELF : CELLS_EXTERNAL;
+    let cells = Number.isFinite(requested) && requested > 0 ? requested : fallback;
+    // A too-small headed tree never discards; clamp so a stale ?cells=400
+    // bookmark cannot silently neuter the demo.
+    if (
+      driver === 'self' &&
+      scheduling === 'interrupted' &&
+      cardinality === 'unique' &&
+      cells < SELF_CELLS_FLOOR
+    ) {
+      cells = SELF_CELLS_FLOOR;
+    }
+    return {
+      cardinality,
+      selector: (p.get('sel') as Axis['selector']) || 'narrow',
+      layoutReads,
+      scheduling,
+      driver,
+      cells: Math.max(100, cells),
+    };
+  }
+
+  /** Urgent update from a real (or scripted) keystroke on the input. */
+  function driveFromInput(value: string) {
+    setQuery(value);
+    if (axis.scheduling === 'transition' || axis.scheduling === 'interrupted') {
+      // Queue depth one: the new transition supersedes whatever is in flight,
+      // so every keystroke interrupts the current pass without piling an
+      // unbounded backlog of stale transitions onto the scheduler. With pass
+      // cost above the input cadence this makes interruption structural and
+      // keeps the workload measurable instead of livelocked.
+      startTransition(() => setDeferredQuery(value));
+    } else {
+      setDeferredQuery(value);
+    }
+  }
+
+  function snapshotLive(step: number) {
+    let discarded = 0;
+    Instrument.renderedQueries.forEach(q => {
+      if (!Instrument.committedQueries.has(q)) discarded++;
+    });
+    setLive({
+      attempts: Instrument.renderAttempts,
+      commits: Instrument.commits,
+      discarded,
+      insertRuleCalls: Instrument.insertRuleCalls,
+      step,
+    });
+  }
+
+  /** Each committed tree floods the container wash with its query's hue. */
+  function onTreeCommit(committedQuery: string) {
+    if (axis.driver !== 'self') return;
+    let h = 0;
+    for (let i = 0; i < committedQuery.length; i++)
+      h = (h * 31 + committedQuery.charCodeAt(i)) % 360;
+    setTreeWash(`hsl(${h}, 70%, 90%)`);
+    snapshotLive(runState.current.inputs);
+  }
+
+  function startRun() {
+    Instrument.reset();
+    runState.current = { inputs: 0, done: false, timer: null };
+    setReport(null);
+    setLive({ attempts: 0, commits: 0, discarded: 0, insertRuleCalls: 0, step: 0 });
+    setTreeWash('transparent');
+    setRunning(true);
+
+    if (axis.driver === 'external') return; // the runner types trusted keys
+
+    // Self-drive: chained timeouts (not setInterval) so a blocked main thread
+    // cannot queue a burst of ticks that collapse into one transition. Synthetic
+    // events do not populate Event Timing; the report says so.
+    let step = 0;
+    const tick = () => {
+      if (runState.current.done) return;
+      step++;
+      runState.current.inputs++;
+      driveFromInput('q' + step);
+      snapshotLive(step);
+      if (step >= SELF_STEPS) {
+        finishRun();
+        return;
+      }
+      runState.current.timer = window.setTimeout(tick, SELF_INTERVAL_MS);
+    };
+    runState.current.timer = window.setTimeout(tick, SELF_INTERVAL_MS);
+  }
+
+  function finishRun(): InstrumentReport | null {
+    if (runState.current.done) return null;
+    runState.current.done = true;
+    if (runState.current.timer !== null) window.clearTimeout(runState.current.timer);
+
+    // Drain the live observer's key events since run start.
+    const durations: number[] = [];
+    const delays: number[] = [];
+    const processing: number[] = [];
+    for (const entry of Instrument.events) {
+      if (entry.startTime < Instrument.runStart) continue;
+      durations.push(entry.duration);
+      delays.push(entry.processingStart - entry.startTime);
+      processing.push(entry.processingEnd - entry.processingStart);
+    }
+
+    // Discards are counted honestly: a query value whose render bodies ran
+    // but whose tree never committed. Cell renders against a discarded query
+    // are the wasted work concurrent rendering threw away.
+    let discardedQueries = 0;
+    Instrument.renderedQueries.forEach(q => {
+      if (!Instrument.committedQueries.has(q)) discardedQueries++;
+    });
+    const discardedRenders = discardedQueries * axis.cells;
+
+    const failed: string[] = [];
+    if (Instrument.insertRuleCalls === 0 && axis.cardinality !== 'zero')
+      failed.push('no insertRule calls recorded');
+    if (Instrument.renderAttempts === 0) failed.push('no render attempts recorded');
+    if (axis.scheduling === 'interrupted' && discardedQueries === 0)
+      failed.push(
+        'interrupted axis discarded nothing: render cost never exceeded the input cadence'
+      );
+    if (durations.length === 0) {
+      const names = Object.entries(Instrument.eventNameCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([n, c]) => `${n}:${c}`)
+        .join(',');
+      failed.push(
+        `Event Timing produced no key entries (kept=${Instrument.events.length} dropped=${Instrument.observerDropped} names=[${names}])`
+      );
+    }
+
+    const max = (xs: number[]) => (xs.length ? Math.max.apply(null, xs) : 0);
+
+    const rep: InstrumentReport = {
+      cell: `card=${axis.cardinality} sel=${axis.selector} layout=${axis.layoutReads} sched=${axis.scheduling} driver=${axis.driver}`,
+      inputCount: runState.current.inputs,
+      eventDurationMedianMs: getMedian(durations),
+      eventDurationMaxMs: max(durations),
+      inputDelayMedianMs: getMedian(delays),
+      processingMedianMs: getMedian(processing),
+      renderAttempts: Instrument.renderAttempts,
+      commits: Instrument.commits,
+      discardedQueries,
+      discardedRenders,
+      insertRuleCalls: Instrument.insertRuleCalls,
+      failed,
+    };
+    setReport(rep);
+    setRunning(false);
+    if (onBenchmarkComplete) {
+      onBenchmarkComplete({
+        inputCount: rep.inputCount,
+        durationMs: performance.now() - Instrument.runStart,
+        discardedQueries,
+        insertRuleCalls: rep.insertRuleCalls,
+      });
+    }
+    return rep;
+  }
+
+  // Runner API: the external matrix runner drives runs through these.
+  React.useEffect(() => {
+    const w = window as any;
+    w.__scBench = { start: startRun, finish: finishRun, drive: driveFromInput, Instrument };
+    return () => {
+      delete w.__scBench;
+    };
+  });
+
+  // Harness-driven start: the App's Run button flips benchmarkRunning.
+  const wasBenchmarkRunning = React.useRef(false);
+  React.useEffect(() => {
+    if (benchmarkRunning && !wasBenchmarkRunning.current) startRun();
+    wasBenchmarkRunning.current = !!benchmarkRunning;
+  }, [benchmarkRunning]);
+
+  return (
+    <div
+      style={{
+        fontFamily: 'monospace',
+        color: 'var(--bench-text)',
+        padding: 16,
+        boxSizing: 'border-box',
+        width: '100%',
+        height: '100%',
+        overflow: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <h2 style={{ fontSize: 18, margin: '0 0 4px' }}>Concurrent CSS responsiveness</h2>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 8, alignItems: 'center' }}>
+        {!running && !report && axis.driver === 'self' ? (
+          <span style={{ fontSize: 12, color: 'var(--bench-text-muted)' }}>
+            Press <strong>Run</strong> in the toolbar to start the cell.
+          </span>
+        ) : null}
+        {running ? <span style={{ color: '#E0245E' }}>running…</span> : null}
+        {isPending ? <span style={{ color: '#E0245E' }}>pending</span> : null}
+      </div>
+
+      <div style={{ marginBottom: 12, fontSize: 12, opacity: 0.8 }}>
+        cell: card={axis.cardinality} sel={axis.selector} layout={axis.layoutReads} sched=
+        {axis.scheduling} cells={axis.cells} (URL: ?card=&sel=&layout=&sched=&cells=)
+      </div>
+
+      {axis.driver === 'self' && (running || live.step > 0) ? (
+        <div data-live="" style={{ marginBottom: 12 }}>
+          <div
+            style={{
+              height: 6,
+              borderRadius: 3,
+              background: 'var(--bench-border)',
+              overflow: 'hidden',
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${Math.min(100, (live.step / SELF_STEPS) * 100)}%`,
+                background: running ? 'var(--bench-accent)' : 'var(--bench-text-muted)',
+                transition: 'width 0.1s linear',
+              }}
+            />
+          </div>
+          <div style={{ display: 'flex', gap: 18, fontSize: 13 }}>
+            <span>
+              step <strong>{live.step}</strong>/{SELF_STEPS}
+            </span>
+            <span>
+              rendered <strong data-live-attempts="">{live.attempts}</strong>
+            </span>
+            <span>
+              committed <strong data-live-commits="">{live.commits}</strong>
+            </span>
+            <span style={{ color: live.discarded > 0 ? '#E0245E' : 'inherit' }}>
+              discarded <strong data-live-discarded="">{live.discarded}</strong> queries
+            </span>
+            <span>
+              CSSOM writes <strong data-live-ins="">{live.insertRuleCalls}</strong>
+            </span>
+          </div>
+        </div>
+      ) : null}
+
+      {/*
+       * Uncontrolled in external-driver mode: trusted input events must flow
+       * through onChange like a real user's, and binding value={query} makes
+       * React restore the field's value after every churn render, which wedges
+       * the renderer outright when trusted text insertion lands mid-churn.
+       */}
+      <input
+        data-urgent-input=""
+        {...(axis.driver === 'external' ? { defaultValue: '' } : { value: query })}
+        onChange={e => {
+          runState.current.inputs++;
+          driveFromInput(e.target.value);
+        }}
+        placeholder="urgent input"
+        style={{ fontSize: 16, padding: 8, width: 320, marginBottom: 12 }}
+      />
+
+      {report ? (
+        <pre
+          data-report=""
+          style={{
+            background: 'var(--bench-surface-alt)',
+            padding: 12,
+            borderRadius: 8,
+            fontSize: 12,
+            maxWidth: '100%',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {JSON.stringify(report, null, 2)}
+        </pre>
+      ) : null}
+
+      <div
+        style={{
+          flex: 1,
+          minHeight: 180,
+          maxHeight: 400,
+          overflow: 'auto',
+          border: '1px solid var(--bench-border)',
+          backgroundColor: treeWash,
+          transition: 'background-color 0.25s',
+        }}
+      >
+        <ResultTree
+          Cell={Cell}
+          query={deferredQuery}
+          axis={axis}
+          onCommit={() => onTreeCommit(deferredQuery)}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Cell factory: selector breadth is baked in per run.
+ * ------------------------------------------------------------------ */
+
+type CellProps = { $bg: string; $q: string };
+
+/** Always styled-components; this case is registered SC-only in the harness. */
+function makeCell(axis: Axis) {
+  const base = styled.div<CellProps>`
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    margin: 2px;
+    background-color: ${p => p.$bg};
+    outline: ${p => (p.$q.length % 2 ? '1px' : '0')} solid transparent;
+  `;
+
+  if (axis.selector === 'descendant') {
+    return styled.div<CellProps>`
+      display: inline-block;
+      width: 18px;
+      height: 18px;
+      margin: 2px;
+      background-color: ${p => p.$bg};
+      [data-tree] & {
+        outline: 1px solid transparent;
+      }
+    `;
+  }
+  if (axis.selector === 'has') {
+    return styled.div<CellProps>`
+      display: inline-block;
+      width: 18px;
+      height: 18px;
+      margin: 2px;
+      background-color: ${p => p.$bg};
+      :has(&) {
+        content: '';
+      }
+    `;
+  }
+  return base;
+}
+
+ConcurrentResponsiveness.displayName = 'ConcurrentResponsiveness';
+ConcurrentResponsiveness.benchmarkType = 'update';

--- a/packages/benchmarks/src/index.js
+++ b/packages/benchmarks/src/index.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './app/App';
+import ConcurrentResponsiveness from './cases/ConcurrentResponsiveness';
 import ParentRerender from './cases/ParentRerender';
 import SierpinskiTriangle from './cases/SierpinskiTriangle';
 import Tree from './cases/Tree';
@@ -11,10 +12,13 @@ import impl from './impl';
 const implementations = impl;
 const packageNames = Object.keys(implementations);
 
-const createTestBlock = fn => {
-  return packageNames.reduce((testSetups, packageName) => {
-    const { name, components, version } = implementations[packageName];
-    const { Component, getComponentProps, sampleCount, Provider, benchmarkType } = fn(components);
+const createTestBlock = (fn, { libraries = packageNames } = {}) => {
+  return libraries.reduce((testSetups, packageName) => {
+    const impl = implementations[packageName];
+    if (!impl) return testSetups;
+    const { name, components, version } = impl;
+    const { Component, getComponentProps, sampleCount, Provider, benchmarkType, selfTimed } =
+      fn(components);
 
     testSetups[packageName] = {
       Component,
@@ -22,12 +26,16 @@ const createTestBlock = fn => {
       sampleCount,
       Provider,
       benchmarkType,
+      selfTimed,
       version,
       name,
     };
     return testSetups;
   }, {});
 };
+
+/** Sync vs buffered injection is a styled-components private A/B only. */
+const SC_ONLY = ['styled-components'];
 
 const tests = {
   'Mount deep tree': createTestBlock(components => ({
@@ -67,6 +75,30 @@ const tests = {
     Provider: components.Provider,
     sampleCount: 1000,
   })),
+  'Concurrent CSS responsiveness': createTestBlock(
+    components => ({
+      benchmarkType: 'update',
+      Component: ConcurrentResponsiveness,
+      getComponentProps: () => ({ components }),
+      Provider: components.Provider,
+      sampleCount: 1,
+      selfTimed: true,
+    }),
+    { libraries: SC_ONLY }
+  ),
 };
+
+// `?bench=<name>` preselects a benchmark so headless runners can land
+// directly on a case without driving the picker.
+const requestedBench = new URLSearchParams(window.location.search).get('bench');
+if (requestedBench && Object.prototype.hasOwnProperty.call(tests, requestedBench)) {
+  try {
+    const saved = JSON.parse(localStorage.getItem('sc-bench-settings') || '{}');
+    saved.currentBenchmarkName = requestedBench;
+    localStorage.setItem('sc-bench-settings', JSON.stringify(saved));
+  } catch (e) {
+    // storage unavailable; the picker default wins
+  }
+}
 
 createRoot(document.querySelector('.root')).render(<App tests={tests} />);

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -16,3 +16,4 @@ Visit http://localhost:3000.
 - `/global-style-test` - `createGlobalStyle` mounting / unmounting cases
 - `/rsc` - server-component rendering
 - `/perf` - render-cost scratch pad
+- `/perf/data-grid` - 2000-cell monitoring grid that patches ~400 cells every 100ms inside `startTransition` + `useDeferredValue`, with a sync filter and pause/resume

--- a/packages/sandbox/app/components/sidebar.tsx
+++ b/packages/sandbox/app/components/sidebar.tsx
@@ -19,7 +19,7 @@ const sections = [
   {
     title: 'Performance',
     items: [
-      { href: '/perf/data-grid', label: 'Data Grid' },
+      { href: '/perf/data-grid', label: 'Data Grid (concurrent)' },
       { href: '/perf/dashboard', label: 'Dashboard' },
       { href: '/perf/form', label: 'Form' },
       { href: '/perf/list', label: 'List' },

--- a/packages/sandbox/app/layout.tsx
+++ b/packages/sandbox/app/layout.tsx
@@ -21,8 +21,6 @@ export const viewport: Viewport = {
   ],
 };
 
-const themeScript = `(function(){try{var d=document.documentElement,s=localStorage.getItem('theme');if(s==='dark'||s==='light'){d.classList.add(s)}else if(window.matchMedia('(prefers-color-scheme:dark)').matches){d.classList.add('dark')}}catch(e){}})();`;
-
 const Content = styled.div`
   flex: 1;
   padding: ${theme.spacing.large};
@@ -33,9 +31,6 @@ const Content = styled.div`
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
-      </head>
       <body suppressHydrationWarning>
         <StyledComponentsRegistry>
           <CustomThemeProvider>

--- a/packages/sandbox/app/lib/registry.tsx
+++ b/packages/sandbox/app/lib/registry.tsx
@@ -1,16 +1,30 @@
 'use client';
 
 import { useServerInsertedHTML } from 'next/navigation';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
+
+/** FOUC guard for html.dark / html.light; injected via useServerInsertedHTML to avoid React 19's script-in-tree warning. */
+const THEME_BOOT_SCRIPT = `(function(){try{var d=document.documentElement,s=localStorage.getItem('theme');if(s==='dark'||s==='light'){d.classList.add(s)}else if(window.matchMedia('(prefers-color-scheme:dark)').matches){d.classList.add('dark')}}catch(e){}})();`;
 
 export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
   const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+  const themeBootInserted = useRef(false);
 
   useServerInsertedHTML(() => {
     const styles = styledComponentsStyleSheet.getStyleElement();
     styledComponentsStyleSheet.instance.clearTag();
-    return <>{styles}</>;
+    const boot =
+      themeBootInserted.current === false ? (
+        <script key="sc-theme-boot" dangerouslySetInnerHTML={{ __html: THEME_BOOT_SCRIPT }} />
+      ) : null;
+    themeBootInserted.current = true;
+    return (
+      <>
+        {boot}
+        {styles}
+      </>
+    );
   });
 
   if (typeof window !== 'undefined') return <>{children}</>;

--- a/packages/sandbox/app/perf/data-grid/page.tsx
+++ b/packages/sandbox/app/perf/data-grid/page.tsx
@@ -1,12 +1,26 @@
 'use client';
 
-import React, { useState } from 'react';
-import styled, { css } from 'styled-components';
-import { generateCells, type GridCellData } from '../lib/data-generators';
+import React, {
+  memo,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import styled, { css, keyframes } from 'styled-components';
+import { generateCells, patchCells, type GridCellData } from '../lib/data-generators';
 import { TimerDisplay } from '../lib/timer-display';
-import { useAutoRun, useRenderTimer } from '../lib/use-render-timer';
+import { useRenderTimer } from '../lib/use-render-timer';
 
-const CELL_COUNT = 1000;
+/** Large enough that a filter + poll still taxes React + styled-components. */
+const CELL_COUNT = 2000;
+/** Live poll interval (ms). */
+const POLL_MS = 100;
+/** Cells rewritten per poll: enough churn without rebuilding the whole grid. */
+const PATCH_PER_POLL = 400;
 
 type CellStatus = GridCellData['status'];
 type Priority = GridCellData['priority'];
@@ -37,25 +51,83 @@ const priorityBorder = (priority: Priority, theme: any) => {
 
 const initialCells = generateCells(CELL_COUNT, 42);
 
+const GridCell = memo(function GridCell({ cell }: { cell: GridCellData }) {
+  return (
+    <Cell $status={cell.status} $priority={cell.priority}>
+      <CellValue $status={cell.status}>{cell.value}</CellValue>
+      <CellMeta>
+        <PriorityBadge $priority={cell.priority}>{cell.priority[0].toUpperCase()}</PriorityBadge>
+        <IntensityBar $intensity={cell.intensity} $status={cell.status} />
+      </CellMeta>
+    </Cell>
+  );
+});
+
 export default function DataGridPage() {
   const [cells, setCells] = useState(initialCells);
+  /** Sync filter: stays urgent while polls run in transitions. */
+  const [filter, setFilter] = useState('');
+  const [live, setLive] = useState(true);
+  const [isPending, startTransition] = useTransition();
   const { timings, markStart, clear } = useRenderTimer();
+  const pollSample = useRef(0);
 
-  function handleRefresh() {
-    markStart('Refresh All');
-    setCells(generateCells(CELL_COUNT));
-  }
+  /** Defer the heavy grid so filter keystrokes commit without waiting on cell work. */
+  const deferredCells = useDeferredValue(cells);
+  const gridPending = isPending || deferredCells !== cells;
 
-  const { autoRun, start, stop } = useAutoRun(handleRefresh, 50);
+  const poll = useCallback(() => {
+    pollSample.current += 1;
+    if (pollSample.current % 5 === 1) markStart('Poll patch');
+    startTransition(() => {
+      setCells(prev => patchCells(prev, PATCH_PER_POLL));
+    });
+  }, [markStart]);
+
+  const refreshAll = useCallback(() => {
+    markStart('Full refresh');
+    startTransition(() => {
+      setCells(generateCells(CELL_COUNT));
+    });
+  }, [markStart]);
+
+  useEffect(() => {
+    if (!live) return;
+    const id = setInterval(poll, POLL_MS);
+    return () => clearInterval(id);
+  }, [live, poll]);
+
+  const visible = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return deferredCells;
+    return deferredCells.filter(
+      cell => cell.status.includes(q) || cell.priority.includes(q) || String(cell.value).includes(q)
+    );
+  }, [deferredCells, filter]);
 
   return (
     <PageRoot>
       <Header>
         <HeaderLeft>
-          <PageTitle>Monitoring Grid</PageTitle>
-          <DimLabel>{CELL_COUNT} cells</DimLabel>
+          <TitleRow>
+            <PageTitle>Monitoring Grid</PageTitle>
+            <LiveBadge $on={live} aria-live="polite">
+              <LiveDot $on={live} $pending={gridPending} />
+              {live ? 'Live' : 'Paused'}
+            </LiveBadge>
+          </TitleRow>
+          <DimLabel>
+            {CELL_COUNT} cells · ~{PATCH_PER_POLL}/poll every {POLL_MS}ms (transition + deferred)
+          </DimLabel>
         </HeaderLeft>
         <Controls>
+          <FilterField
+            type="search"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            placeholder="Filter status, priority, or value"
+            aria-label="Filter cells"
+          />
           <Legend>
             <Dot $status="ok" />
             ok
@@ -66,29 +138,20 @@ export default function DataGridPage() {
             <Dot $status="inactive" />
             off
           </Legend>
-          <RefreshButton onClick={handleRefresh}>Refresh All</RefreshButton>
+          <RefreshButton type="button" onClick={refreshAll}>
+            Refresh
+          </RefreshButton>
+          <RefreshButton type="button" onClick={() => setLive(v => !v)} $secondary>
+            {live ? 'Pause' : 'Resume'}
+          </RefreshButton>
         </Controls>
       </Header>
 
-      <TimerDisplay
-        timings={timings}
-        onClear={clear}
-        autoRun={autoRun}
-        onAutoStart={start}
-        onAutoStop={stop}
-      />
+      <TimerDisplay timings={timings} onClear={clear} />
 
-      <Grid>
-        {cells.map(cell => (
-          <Cell key={cell.id} $status={cell.status} $priority={cell.priority}>
-            <CellValue $status={cell.status}>{cell.value}</CellValue>
-            <CellMeta>
-              <PriorityBadge $priority={cell.priority}>
-                {cell.priority[0].toUpperCase()}
-              </PriorityBadge>
-              <IntensityBar $intensity={cell.intensity} $status={cell.status} />
-            </CellMeta>
-          </Cell>
+      <Grid aria-busy={gridPending}>
+        {visible.map(cell => (
+          <GridCell key={cell.id} cell={cell} />
         ))}
       </Grid>
     </PageRoot>
@@ -115,12 +178,73 @@ const HeaderLeft = styled.div`
   gap: 4px;
 `;
 
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
 const PageTitle = styled.h1`
   margin: 0;
   font-size: ${p => p.theme.typography.fontSize.large};
   font-family: ${p => p.theme.typography.fontFamily};
   color: ${p => p.theme.colors.text};
   font-weight: 700;
+`;
+
+const LiveBadge = styled.span<{ $on: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: ${p => p.theme.typography.fontFamily};
+  color: ${p => (p.$on ? p.theme.colors.success : p.theme.colors.textMuted)};
+  background: ${p =>
+    p.$on
+      ? `color-mix(in srgb, ${p.theme.colors.success} 14%, ${p.theme.colors.surface})`
+      : p.theme.colors.surface};
+  border: 1px solid
+    ${p =>
+      p.$on
+        ? `color-mix(in srgb, ${p.theme.colors.success} 35%, transparent)`
+        : p.theme.colors.border};
+  transition:
+    color 0.2s ease,
+    background 0.2s ease,
+    border-color 0.2s ease;
+`;
+
+const livePulse = keyframes`
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+`;
+
+const LiveDot = styled.span<{ $on: boolean; $pending: boolean }>`
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: ${p => (p.$on ? p.theme.colors.success : p.theme.colors.textMuted)};
+  box-shadow: ${p =>
+    p.$on && p.$pending
+      ? `0 0 0 3px color-mix(in srgb, ${p.theme.colors.success} 35%, transparent)`
+      : '0 0 0 0 transparent'};
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+  animation: ${p =>
+    p.$on && p.$pending
+      ? css`
+          ${livePulse} 0.9s ease-in-out infinite
+        `
+      : 'none'};
 `;
 
 const DimLabel = styled.span`
@@ -133,6 +257,27 @@ const Controls = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
+  flex-wrap: wrap;
+`;
+
+const FilterField = styled.input`
+  min-width: 220px;
+  padding: 6px 10px;
+  border: 1px solid ${p => p.theme.colors.border};
+  border-radius: 6px;
+  background: ${p => p.theme.colors.surface};
+  color: ${p => p.theme.colors.text};
+  font-size: ${p => p.theme.typography.fontSize.small};
+  font-family: ${p => p.theme.typography.fontFamily};
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+
+  &:focus {
+    outline: none;
+    border-color: ${p => p.theme.colors.primary};
+    box-shadow: 0 0 0 2px color-mix(in srgb, ${p => p.theme.colors.primary} 35%, transparent);
+  }
 `;
 
 const Legend = styled.div`
@@ -152,17 +297,19 @@ const Dot = styled.span<{ $status: CellStatus }>`
   background: ${p => statusColor(p.$status, p.theme)};
 `;
 
-const RefreshButton = styled.button`
+const RefreshButton = styled.button<{ $secondary?: boolean }>`
   padding: ${p => p.theme.spacing.small} ${p => p.theme.spacing.medium};
-  background: ${p => p.theme.colors.primary};
-  color: ${p => p.theme.colors.background};
-  border: none;
+  background: ${p => (p.$secondary ? p.theme.colors.surface : p.theme.colors.primary)};
+  color: ${p => (p.$secondary ? p.theme.colors.text : p.theme.colors.background)};
+  border: 1px solid ${p => (p.$secondary ? p.theme.colors.border : 'transparent')};
   border-radius: 6px;
   font-size: ${p => p.theme.typography.fontSize.small};
   font-family: ${p => p.theme.typography.fontFamily};
   font-weight: 600;
   cursor: pointer;
-  transition: opacity 0.1s;
+  transition:
+    opacity 0.15s ease,
+    transform 0.1s ease;
 
   &:hover {
     opacity: 0.85;
@@ -170,6 +317,7 @@ const RefreshButton = styled.button`
 
   &:active {
     opacity: 0.7;
+    transform: scale(0.97);
   }
 `;
 

--- a/packages/sandbox/app/perf/lib/data-generators.ts
+++ b/packages/sandbox/app/perf/lib/data-generators.ts
@@ -60,6 +60,21 @@ export function generateCells(count: number, seed?: number): GridCellData[] {
   return cells;
 }
 
+/** Replace `count` random entries (new array); ids stay stable for memoized rows. */
+export function patchCells(
+  cells: readonly GridCellData[],
+  count: number,
+  rand: () => number = Math.random
+): GridCellData[] {
+  const next = cells.slice();
+  const n = Math.min(count, next.length);
+  for (let i = 0; i < n; i++) {
+    const idx = (rand() * next.length) | 0;
+    next[idx] = randomCell(next[idx].id, rand);
+  }
+  return next;
+}
+
 export interface DashboardStat {
   id: string;
   label: string;

--- a/packages/styled-components/rollup.config.mjs
+++ b/packages/styled-components/rollup.config.mjs
@@ -117,7 +117,7 @@ const minifierPlugin = terser({
     keep_infinity: true,
     pure_getters: true,
   },
-  ecma: 2015,
+  ecma: 2020,
   format: {
     wrap_func_args: false,
     comments: /^\s*([@#]__[A-Z]+__\s*$|@cc_on)/,

--- a/packages/styled-components/src/constructors/styled.tsx
+++ b/packages/styled-components/src/constructors/styled.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import createStyledComponent from '../models/StyledComponent';
 import { BaseObject, KnownTarget, WebTarget } from '../types';
-import domElements, { SupportedHTMLElements } from '../utils/domElements';
+import type { SupportedHTMLElements } from '../utils/domElements';
 import constructWithOptions, { Styled as StyledInstance } from './constructWithOptions';
 
 /**
@@ -21,17 +21,52 @@ const baseStyled = <Target extends WebTarget, InjectedProps extends object = Bas
     Target extends KnownTarget ? React.ComponentPropsWithRef<Target> & InjectedProps : InjectedProps
   >(createStyledComponent, tag);
 
-const styled = baseStyled as typeof baseStyled & {
+/**
+ * Shape test for a property read that should become a shorthand: all-lowercase
+ * HTML tags, plus the closed set of camelCase SVG names. Deliberately
+ * permissive on the lowercase side so `styled.blink` yields a factory just as
+ * `styled('blink')` does. Excludes `then` because promise adoption would treat
+ * a returned factory as a thenable; other probes (`$$typeof`, `toJSON`,
+ * `displayName`) fail the shape test on their own.
+ */
+const TAG_NAME_RE =
+  /^(?:[a-z][a-z\d]*|fe[A-Z][a-zA-Z]*|clipPath|foreignObject|linearGradient|radialGradient|textPath)$/;
+
+function isTagShorthand(prop: string): boolean {
+  return prop !== 'then' && TAG_NAME_RE.test(prop);
+}
+
+const shorthands = new Map<string, ReturnType<typeof baseStyled>>();
+
+/**
+ * `styled.div` and friends are built on first access and cached, so an app pays
+ * only for the tags it uses and no bundle carries a table of element names.
+ */
+const styled = new Proxy(baseStyled, {
+  get(target, prop) {
+    if (typeof prop === 'string') {
+      const cached = shorthands.get(prop);
+      if (cached !== undefined) return cached;
+
+      if (!(prop in target) && isTagShorthand(prop)) {
+        const shorthand = baseStyled(prop);
+        shorthands.set(prop, shorthand);
+        return shorthand;
+      }
+    }
+
+    return Reflect.get(target, prop);
+  },
+
+  /** Feature detection (`'div' in styled`) has to agree with what `get` answers. */
+  has(target, prop) {
+    return prop in target || (typeof prop === 'string' && isTagShorthand(prop));
+  },
+
+  // The mapped type below is the contract; the trap answers for every member of it.
+}) as typeof baseStyled & {
   [E in SupportedHTMLElements]: StyledInstance<'web', E, React.JSX.IntrinsicElements[E]>;
 };
-
-// Shorthands for all valid HTML Elements.
-// The type assertion avoids 120 Styled<> instantiations during type checking;
-// the correct types are declared on the `styled` const above via the mapped type.
-const styledShorthands = styled as Record<SupportedHTMLElements, ReturnType<typeof baseStyled>>;
-domElements.forEach(domElement => {
-  styledShorthands[domElement] = baseStyled(domElement);
-});
 
 export default styled;
 export { StyledInstance };

--- a/packages/styled-components/src/constructors/test/styled.test.tsx
+++ b/packages/styled-components/src/constructors/test/styled.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 import { getRenderedCSS, resetStyled } from '../../test/utils';
-import domElements from '../../utils/domElements';
+import { elements } from '../../utils/domElements';
 
 let styled: ReturnType<typeof resetStyled>;
 
@@ -11,9 +11,61 @@ describe('styled', () => {
   });
 
   it('should have all valid HTML5 elements defined as properties', () => {
-    domElements.forEach(domElement => {
-      expect(styled[domElement]).toBeTruthy();
+    elements.forEach(element => {
+      expect(styled[element]).toBeTruthy();
     });
+  });
+
+  it('renders a shorthand as its tag', () => {
+    const Box = styled.section`
+      color: red;
+    `;
+
+    const { container } = render(<Box />);
+
+    expect(container.firstElementChild?.tagName).toBe('SECTION');
+  });
+
+  it('returns the same factory for repeated access to a shorthand', () => {
+    expect(styled.div).toBe(styled.div);
+  });
+
+  it('leaves probe property reads undefined so serializers and thenables are not answered', () => {
+    // `then` is lowercase so it needs an explicit exclusion; camelCase probes
+    // (`toJSON`, `displayName`, `asymmetricMatch`) fail the tag-shape test.
+    const readProperty = (target: object, key: PropertyKey): unknown => Reflect.get(target, key);
+
+    for (const key of [
+      '$$typeof',
+      'then',
+      '__esModule',
+      'Fragment',
+      '_owner',
+      'DIV',
+      'toJSON',
+      'displayName',
+      'asymmetricMatch',
+      'nodeType',
+    ]) {
+      expect(readProperty(styled, key)).toBeUndefined();
+      expect(key in styled).toBe(false);
+    }
+
+    expect(readProperty(styled, Symbol.iterator)).toBeUndefined();
+  });
+
+  it('reports tag shorthands as present so feature detection agrees with access', () => {
+    expect('div' in styled).toBe(true);
+    expect('feBlend' in styled).toBe(true);
+    expect('clipPath' in styled).toBe(true);
+    expect('then' in styled).toBe(false);
+    expect('$$typeof' in styled).toBe(false);
+    expect('toJSON' in styled).toBe(false);
+  });
+
+  it('keeps its own function properties readable through the shorthand trap', () => {
+    expect(typeof styled.name).toBe('string');
+    expect(typeof styled.call).toBe('function');
   });
 
   it('should expose the component static attribute like components', () => {

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -61,6 +61,60 @@ const hasOwn = Object.prototype.hasOwnProperty;
 
 const identifiers: { [key: string]: number } = {};
 
+const subscribeNoop = (): (() => void) => () => {};
+const getFalse = (): boolean => false;
+const getTrue = (): boolean => true;
+
+/**
+ * Writes one render's generated CSS into the sheet from an insertion effect,
+ * so a committed render's rules land before paint and a discarded render
+ * writes nothing. Mounted only when a render still has unwritten rules.
+ */
+function StyleInjector({
+  generated,
+  sheet,
+  webStyle,
+}: {
+  generated: GeneratedStyle;
+  sheet: StyleSheet;
+  webStyle: WebStyle;
+}): null {
+  // getServerSnapshot runs under renderToString; getSnapshot under createRoot.
+  // Distinguishes the jsdom-without-ServerStyleSheet footgun (buffered path,
+  // insertion effects never fire) from a normal client mount, without the
+  // false positives a post-render microtask probe would raise on discarded
+  // concurrent renders.
+  const isServerRender = React.useSyncExternalStore(subscribeNoop, getFalse, getTrue);
+  if (__DEV__ && isServerRender) {
+    warnOnce(
+      'buffered-ssr-without-sheet',
+      'client styles inject through useInsertionEffect, which does not run during renderToString / renderToStaticMarkup. Wrap the tree in ServerStyleSheet#collectStyles so styles flush during render.'
+    );
+  }
+  React.useInsertionEffect(() => {
+    webStyle.inject(sheet, generated);
+  });
+  return null;
+}
+
+/** True when `generated` carries rules or keyframes the sheet has not emitted. */
+function generatedNeedsSheetWrite(generated: GeneratedStyle, sheet: StyleSheet): boolean {
+  if (generated.keyframes.length > 0) {
+    for (let i = 0; i < generated.keyframes.length; i++) {
+      const kf = generated.keyframes[i];
+      if (!sheet.hasNameForId(kf.id, kf.name)) return true;
+    }
+  }
+  const levels = generated.levels;
+  for (let i = 0; i < levels.length; i++) {
+    const level = levels[i];
+    if (level.rules.length > 0 && !sheet.hasNameForId(level.componentId, level.name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Shared `toString` for styled components: returns `.styledComponentId` so
  * `${StyledFoo}` interpolation resolves to the class selector.
@@ -138,7 +192,8 @@ function rscFlush<T extends ExecutionContext>(
 }
 
 // Cached render inputs + style result: [prevProps, prevTheme, prevStyleSheet, prevCompiler,
-// prevPropsKeyCount, cachedContext, cachedClassName, prevWebStyle, popOverrides]
+// prevPropsKeyCount, cachedContext, cachedClassName, prevWebStyle, popOverrides,
+// cachedGenerated]
 type RenderCache = [
   object, // prevProps
   DefaultTheme | undefined, // prevTheme
@@ -149,6 +204,7 @@ type RenderCache = [
   string, // cachedClassName
   WebStyle, // prevWebStyle (for HMR invalidation)
   Dict<string> | null, // popOverrides (post-compile attrs inline-style override)
+  GeneratedStyle | null, // cachedGenerated (reinject if a discarded attempt left the sheet empty)
 ];
 
 function resolveContext<Props extends BaseObject>(
@@ -506,6 +562,8 @@ function useImpl<Props extends BaseObject>(
   let generatedStyle: GeneratedStyle | null = null;
   let popOverrides: Dict<string> | null = null;
   const wantsPostAttrs = forwardedComponent.hasPostAttrs === true;
+  /** The CSSOM write to schedule in the insertion effect (buffered path only). */
+  let pendingInject: GeneratedStyle | null = null;
 
   if (!__SERVER__ && !IS_RSC) {
     const renderCacheRef = React.useRef<RenderCache | null>(null);
@@ -522,6 +580,16 @@ function useImpl<Props extends BaseObject>(
       context = prev[5] as typeof context;
       generatedClassName = prev[6];
       popOverrides = prev[8];
+      // A discarded concurrent attempt may have cached a GeneratedStyle whose
+      // rules never reached the sheet; reinstate the injector when needed.
+      const cachedGenerated = prev[9];
+      if (
+        cachedGenerated != null &&
+        !ssc.styleSheet.server &&
+        generatedNeedsSheetWrite(cachedGenerated, ssc.styleSheet)
+      ) {
+        pendingInject = cachedGenerated;
+      }
     } else {
       context = resolveContext<Props>(componentAttrs, props, theme);
       if (wantsPostAttrs) {
@@ -533,7 +601,18 @@ function useImpl<Props extends BaseObject>(
           webStyle
         );
       }
-      generatedClassName = useInjectedStyle(webStyle, context, ssc.styleSheet, ssc.compiler);
+      // ServerStyleSheet SSR never runs insertion effects, so the CSSOM write
+      // must stay synchronous whenever styleSheet.server is set. The browser
+      // path generates during render and injects via StyleInjector.
+      let cachedGenerated: GeneratedStyle | null = null;
+      if (!ssc.styleSheet.server) {
+        const generated = webStyle.generate(context, ssc.styleSheet, ssc.compiler);
+        generatedClassName = generated.className;
+        cachedGenerated = generated;
+        pendingInject = generatedNeedsSheetWrite(generated, ssc.styleSheet) ? generated : null;
+      } else {
+        generatedClassName = useInjectedStyle(webStyle, context, ssc.styleSheet, ssc.compiler);
+      }
 
       let propsKeyCount = 0;
       for (const key in props) {
@@ -549,6 +628,7 @@ function useImpl<Props extends BaseObject>(
         generatedClassName,
         webStyle,
         popOverrides,
+        cachedGenerated,
       ];
     }
   } else {
@@ -603,7 +683,32 @@ function useImpl<Props extends BaseObject>(
     elementProps.ref = forwardedRef;
   }
 
+  // Client path: stable Fragment shape so the host element keeps identity
+  // when the injector mounts or unmounts across commits. Only instances that
+  // still need a CSSOM write mount StyleInjector.
+  const injectsAfterCommit = !__SERVER__ && !IS_RSC && !ssc.styleSheet.server;
+
+  if (injectsAfterCommit) {
+    elementProps.key = 'sc-el';
+  }
+
   const element = createElement(elementToBeCreated, elementProps);
+
+  if (injectsAfterCommit) {
+    return createElement(
+      React.Fragment,
+      null,
+      pendingInject
+        ? createElement(StyleInjector, {
+            key: 'sc-inject',
+            generated: pendingInject,
+            sheet: ssc.styleSheet,
+            webStyle,
+          })
+        : null,
+      element
+    );
+  }
 
   // RSC mode: emit this component's CSS (and its inheritance chain + keyframes)
   // as an inline <style> tag. No `precedence`; server component output isn't

--- a/packages/styled-components/src/models/WebStyle.ts
+++ b/packages/styled-components/src/models/WebStyle.ts
@@ -35,6 +35,11 @@ type GeneratedLevel = {
   componentId: string;
   name: string;
   rules: string[];
+  /**
+   * True when this generate call won the name claim and produced `rules`.
+   * A later claimant sees false but still receives the winner's `rules` so
+   * inject can write them if the winner's render was discarded.
+   */
   isNew: boolean;
 };
 
@@ -83,8 +88,10 @@ export default class WebStyle {
   }
 
   /**
-   * Produce per-level compiled CSS without writing to the sheet. Walks the
-   * inheritance chain so callers get the full chain's output in one pass.
+   * Produce per-level compiled CSS without writing any rules to the tag.
+   * Claims each level's name on the sheet for the current turn so a sibling
+   * generating the same class skips recompilation; the CSSOM write happens
+   * in {@link inject}.
    */
   generate(
     executionContext: ExecutionContext,
@@ -202,10 +209,13 @@ export default class WebStyle {
       }
     }
 
-    const isNew = !styleSheet.hasNameForId(this.componentId, name);
+    // Permanent registration or a same-turn claim by a sibling both mean the
+    // rules already exist, so skip compilation. Followers still receive the
+    // winner's bytes so a discarded claimer cannot leave them empty-handed.
+    const claimed = styleSheet.claimNameForId(this.componentId, name);
     let rules: string[];
-    if (!isNew) {
-      rules = EMPTY_RULES;
+    if (!claimed) {
+      rules = styleSheet.getProvisionalRules(this.componentId, name) ?? EMPTY_RULES;
     } else if (source !== null && fastFilled !== null) {
       const fast = compiler.emit(source, fastFilled, '.' + name, this.componentId, fastFragments);
       if (fast !== null) {
@@ -216,12 +226,14 @@ export default class WebStyle {
         if (!css) css = buildHashCSS(source.strings, fastFilled, fastFragments);
         rules = compiler.compile(css, '.' + name, undefined, this.componentId);
       }
+      styleSheet.stashProvisionalRules(this.componentId, name, rules);
     } else {
       rules = compiler.compile(css, '.' + name, undefined, this.componentId);
+      styleSheet.stashProvisionalRules(this.componentId, name, rules);
     }
 
     const levels = baseGenerated ? baseGenerated.levels.slice() : [];
-    levels.push({ componentId: this.componentId, name, rules, isNew });
+    levels.push({ componentId: this.componentId, name, rules, isNew: claimed });
 
     return {
       className: joinStrings(baseGenerated ? baseGenerated.className : '', name),
@@ -237,7 +249,9 @@ export default class WebStyle {
     const levels = generated.levels;
     for (let i = 0; i < levels.length; i++) {
       const level = levels[i];
-      if (level.isNew) {
+      // Write whenever this payload carries rules the sheet lacks. Followers
+      // may hold the winner's bytes with `isNew` false after a discarded claim.
+      if (level.rules.length > 0 && !styleSheet.hasNameForId(level.componentId, level.name)) {
         styleSheet.insertRules(level.componentId, level.name, level.rules);
       }
     }

--- a/packages/styled-components/src/models/test/BufferedInjection.test.tsx
+++ b/packages/styled-components/src/models/test/BufferedInjection.test.tsx
@@ -1,0 +1,389 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { act, render } from '@testing-library/react';
+import keyframes from '../../constructors/keyframes';
+import { resetStyled, getCSS } from '../../test/utils';
+import StyleSheet from '../../sheet/Sheet';
+import ServerStyleSheet from '../ServerStyleSheet';
+
+let styled: ReturnType<typeof resetStyled>;
+
+describe('buffered style injection (useInsertionEffect)', () => {
+  beforeEach(() => {
+    styled = resetStyled();
+  });
+
+  it('still produces the class name on the render path', () => {
+    const Box = styled.div`
+      color: red;
+    `;
+    const { container } = render(<Box />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toMatch(/sc-/);
+    expect(el.className.split(' ').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('applies the emitted CSS after the insertion effect commits', () => {
+    const Box = styled.div`
+      color: rgb(1, 2, 3);
+    `;
+    render(<Box />);
+    expect(getCSS(document)).toContain('rgb(1, 2, 3)');
+  });
+
+  it('applies styles for blocking updates without startTransition', () => {
+    // Concurrent features off: a plain setState commit must still inject
+    // before paint via useInsertionEffect.
+    const Box = styled.div<{ $c: string }>`
+      color: ${p => p.$c};
+    `;
+    const { rerender } = render(<Box $c="rgb(2, 2, 2)" />);
+    expect(getCSS(document)).toContain('rgb(2, 2, 2)');
+    rerender(<Box $c="rgb(3, 3, 3)" />);
+    expect(getCSS(document)).toContain('rgb(3, 3, 3)');
+  });
+
+  it('ServerStyleSheet SSR still flushes synchronously (no insertion effects)', () => {
+    // renderToString never runs useInsertionEffect; styles must land during
+    // render when styleSheet.server is set.
+    const sheet = new ServerStyleSheet();
+    const Box = styled.div`
+      color: rgb(12, 12, 12);
+    `;
+    try {
+      renderToString(sheet.collectStyles(<Box />));
+      expect(sheet.getStyleTags()).toContain('rgb(12, 12, 12)');
+    } finally {
+      sheet.seal();
+    }
+  });
+
+  it('injects via an insertion effect, not synchronously during render', () => {
+    // Probe inside the render body, after the styled component has rendered:
+    // if the rule is already in the CSSOM at that point, the flush was
+    // synchronous; the buffered path must still have an empty sheet here.
+    let duringRenderCss = '';
+    const Probe = () => {
+      duringRenderCss = getCSS(document) || '';
+      return null;
+    };
+
+    const Box = styled.div`
+      color: rgb(9, 9, 9);
+    `;
+
+    render(
+      <React.Fragment>
+        <Box />
+        <Probe />
+      </React.Fragment>
+    );
+
+    expect(duringRenderCss).not.toContain('rgb(9, 9, 9)');
+    expect(getCSS(document)).toContain('rgb(9, 9, 9)');
+  });
+
+  it('does not inject for a render that is discarded before commit', () => {
+    class Boundary extends React.Component<{ children: React.ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? null : this.props.children;
+      }
+    }
+
+    const Box = styled.div`
+      color: rgb(11, 11, 11);
+    `;
+    const Thrower = () => {
+      throw new Error('boom');
+    };
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        <Boundary>
+          <Box />
+          <Thrower />
+        </Boundary>
+      );
+      expect(getCSS(document)).not.toContain('rgb(11, 11, 11)');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('injects keyframes before the component rule that references them', () => {
+    const pulse = keyframes`
+      from { opacity: 0; }
+      to { opacity: 1; }
+    `;
+    const Box = styled.div`
+      animation: ${pulse} 2s linear infinite;
+      color: blue;
+    `;
+    render(<Box />);
+
+    const css = getCSS(document);
+    expect(css).toContain('@keyframes');
+    expect(css).toContain('animation:');
+    expect(css.indexOf('@keyframes')).toBeLessThan(css.indexOf('animation:'));
+  });
+
+  it('dedupes same-class siblings within one commit', () => {
+    // All instances generate before any effect runs. Provisional name claims
+    // make only the first compile; inject-time hasNameForId still guards
+    // against duplicate CSSOM writes.
+    const insertRuleSpy = jest.spyOn(CSSStyleSheet.prototype, 'insertRule');
+
+    try {
+      const Box = styled.div`
+        color: rgb(4, 4, 4);
+      `;
+      render(
+        <React.Fragment>
+          <Box />
+          <Box />
+          <Box />
+        </React.Fragment>
+      );
+
+      const forOurRule = insertRuleSpy.mock.calls.filter(([rule]) =>
+        String(rule).includes('rgb(4, 4, 4)')
+      );
+      expect(forOurRule).toHaveLength(1);
+    } finally {
+      insertRuleSpy.mockRestore();
+    }
+  });
+
+  it('claims a shared class only once among same-class siblings', () => {
+    const Box = styled.div`
+      color: rgb(6, 6, 6);
+    `;
+    const claimSpy = jest.spyOn(StyleSheet.prototype, 'claimNameForId');
+    try {
+      render(
+        <React.Fragment>
+          <Box />
+          <Box />
+          <Box />
+        </React.Fragment>
+      );
+      expect(claimSpy.mock.results.filter(r => r.value === true)).toHaveLength(1);
+      expect(claimSpy.mock.results.filter(r => r.value === false)).toHaveLength(2);
+    } finally {
+      claimSpy.mockRestore();
+    }
+  });
+
+  it('still writes once when every same-class sibling schedules an insertion effect', () => {
+    // Followers carry the winner's rules so a discarded claimer cannot leave
+    // a committed sibling with an empty payload. Sheet registration still
+    // dedupes the CSSOM write.
+    const insertRuleSpy = jest.spyOn(CSSStyleSheet.prototype, 'insertRule');
+    try {
+      const Box = styled.div`
+        color: rgb(7, 7, 7);
+      `;
+      render(
+        <React.Fragment>
+          <Box />
+          <Box />
+          <Box />
+        </React.Fragment>
+      );
+      const forOurRule = insertRuleSpy.mock.calls.filter(([rule]) =>
+        String(rule).includes('rgb(7, 7, 7)')
+      );
+      expect(forOurRule).toHaveLength(1);
+      expect(getCSS(document)).toContain('rgb(7, 7, 7)');
+    } finally {
+      insertRuleSpy.mockRestore();
+    }
+  });
+
+  it('injects when the claimer is discarded and a same-class sibling commits', () => {
+    class Boundary extends React.Component<{ children: React.ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? null : this.props.children;
+      }
+    }
+
+    const Box = styled.div`
+      color: rgb(8, 8, 8);
+    `;
+    const Thrower = () => {
+      throw new Error('boom');
+    };
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        <React.Fragment>
+          <Boundary>
+            <Box />
+            <Thrower />
+          </Boundary>
+          <Box />
+        </React.Fragment>
+      );
+      expect(getCSS(document)).toContain('rgb(8, 8, 8)');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('injects after a discarded concurrent attempt whose className was cached', async () => {
+    // A transition update that suspends mid-tree can leave a generate() result
+    // in the render cache. The retry must still write the rules that attempt
+    // never committed.
+    let resolve: (() => void) | undefined;
+    const promise = new Promise<void>(r => {
+      resolve = r;
+    });
+    let shouldSuspend = false;
+
+    const Box = styled.div<{ $c: string }>`
+      color: ${p => p.$c};
+    `;
+
+    function Suspender() {
+      if (shouldSuspend) throw promise;
+      return null;
+    }
+
+    function App({ color }: { color: string }) {
+      return (
+        <React.Suspense fallback={null}>
+          <Box $c={color} />
+          <Suspender />
+        </React.Suspense>
+      );
+    }
+
+    const { rerender } = render(<App color="rgb(1, 1, 1)" />);
+    expect(getCSS(document)).toContain('rgb(1, 1, 1)');
+
+    shouldSuspend = true;
+    React.startTransition(() => {
+      rerender(<App color="rgb(14, 14, 14)" />);
+    });
+
+    // Discarded attempt generated the new class; sheet must not have it yet.
+    expect(getCSS(document)).not.toContain('rgb(14, 14, 14)');
+
+    shouldSuspend = false;
+    await act(async () => {
+      resolve!();
+    });
+
+    expect(getCSS(document)).toContain('rgb(14, 14, 14)');
+  });
+
+  it('dedupes a later commit whose class was already written', () => {
+    const insertRuleSpy = jest.spyOn(CSSStyleSheet.prototype, 'insertRule');
+
+    try {
+      const Box = styled.div<{ $n?: number }>`
+        color: rgb(5, 5, ${props => props.$n ?? 5});
+      `;
+      const { rerender } = render(<Box $n={5} />);
+      rerender(<Box $n={5} />);
+
+      const forOurRule = insertRuleSpy.mock.calls.filter(([rule]) =>
+        String(rule).includes('rgb(5, 5, 5)')
+      );
+      expect(forOurRule).toHaveLength(1);
+    } finally {
+      insertRuleSpy.mockRestore();
+    }
+  });
+
+  it('writes base rules when a discarded claimer held the base of an inheritance chain', () => {
+    // Base wins the claim inside a throwing boundary; the extension outside
+    // commits. inject walks every level, so the extension's StyleInjector
+    // writes the base bytes it carried as a follower.
+    class Boundary extends React.Component<{ children: React.ReactNode }, { failed: boolean }> {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? null : this.props.children;
+      }
+    }
+
+    const Base = styled.div`
+      color: rgb(20, 20, 20);
+    `;
+    const Extended = styled(Base)`
+      font-weight: 700;
+    `;
+    const Thrower = () => {
+      throw new Error('boom');
+    };
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        <React.Fragment>
+          <Boundary>
+            <Base />
+            <Thrower />
+          </Boundary>
+          <Extended />
+        </React.Fragment>
+      );
+      const css = getCSS(document);
+      expect(css).toContain('rgb(20, 20, 20)');
+      expect(css).toMatch(/font-weight:\s*700/);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('jsdom renderToString without ServerStyleSheet writes no CSS and warns', () => {
+    // jsdom makes IS_BROWSER true, so the default sheet has server=false and
+    // the buffered path schedules useInsertionEffect. renderToString never
+    // runs those effects, so styles are silent without collectStyles.
+    const { resetWarnOnce } = require('../../utils/warnOnce');
+    resetWarnOnce();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const Box = styled.div`
+        color: rgb(21, 21, 21);
+      `;
+      renderToString(<Box />);
+      expect(getCSS(document)).not.toContain('rgb(21, 21, 21)');
+      expect(warnSpy.mock.calls.some(args => String(args[0]).includes('ServerStyleSheet'))).toBe(
+        true
+      );
+    } finally {
+      warnSpy.mockRestore();
+      resetWarnOnce();
+    }
+  });
+
+  it('createRoot mount does not warn about ServerStyleSheet', () => {
+    const { resetWarnOnce } = require('../../utils/warnOnce');
+    resetWarnOnce();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const Box = styled.div`
+        color: rgb(22, 22, 22);
+      `;
+      render(<Box />);
+      expect(getCSS(document)).toContain('rgb(22, 22, 22)');
+      expect(warnSpy.mock.calls.some(args => String(args[0]).includes('ServerStyleSheet'))).toBe(
+        false
+      );
+    } finally {
+      warnSpy.mockRestore();
+      resetWarnOnce();
+    }
+  });
+});

--- a/packages/styled-components/src/native/web-bridge/index.tsx
+++ b/packages/styled-components/src/native/web-bridge/index.tsx
@@ -534,18 +534,38 @@ function bridgeStyledCall<T>(target: T): unknown {
   const result = (styledWeb as unknown as (t: T) => Factoryish)(effectiveTarget);
   return wrapBridgeFactory(result, allLifts);
 }
-styled = bridgeStyledCall as unknown as typeof styledWeb & BridgedNamespace;
-for (const key of Object.keys(styledWeb)) {
-  const value = (styledWeb as unknown as Record<string, unknown>)[key];
-  if (typeof value === 'function') {
-    (styled as unknown as Record<string, unknown>)[key] = wrapBridgeFactory(
-      value as Factoryish,
-      allLifts
-    );
-  } else {
-    (styled as unknown as Record<string, unknown>)[key] = value;
-  }
-}
+const bridgedShorthands = new Map<string, Factoryish>();
+
+/**
+ * HTML and SVG shorthands (`styled.a`, `styled.div`) come from the web factory
+ * wrapped in the bridge's lifts. Whether a name is a tag shorthand at all is the
+ * web factory's decision, so this asks it rather than repeating the test; the
+ * alias getters installed below own every name they define.
+ */
+styled = new Proxy(bridgeStyledCall, {
+  get(target, prop) {
+    if (typeof prop === 'string') {
+      const cached = bridgedShorthands.get(prop);
+      if (cached !== undefined) return cached;
+
+      if (!(prop in target)) {
+        const webFactory: unknown = Reflect.get(styledWeb, prop);
+        if (typeof webFactory === 'function') {
+          const bridged = wrapBridgeFactory(webFactory as Factoryish, allLifts);
+          bridgedShorthands.set(prop, bridged);
+          return bridged;
+        }
+      }
+    }
+
+    return Reflect.get(target, prop);
+  },
+
+  /** Match the web factory so `'div' in styled` agrees with `styled.div`. */
+  has(target, prop) {
+    return prop in target || Reflect.has(styledWeb, prop);
+  },
+}) as unknown as typeof styledWeb & BridgedNamespace;
 
 type Factoryish = ((
   strings: TemplateStringsArray,

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -10,6 +10,9 @@ import { GroupedTag, Sheet, SheetOptions } from './types';
 
 let SHOULD_REHYDRATE = IS_BROWSER;
 
+/** Placeholder until the claim winner stashes compiled rules. */
+const EMPTY_PROVISIONAL: string[] = [];
+
 type SheetConstructorArgs = {
   isServer?: boolean;
   nonce?: string | undefined;
@@ -26,6 +29,14 @@ const defaultOptions: SheetOptions = {
 export default class StyleSheet implements Sheet {
   names: NamesAllocationMap;
   options: SheetOptions;
+  /**
+   * Turn-scoped compiled rules keyed by `id\\0name`. The first generate for a
+   * name compiles and stores here; same-turn siblings reuse the bytes so a
+   * discarded claimer cannot leave a committed follower with an empty payload.
+   * Dropped on a microtask so a discarded concurrent render cannot pin a name
+   * past the turn that claimed it.
+   */
+  provisionalRules: Map<string, string[]> | null = null;
   server: boolean;
   tag?: GroupedTag | undefined;
 
@@ -87,9 +98,49 @@ export default class StyleSheet implements Sheet {
     return this.tag || (this.tag = makeGroupedTag(makeTag(this.options)));
   }
 
-  /** Check whether a name is known for caching */
+  /** Check whether a name is permanently registered, meaning its rules have already been emitted for this sheet. */
   hasNameForId(id: string, name: string): boolean {
     return this.names.get(id)?.has(name) ?? false;
+  }
+
+  /**
+   * Claim a name for this JS turn so later generates skip recompilation.
+   * Returns true if this call is the first claim (caller should compile and
+   * then {@link stashProvisionalRules}). Does not permanently register;
+   * inject / registerName still required.
+   *
+   * Server sheets skip the provisional store: sync flush registers on inject
+   * in the same call stack, so turn-scoped bookkeeping would only allocate.
+   */
+  claimNameForId(id: string, name: string): boolean {
+    if (this.hasNameForId(id, name)) return false;
+    if (this.server) return true;
+    const key = id + '\0' + name;
+    let map = this.provisionalRules;
+    if (map === null) {
+      map = new Map();
+      this.provisionalRules = map;
+      queueMicrotask(() => {
+        this.provisionalRules = null;
+      });
+    } else if (map.has(key)) {
+      return false;
+    }
+    map.set(key, EMPTY_PROVISIONAL);
+    return true;
+  }
+
+  /** Store compiled rules for same-turn followers after a successful claim. */
+  stashProvisionalRules(id: string, name: string, rules: string[]): void {
+    const map = this.provisionalRules;
+    if (map === null) return;
+    map.set(id + '\0' + name, rules);
+  }
+
+  /** Rules stashed by the turn's claim winner, if any. */
+  getProvisionalRules(id: string, name: string): string[] | undefined {
+    const rules = this.provisionalRules?.get(id + '\0' + name);
+    return rules === undefined || rules === EMPTY_PROVISIONAL ? undefined : rules;
   }
 
   /** Mark a group's name as known for caching; returns the group id. */

--- a/packages/styled-components/src/sheet/test/Sheet.test.ts
+++ b/packages/styled-components/src/sheet/test/Sheet.test.ts
@@ -18,6 +18,35 @@ it('inserts rules correctly', () => {
   expect(tag.length).toBe(1);
 });
 
+it('claimNameForId reserves a name for the current turn without registering', () => {
+  // Client sheet: server sheets skip the provisional store entirely.
+  const client = new StyleSheet({ isServer: false });
+  expect(client.claimNameForId('id', 'name')).toBe(true);
+  expect(client.claimNameForId('id', 'name')).toBe(false);
+  // Provisional only: not permanently registered until insertRules/registerName.
+  expect(client.hasNameForId('id', 'name')).toBe(false);
+  client.registerName('id', 'name');
+  expect(client.hasNameForId('id', 'name')).toBe(true);
+  expect(client.claimNameForId('id', 'name')).toBe(false);
+});
+
+it('shares stashed rules with same-turn followers and clears them after the turn', async () => {
+  const client = new StyleSheet({ isServer: false });
+  expect(client.claimNameForId('id', 'temp')).toBe(true);
+  client.stashProvisionalRules('id', 'temp', ['.temp{}']);
+  expect(client.claimNameForId('id', 'temp')).toBe(false);
+  expect(client.getProvisionalRules('id', 'temp')).toEqual(['.temp{}']);
+  await Promise.resolve();
+  expect(client.getProvisionalRules('id', 'temp')).toBeUndefined();
+  expect(client.claimNameForId('id', 'temp')).toBe(true);
+});
+
+it('skips provisional bookkeeping on server sheets', () => {
+  expect(sheet.claimNameForId('id', 'a')).toBe(true);
+  expect(sheet.claimNameForId('id', 'a')).toBe(true);
+  expect(sheet.getProvisionalRules('id', 'a')).toBeUndefined();
+});
+
 it('allows to register and clear names for ids manually', () => {
   sheet.registerName('id', 'name');
   expect(sheet.hasNameForId('id', 'name')).toBe(true);

--- a/packages/styled-components/src/sheet/types.ts
+++ b/packages/styled-components/src/sheet/types.ts
@@ -25,15 +25,18 @@ export type SheetOptions = {
 };
 
 export interface Sheet {
+  claimNameForId(id: string, name: string): boolean;
   clearNames(id: string): void;
   clearRules(id: string): void;
   clearTag(): void;
+  getProvisionalRules(id: string, name: string): string[] | undefined;
   getTag(): GroupedTag;
   hasNameForId(id: string, name: string): boolean;
   insertRules(id: string, name: string, rules: string[]): void;
-  options: SheetOptions;
   names: Map<string, Set<string>>;
+  options: SheetOptions;
   registerName(id: string, name: string): number;
   rehydrate(): void;
+  stashProvisionalRules(id: string, name: string, rules: string[]): void;
   toString(): string;
 }

--- a/packages/styled-components/src/test/treeshake.test.ts
+++ b/packages/styled-components/src/test/treeshake.test.ts
@@ -470,10 +470,11 @@ describe('per-plugin DCE from plugins subpath', () => {
 });
 
 describe('bundle size', () => {
-  // NOTE (v7): ceilings are intentionally loose through the v7 development
-  // cycle. Ratchet down to the v7 targets (standalone 12.0 kB / webpack 6.8 kB
-  // / all-in 10.5 kB) toward release. See AGENTS.md → CSS Parser for arc.
-  it('standalone minified bundle is under 15.5kB gzip', () => {
+  // Ceilings sit just above the current figures so any regression trips here.
+  // `pnpm --filter styled-components test:build` prints each live number.
+  // v7 release targets to ratchet toward: standalone 12.0kB, webpack 6.8kB,
+  // all-in 10.5kB.
+  it('standalone minified bundle stays under its gzip ceiling', () => {
     const zlib = require('zlib');
     const minified = fs.readFileSync(path.join(distDir, 'styled-components.min.js'));
     const gzipped = zlib.gzipSync(minified);
@@ -481,15 +482,12 @@ describe('bundle size', () => {
 
     console.log(`  styled-components.min.js: ${sizeKB.toFixed(2)}kB gzip`);
 
-    // Bumped from 15kB after the arity-2 attrs feature shipped (CompiledAst
-    // pop/peek): adds ~0.7kB of always-shipped trace + runtime-fallback
-    // scaffolding. Worth it for the third-party-component bridge ergonomics.
-    // Bumped again for the fragment-slot missing-`;` recovery in the parser
-    // (~0.1kB of charCode imports + the cssProduct structure check).
-    // Bumped for multi-result plugin composition in createCompiler (~0.1kB).
-    expect(sizeKB).toBeLessThan(15.6);
+    // Carries every export, so this is the widest surface: the in-house parser,
+    // arity-2 attrs tracing with its runtime fallback, and the server entry
+    // points a consumer bundle would shake away. Ceiling includes buffered
+    // injection (StyleInjector + provisional rule stash) on top of main.
+    expect(sizeKB).toBeLessThan(15.4);
   });
-
   it('production bundle size with real bundler tree-shaking', async () => {
     const webpack = require('webpack');
     const zlib = require('zlib');
@@ -550,29 +548,31 @@ describe('bundle size', () => {
       expect(bundle).not.toContain('border-top-left-radius');
       expect(bundle).not.toContain('styled-components/plugins/rtl');
 
-      // Phase 1 + 2 + B + C + D + E architecture: Source + AST-direct emit
-      // + pre-classified slot kinds + fragment splicing + on-demand string
-      // fragments + Source synthesis for non-`css(...)` inputs + objectToCSS
-      // / objectToTemplate + Phase C TemplateValue + interpolation-sentinel
-      // gate (`ParseContext.templates`) hardening the static-input parse
-      // path against malicious user-supplied filled[] values that contain
-      // sentinel-shaped byte patterns. Plus arity-2 attrs (CompiledAst
-      // pop/peek) trace + runtime-fallback scaffolding: ~0.6kB. Net
-      // ~2.5kB above v6.4.1 baseline after scanQP/isWS scan-primitive
-      // unification. Plus fragment-slot missing-`;` recovery: ~0.1kB.
-      // Plus multi-result plugin composition: ~0.1kB.
-      expect(sizeKB).toBeLessThan(14.4);
+      // `styled.div` is synthesized on first access, so the element table does
+      // not ship. A few camelCase SVG names remain in the shorthand shape
+      // test; assert names that exist only in the dropped table.
+      expect(bundle).not.toContain('blockquote');
+      expect(bundle).not.toContain('feConvolveMatrix');
+      expect(bundle).not.toContain('optgroup');
+      // Control for the tag-name checks above: a string that IS present, proving
+      // the probe reads a bundle it can actually match against.
+      expect(bundle).toContain('sc-');
+
+      // The in-house parser (Source, AST-direct emit, fragment splicing,
+      // interpolation-sentinel gating) is reachable from any styled call, so it
+      // dominates what survives here and cannot shake away. Ceiling includes
+      // buffered injection on top of main's plugin composition.
+      expect(sizeKB).toBeLessThan(14.3);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30000);
 
-  it('all-in consumer bundle (only react/react-dom external) stays smaller than v6.4.1', async () => {
+  it('all-in consumer bundle (only react/react-dom external) stays under its gzip ceiling', async () => {
     // Real consumer cost: what an app actually ships when it imports
     // styled-components. v6 shipped a bundled CSS preprocessor; v7 replaced it with the
     // in-house parser AND inlined the prop-validator (formerly
-    // @emotion/is-prop-valid). This test guards against transitive-dep drift
-    // and locks in v7's all-in win over v6 so regressions are caught early.
+    // @emotion/is-prop-valid). This test guards against transitive-dep drift.
     const webpack = require('webpack');
     const zlib = require('zlib');
     const os = require('os');
@@ -617,13 +617,11 @@ describe('bundle size', () => {
 
       console.log(`  all-in consumer bundle: ${sizeKB.toFixed(2)}kB gzip`);
 
-      // v6.4.1 all-in for the same entry is 11.44kB gzip. v7 ships extra
-      // scaffolding (Source-everywhere, AST-direct emit, fragment splicing,
-      // shared `warnOnce` + `[sc]` taxonomy) plus the arity-2 attrs
-      // bridge (CompiledAst trace + runtime fallback) for net ~2.5kB.
-      // Plus fragment-slot missing-`;` recovery: ~0.1kB.
-      // Plus multi-result plugin composition: ~0.1kB.
-      expect(sizeKB).toBeLessThan(14.4);
+      // v6.4.1 all-in for this same entry is 11.44kB gzip. v7 sits above it
+      // because the in-house parser and the arity-2 attrs bridge ship in full
+      // while v6 leaned on a smaller bundled preprocessor. Ceiling includes
+      // buffered injection on top of main's plugin composition.
+      expect(sizeKB).toBeLessThan(14.3);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/packages/styled-components/src/utils/domElements.ts
+++ b/packages/styled-components/src/utils/domElements.ts
@@ -1,7 +1,11 @@
+/**
+ * The tag list behind `SupportedHTMLElements`. Only the type and the tests
+ * read it, so bundlers drop the array: `styled` synthesizes each shorthand on
+ * first access rather than walking a table.
+ */
 // prettier-ignore
-const elements = [
+export const elements = [
   'a','abbr','address','area','article','aside','audio','b','bdi','bdo','blockquote','body','button','br','canvas','caption','cite','code','col','colgroup','data','datalist','dd','del','details','dfn','dialog','div','dl','dt','em','embed','fieldset','figcaption','figure','footer','form','h1','h2','h3','h4','h5','h6','header','hgroup','hr','html','i','iframe','img','input','ins','kbd','label','legend','li','main','map','mark','menu','meter','nav','object','ol','optgroup','option','output','p','picture','pre','progress','q','rp','rt','ruby','s','samp','search','section','select','slot','small','span','strong','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th','thead','time','tr','u','ul','var','video','wbr','circle','clipPath','defs','ellipse','feBlend','feColorMatrix','feComponentTransfer','feComposite','feConvolveMatrix','feDiffuseLighting','feDisplacementMap','feDistantLight','feDropShadow','feFlood','feFuncA','feFuncB','feFuncG','feFuncR','feGaussianBlur','feImage','feMerge','feMergeNode','feMorphology','feOffset','fePointLight','feSpecularLighting','feSpotLight','feTile','feTurbulence','filter','foreignObject','g','image','line','linearGradient','marker','mask','path','pattern','polygon','polyline','radialGradient','rect','stop','svg','switch','symbol','text','textPath','tspan','use',
 ] as const;
 
-export default new Set(elements);
 export type SupportedHTMLElements = (typeof elements)[number];

--- a/packages/styled-components/tsconfig.json
+++ b/packages/styled-components/tsconfig.json
@@ -18,7 +18,13 @@
 
     /* Basic Options */
     "incremental": true /* Enable incremental compilation */,
-    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    /**
+     * ES2020 emits `?.`, `??` and object spread natively instead of TypeScript's
+     * downlevel helpers. Safe against every declared peer (React 19, RN 0.85
+     * Hermes, Node 16). ES2021+ buys no further bytes and native class fields
+     * change field-initialization semantics, so ES2020 is the ceiling.
+     */
+    "target": "ES2020",
     "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": ["ES2021", "DOM"] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
## Summary

- Client styles inject through `useInsertionEffect` via a conditionally mounted `StyleInjector`, so discarded concurrent renders leave no CSS in the document. Class names still resolve during render; provisional rule stashing keeps same-class siblings from recompiling and recovers when a claimer is discarded.
- `styled.div` and other element shorthands are built on first access through a `Proxy`, so the element-name table no longer ships. Published bundles emit ES2020.
- Adds a concurrent CSS responsiveness benchmark case and a headless Chrome matrix runner for Interaction to Next Paint measurements.
- Sandbox `/perf/data-grid` is a live monitoring grid under concurrent pressure (partial polls in `startTransition` + `useDeferredValue`, sync filter), plus a React 19-safe theme boot script via `useServerInsertedHTML`.

Related to #5607.

## Test plan

- [x] `pnpm --filter styled-components test:web`
- [x] `pnpm --filter styled-components test:native`
- [x] `pnpm build` + treeshake size gates
- [ ] Headless concurrent matrix (`packages/benchmarks/headless/concurrent.mjs`) if you want fresh INP numbers on this machine
- [ ] Smoke `/perf/data-grid` in the sandbox: type in the filter while live polling