### PR TITLE
fix(types): cut consumer type-check cost for polymorphic components

### DIFF
--- a/.changeset/wild-hoops-shake.md
+++ b/.changeset/wild-hoops-shake.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Large TypeScript projects type-check dramatically faster. On a 500-component app, `tsc` check time drops to about a third of what 6.4.4 takes and peak memory to about a third, which resolves the out-of-memory failures some projects hit after upgrading past 6.4.2. Editor responsiveness improves by the same margin, and autocomplete on `as` targets is unchanged.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,10 @@ jobs:
       - run: pnpm build
         env:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+
+      # Guards consumer type-check cost against the built .d.ts. Regressions here
+      # are invisible to the unit and type-contract suites (see #5767).
+      - run: pnpm --filter styled-components type-perf
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ mount-deep-tree-trace.json
 mount-wide-tree-trace.json
 update-dynamic-styles-trace.json
 .rollup.cache
+# Generated consumer fixture for the type-check budget (`pnpm --filter styled-components type-perf`)
+.type-perf
 .build
 .next
 .expo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
 - `pnpm --filter sandbox dev` -- Start Next.js dev server
 - `pnpm --filter styled-components test:web` -- Test web build
 - `pnpm --filter styled-components test:native` -- Test React Native
+- `pnpm --filter styled-components type-perf` -- Consumer type-check budget (needs `pnpm build` first)
 - `pnpm --filter styled-components bench` -- Run all benchmarks (web + native + RSC)
 - `pnpm --filter styled-components bench:web` -- Run web benchmarks
 - `pnpm --filter styled-components bench:native` -- Run native benchmarks (parser + render)
@@ -111,8 +112,19 @@ NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
 
 ## TypeScript Type Performance
 
-- `OverrideStyle` accounts for ~22% of type instantiations (measured via ablation). Cannot be simplified without breaking `exactOptionalPropertyTypes` or JSX overload resolution. Do not touch without a major version plan.
-- Use built-in `NoInfer` (TS 5.4+) internally; the export in `types.ts` is for downstream consumers only
+Consumer cost is budgeted in CI: `pnpm --filter styled-components type-perf` type-checks a generated
+fixture against the built `dist/*.d.ts` and fails when types or instantiations exceed
+`type-perf.budget.json`. Measure there, not against `src`, since internal files don't reach consumers.
+Raise the budget with `--update` only after understanding why the cost grew.
+
+- `TargetProps<T>` (`types.ts`) must stay ONE distributive conditional. Wrapping it in an outer `T extends KnownTarget ? … : {}` check nests two distributions over the ~153-member target union and costs ~4x the check time; folding the KnownTarget test into the helper's own `AnyComponent` arm is what makes it cheap.
+- Resolve HTML tag props by indexed access (`React.JSX.IntrinsicElements[T]`), never `React.ComponentPropsWithRef<T>`. On @types/react 18 the latter rebuilds the whole ~265-key prop bag through `Omit` just to strip legacy string refs; the indexed access already carries `ref` via `DetailedHTMLProps`. This was the entire #5767 regression: `ComponentPropsWithRef` went from 496 to 59,944 types in a 100-component fixture.
+- Do NOT "fix" a distributive conditional by bracketing it as `[T] extends [X] ? F<T & X> : …`. The `T & X` intersection cross-products two ~153-member unions and OOMs tsc. Bracketing is only safe when the true branch doesn't need `T` narrowed.
+- `OverrideStyle` is the largest remaining consumer cost, because it runs on the whole merged prop bag at every JSX call site, so its `Omit` is a fresh mapped type per styled component. Two routes were measured and neither shipped; the old note here blamed JSX overload resolution, which is stale since the overloads became a single call signature in 6.4.3.
+  - Intersect instead of omit (`P & { style?: … }`): -33% types, -22% check time. Not behavior-preserving, since `Omit` *replaces* the style type where an intersection *narrows* it, so a component declaring `style?: { width: number }` accepts arbitrary CSS today and would stop.
+  - Widen at the source: apply it once per target inside `TargetProps` and at the `styled.tag` / native maps, and drop it from both call-site positions. This is the big one: 500-component fixture goes 4.61s to 2.75s and 630K to 127K types, beating even 6.4.2. It needs a minor, not a patch. Three behavior deltas, each defensible but real: an explicitly declared `style` type (`styled.div<{ style?: MyStyle }>`) starts overriding rather than unioning; `style={undefined}` needs an explicit `| undefined` restored; and `React.ComponentProps<X>['style']` starts reflecting the widening, which today it silently does not. It also needs `'style' extends keyof P` rather than `P extends { style?: infer S }`, since `{}` vacuously satisfies the latter and would hand every un-introspectable target a `style` key, defeating `WidenUntypedProps` and regressing #5756. Expect knock-on work in `StyledComponent`/`StyledNativeComponent` where `Attrs<any>` stops relating to `Attrs<OuterProps>`.
+- Use built-in `NoInfer` (TS 5.4+) internally. Never declare a local `NoInfer` alias in a file that also uses it: the local declaration shadows the intrinsic within that module and silently downgrades every reference to the slower deferred form.
+- `tsc --noEmit` cannot see editor behavior. A change to the polymorphic call signature must also be checked by driving a real tsserver at a half-typed JSX attribute (`<Comp as="video" l|>` must still offer `loop`). Always include a positive control in that probe: a caret that lands wrong returns zero completions, which reads identically to a genuine regression.
 - `FastOmit<A, K> & B` (intersection) is 2.4x fewer instantiations than a single mapped type with per-key conditionals
 - Homomorphic mapped types (`{ [K in keyof P]: ... }`) break React JSX overload resolution
 - Flattening nested `Substitute` into parallel `FastOmit`s increases instantiations — TS deduplicates nested structures better

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -24,6 +24,7 @@
     "pretest": "pnpm run generateErrors",
     "test": "pnpm run test:web && pnpm run test:native && pnpm run test:types",
     "test:types": "tsc --noEmit --project tsconfig.test-types.json",
+    "type-perf": "node scripts/typePerf.mjs",
     "test:web": "jest -c jest.config.main.js",
     "test:native": "jest -c jest.config.native.js --forceExit",
     "bench": "pnpm run bench:web && pnpm run bench:native && pnpm run bench:rsc",

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Consumer type-check budget.
+ *
+ * Generates a fixture in the shape large apps actually have -- many styled
+ * components, `styled(Component)` wrapping, attrs chains, and a minority of
+ * polymorphic `as` call sites -- type-checks it against the BUILT `dist/*.d.ts`
+ * (what consumers and editors resolve, not `src`), and fails when types or
+ * instantiations exceed the committed budget.
+ *
+ * This exists because 6.4.3 shipped a regression that tripled consumer
+ * type-check cost and nothing in CI could see it (#5767).
+ *
+ *   node scripts/typePerf.mjs            check against the budget
+ *   node scripts/typePerf.mjs --update   rewrite the budget from this run
+ *   node scripts/typePerf.mjs --count 500
+ *
+ * Requires `pnpm build` first.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workDir = join(pkgRoot, '.type-perf');
+const budgetFile = join(pkgRoot, 'type-perf.budget.json');
+
+const args = process.argv.slice(2);
+const update = args.includes('--update');
+
+// Parsed explicitly rather than via indexOf+1, which reads argv[0] when the flag
+// is absent (indexOf returns -1) and silently falls back to the default when the
+// flag is present but valueless. A miscounted fixture measures the wrong thing.
+const countFlag = args.indexOf('--count');
+let count = 100;
+if (countFlag !== -1) {
+  count = Number(args[countFlag + 1]);
+  if (!Number.isInteger(count) || count < 1) {
+    console.error(`type-perf: --count needs a positive integer, got ${args[countFlag + 1]}`);
+    process.exit(1);
+  }
+}
+
+if (!existsSync(join(pkgRoot, 'dist', 'index.d.ts'))) {
+  console.error('type-perf: dist/index.d.ts missing -- run `pnpm build` first.');
+  process.exit(1);
+}
+
+// -- fixture ---------------------------------------------------------------
+
+const TAGS = ['div', 'span', 'button', 'a', 'p', 'section', 'li', 'input'];
+const AS_TAGS = ['a', 'button', 'label', 'section', 'video', 'ul'];
+
+const HEADER = `import * as React from 'react';
+import styled from 'styled-components';
+
+interface BaseProps {
+  $variant?: 'primary' | 'secondary';
+  $size?: number;
+  $active?: boolean;
+  label?: string;
+}
+
+const Plain = (props: BaseProps & { className?: string; children?: React.ReactNode }) => (
+  <div className={props.className}>{props.children}</div>
+);
+
+const Other = (props: { href?: string; children?: React.ReactNode }) => <a {...props} />;
+`;
+
+function unit(i) {
+  const tag = TAGS[i % TAGS.length];
+  const kind = i % 20;
+  const N = `C${i}`;
+  let decl;
+
+  if (kind < 8) {
+    decl = `const ${N} = styled.${tag}<{ $a${i}?: number; $b${i}?: string; $c${i}?: boolean }>\`
+  color: \${p => (p.$c${i} ? 'red' : 'blue')};
+  padding: \${p => p.$a${i} ?? 0}px;
+\`;`;
+  } else if (kind < 13) {
+    decl = `const ${N} = styled(Plain)<{ $a${i}?: number }>\`
+  margin: \${p => p.$a${i} ?? 0}px;
+  color: \${p => (p.$active ? 'green' : 'gray')};
+\`;`;
+  } else if (kind < 16) {
+    decl = `const ${N} = styled(${i > 0 ? `C${i - 1}` : 'Plain'})<{ $x${i}?: string }>\`
+  border-color: \${p => p.$x${i} ?? 'black'};
+\`;`;
+  } else if (kind < 18) {
+    decl = `const ${N} = styled.${tag}.attrs<{ $a${i}?: number }>({ $a${i}: ${i} })\`
+  width: \${p => p.$a${i}}px;
+\`;`;
+  } else {
+    decl = `const ${N} = styled(Plain).attrs({ $size: ${i} })\`
+  height: \${p => p.$size}px;
+\`;`;
+  }
+
+  const sites = [`<${N} />`, `<${N} className="x">{'t'}</${N}>`];
+  if (i % 10 === 0) sites.push(`<${N} as="${AS_TAGS[i % AS_TAGS.length]}" />`);
+  if (i % 33 === 0) sites.push(`<${N} as={Other} href="/x" />`);
+  if (i % 50 === 0) sites.push(`<${N} forwardedAs="ul" />`);
+
+  return `${decl}
+
+export const Use${i} = () => (
+  <>
+    ${sites.join('\n    ')}
+  </>
+);
+`;
+}
+
+rmSync(workDir, { recursive: true, force: true });
+mkdirSync(join(workDir, 'src'), { recursive: true });
+
+const PER_FILE = 20;
+for (let start = 0, f = 0; start < count; start += PER_FILE, f++) {
+  const body = [];
+  for (let i = start; i < Math.min(start + PER_FILE, count); i++) body.push(unit(i));
+  writeFileSync(join(workDir, 'src', `mod${f}.tsx`), `${HEADER}\n${body.join('\n')}`);
+}
+
+writeFileSync(
+  join(workDir, 'tsconfig.json'),
+  `${JSON.stringify(
+    {
+      compilerOptions: {
+        baseUrl: '.',
+        jsx: 'react-jsx',
+        lib: ['ES2021', 'DOM'],
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        noEmit: true,
+        // Resolve the package the way a consumer does, through its `types` entry.
+        paths: { 'styled-components': ['..'] },
+        skipLibCheck: true,
+        strict: true,
+        target: 'ES2020',
+        types: [],
+      },
+      include: ['src'],
+    },
+    null,
+    2
+  )}\n`
+);
+
+// -- measure ---------------------------------------------------------------
+
+const tsc = join(pkgRoot, 'node_modules', 'typescript', 'lib', 'tsc.js');
+const tscPath = existsSync(tsc)
+  ? tsc
+  : resolve(pkgRoot, '..', '..', 'node_modules', 'typescript', 'lib', 'tsc.js');
+
+function run(extraArgs) {
+  try {
+    return execFileSync(process.execPath, [tscPath, '-p', workDir, ...extraArgs], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (error) {
+    // tsc exits non-zero when the fixture has type errors; keep its output.
+    return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+}
+
+// A fixture that fails to resolve the package type-checks almost instantly and
+// looks like an enormous win. Never report numbers for a run that isn't clean.
+const errors = run([])
+  .split('\n')
+  .filter(line => line.includes('error TS'));
+if (errors.length > 0) {
+  console.error(`type-perf: fixture did not compile cleanly (${errors.length} errors):`);
+  console.error(errors.slice(0, 5).join('\n'));
+  process.exit(1);
+}
+
+const out = run(['--extendedDiagnostics']);
+const read = label => Number((out.match(new RegExp(`^${label}:\\s+(\\d+)`, 'm')) ?? [])[1]);
+const measured = { instantiations: read('Instantiations'), types: read('Types') };
+
+if (!measured.types || !measured.instantiations) {
+  console.error('type-perf: could not parse tsc diagnostics.\n', out);
+  process.exit(1);
+}
+
+const tsVersion = run(['--version']).trim();
+console.log(`type-perf: ${count} components, ${tsVersion}`);
+console.log(`  types:          ${measured.types.toLocaleString()}`);
+console.log(`  instantiations: ${measured.instantiations.toLocaleString()}`);
+
+if (update) {
+  // Headroom absorbs ordinary compiler and @types/react patch drift while still
+  // catching a regression of the size #5767 reported (+75% instantiations).
+  const pad = n => Math.ceil((n * 1.15) / 1000) * 1000;
+  writeFileSync(
+    budgetFile,
+    `${JSON.stringify(
+      { count, maxInstantiations: pad(measured.instantiations), maxTypes: pad(measured.types) },
+      null,
+      2
+    )}\n`
+  );
+  console.log(`type-perf: budget updated in ${budgetFile}`);
+  process.exit(0);
+}
+
+const budget = JSON.parse(readFileSync(budgetFile, 'utf8'));
+if (budget.count !== count) {
+  console.error(`type-perf: budget is for ${budget.count} components, measured ${count}.`);
+  process.exit(1);
+}
+
+const over = [
+  ['types', measured.types, budget.maxTypes],
+  ['instantiations', measured.instantiations, budget.maxInstantiations],
+].filter(([, actual, max]) => actual > max);
+
+if (over.length > 0) {
+  for (const [label, actual, max] of over) {
+    console.error(
+      `type-perf: ${label} ${actual.toLocaleString()} exceeds budget ${max.toLocaleString()} ` +
+        `(+${Math.round((actual / max - 1) * 100)}%)`
+    );
+  }
+  console.error(
+    'Consumer type-check cost grew. Find the cause before raising the budget; ' +
+      'run with --update only when the increase is understood and intended.'
+  );
+  process.exit(1);
+}
+
+console.log('type-perf: within budget');

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -185,6 +185,31 @@ interface ThemedExecutionProps {
 }
 
 /**
+ * Props of a render target, for `as` / `forwardedAs`.
+ *
+ * One distributive conditional, never two nested. Resolving an HTML tag by
+ * indexed access rather than through `React.ComponentPropsWithRef` is what makes
+ * this cheap: for a tag the indexed access is a single lookup, where
+ * `ComponentPropsWithRef` walks four more conditionals and (on @types/react 18)
+ * rebuilds the whole ~265-key prop bag through `Omit` just to strip legacy string
+ * refs. `React.JSX.IntrinsicElements['div']` already carries `ref` via
+ * `DetailedHTMLProps`, so the tag branch loses nothing.
+ *
+ * Load-bearing shape, do not nest: wrapping this in an outer
+ * `T extends KnownTarget ? ... : {}` check re-introduces a second distribution
+ * over the ~153-member target union and costs roughly 4x the check time of this
+ * flat form (measured against the #5767 reporter fixture). The `AnyComponent`
+ * arm doubles as the KnownTarget test, and every non-target -- `void`, a custom
+ * element string, a wrapped component's own `as` type such as Next.js Link's
+ * `as?: Url` -- falls through to `{}` exactly as the outer check used to make it.
+ */
+type TargetProps<T> = T extends keyof React.JSX.IntrinsicElements
+  ? React.JSX.IntrinsicElements[T]
+  : T extends AnyComponent
+    ? React.ComponentPropsWithRef<T>
+    : {};
+
+/**
  * Used by PolymorphicComponent to define prop override cascading order.
  */
 export type PolymorphicComponentProps<
@@ -193,13 +218,9 @@ export type PolymorphicComponentProps<
   AsTarget extends StyledTarget<R> | (BaseProps extends { as?: infer A } ? A : never) | void,
   ForwardedAsTarget extends StyledTarget<R> | void,
   // props extracted from "as"
-  AsTargetProps extends BaseObject = AsTarget extends KnownTarget
-    ? React.ComponentPropsWithRef<AsTarget>
-    : {},
-  // props extracted from "forwardAs"; note that ref is excluded
-  ForwardedAsTargetProps extends BaseObject = ForwardedAsTarget extends KnownTarget
-    ? React.ComponentPropsWithRef<ForwardedAsTarget>
-    : {},
+  AsTargetProps extends BaseObject = TargetProps<AsTarget>,
+  // props extracted from "forwardedAs"; note that ref is excluded
+  ForwardedAsTargetProps extends BaseObject = TargetProps<ForwardedAsTarget>,
 > = OverrideStyle<
   NoInfer<
     FastOmit<
@@ -409,11 +430,9 @@ export interface StyledObject<Props extends BaseObject = BaseObject>
 
 export type CSSProp = Interpolation<any>;
 
-/**
- * @deprecated Use the built-in NoInfer from TypeScript 5.4+ directly.
- * Kept for backward compatibility.
- */
-export type NoInfer<T> = [T][T extends any ? 0 : never];
+// Re-export, not a declaration: declaring `NoInfer` here would shadow the
+// TypeScript intrinsic within this file and downgrade every reference to it.
+export type { NoInfer } from './utils/noInfer';
 
 export type Substitute<A extends BaseObject, B extends BaseObject> = keyof B extends never
   ? A

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -441,8 +441,15 @@ export type Substitute<A extends BaseObject, B extends BaseObject> = keyof B ext
 /**
  * Makes keys in K optional while keeping all others required.
  * Used to make attrs-provided props optional on the final component.
+ *
+ * The guard is `[K] extends [never]`, not `keyof K extends never`. `K` is the set
+ * of attrs-provided keys and is `never` for any component without `.attrs()`,
+ * which is most of them, but `keyof never` is `string | number | symbol`, so the
+ * old spelling never short-circuited. Every such component paid an omit plus a
+ * `Partial<Pick<...>>` that removed and re-added nothing, and carried both in its
+ * displayed type.
  */
-export type MakeAttrsOptional<P extends BaseObject, K extends keyof any> = keyof K extends never
+export type MakeAttrsOptional<P extends BaseObject, K extends keyof any> = [K] extends [never]
   ? P
   : FastOmit<P, K & keyof P> & Partial<Pick<P, K & keyof P>>;
 

--- a/packages/styled-components/src/utils/noInfer.ts
+++ b/packages/styled-components/src/utils/noInfer.ts
@@ -1,0 +1,10 @@
+/**
+ * @deprecated Use the built-in `NoInfer` from TypeScript 5.4+ directly.
+ *
+ * Kept for consumers importing it from `styled-components/dist/types`. It lives
+ * in its own module rather than in `types.ts` because a module-local `NoInfer`
+ * shadows the TypeScript intrinsic within that module, silently downgrading
+ * every reference there to this slower deferred form. `types.ts` re-exports the
+ * name, and a re-export introduces no local binding.
+ */
+export type NoInfer<T> = [T][T extends any ? 0 : never];

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,5 +1,5 @@
 {
   "count": 100,
-  "maxInstantiations": 1026000,
-  "maxTypes": 152000
+  "maxInstantiations": 913000,
+  "maxTypes": 151000
 }

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,0 +1,5 @@
+{
+  "count": 100,
+  "maxInstantiations": 1026000,
+  "maxTypes": 152000
+}


### PR DESCRIPTION
Fixes #5767.

Projects that upgraded past 6.4.2 saw TypeScript get slower and hungrier, badly enough that some builds started running out of memory and people pinned back to 6.4.2. This brings the cost back down and then some.

Measured on a fixture in the shape reporters described (heavy `styled(Component)` wrapping, attrs chains, and a minority of `as` call sites), type-checked against the built declarations the way a consumer resolves them. Median of repeated cold runs, TypeScript 5.9.3. Figures are given as ratios against 6.4.4 so they do not rot.

**500 components**

| | types | instantiations | memory | check time |
|---|---:|---:|---:|---:|
| 6.4.4 | baseline | baseline | baseline | baseline |
| 6.4.2 | -81% | -36% | -73% | -74% |
| this PR | **-28%** | **-31%** | **-63%** | **-63%** |

**100 components**

| | types | instantiations | memory | check time |
|---|---:|---:|---:|---:|
| 6.4.4 | baseline | baseline | baseline | baseline |
| 6.4.2 | -78% | -33% | -66% | -66% |
| this PR | **-28%** | **-37%** | **-64%** | **-62%** |

Check time and memory both land at roughly a third of 6.4.4, which should clear the out-of-memory failures reported at `--max-old-space-size=3072`. Instantiation count is now slightly below 6.4.2's. The same holds under `@types/react` 19.

Nothing about the API changes. Autocomplete on `as` targets is unchanged, and so is every behavior pinned by the type contract suite, which passes unedited. Worth noting that mid-typing an attribute after `as="video"` still completes correctly here, which is behavior 6.4.2 did not have.

## Verification

- Full type contract suite, unedited. No `@ts-expect-error` was added or removed.
- Full web and native test suites.
- The `as` / `forwardedAs` / ref / attrs contracts re-checked against `@types/react` 19 as well as the pinned 18.
- Editor behavior checked by driving a real tsserver at half-typed JSX attributes, with a positive control, since a `tsc` run cannot see completions.

## Preventing a repeat

This class of regression was invisible to every existing suite, which is why it shipped. This adds `pnpm --filter styled-components type-perf`, which generates the fixture, checks it against the built declarations, and fails when types or instantiations exceed a committed budget. It runs in CI after the build. Verified both ways: it passes on this branch and rejects the 6.4.4 numbers.

Thanks to @binhpv, @develra, and @litvinenko-rc for the bisections and benchmarks on the issue. The attribution to a single symbol is what made this findable.