### PR TITLE
fix(types): keep union props through styled(), and stabilize the hook sequence

### DIFF
--- a/.changeset/disjoint-union-props.md
+++ b/.changeset/disjoint-union-props.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fix styled components silently dropping props declared as a union whose members share no keys, so `styled.div<{ a: string } | { b: number }>` rejected both `a` and `b`. The same collapse applied when `as` pointed at a component with such props. A union whose members are all-optional is still flattened; declare the combined optional shape instead.

--- a/.changeset/disjoint-union-props.md
+++ b/.changeset/disjoint-union-props.md
@@ -2,4 +2,4 @@
 'styled-components': patch
 ---
 
-Fix styled components silently dropping props declared as a union whose members share no keys, so `styled.div<{ a: string } | { b: number }>` rejected both `a` and `b`. The same collapse applied when `as` pointed at a component with such props. A union whose members are all-optional is still flattened; declare the combined optional shape instead.
+Fix a styled component silently dropping props declared as a union whose members have no prop in common, which left every one of those props rejected. The same applied when `as` pointed at a component with such props. Where every member's props are optional the union is still flattened, so declare the combined optional shape instead.

--- a/.changeset/stable-hook-sequence.md
+++ b/.changeset/stable-hook-sequence.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Styled components now report the same debug value to React DevTools on every render. Previously the value was only reported on renders that recomputed styles, so it disappeared from the DevTools panel whenever a component re-rendered with unchanged style props.

--- a/.changeset/union-props-survive-styled.md
+++ b/.changeset/union-props-survive-styled.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fix a component whose props are a union losing its member-specific props when wrapped in `styled()`. Since 6.5.0, `styled(Pressable)` where `Pressable` accepts `ButtonHTMLAttributes | AnchorHTMLAttributes` rejected `href` at the JSX call site, accepting only the props common to every member of the union.

--- a/.changeset/union-props-survive-styled.md
+++ b/.changeset/union-props-survive-styled.md
@@ -2,4 +2,4 @@
 'styled-components': patch
 ---
 
-Fix a component whose props are a union losing its member-specific props when wrapped in `styled()`. Since 6.5.0, `styled(Pressable)` where `Pressable` accepts `ButtonHTMLAttributes | AnchorHTMLAttributes` rejected `href` at the JSX call site, accepting only the props common to every member of the union.
+Fix wrapping a component whose props are a union. Since 6.5.0 the wrapped version accepted only the props common to every member of the union, so a prop belonging to just one member was rejected even though the unwrapped component accepted it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
-NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
+Read this file for the rules. Everything a rule only summarizes is specified in full under `docs/`,
+mapped below.
 
 ## Basics
 
@@ -8,26 +9,42 @@ NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
 
 ## Critical Constraints
 
-- NEVER use `precedence` or `href` on `<style>` elements -- React 19 Float merges same-precedence tags, strips custom `data-*` attributes, and hoists to `<head>` where source ordering is unpredictable. RSC style tags must be plain inline `<style>` (server component output is not hydrated, so no mismatch).
-- The native entry must NEVER transitively import DOM code via value imports. Use `import type` and branded `Symbol.for()` checks instead of `instanceof`. Verify: `grep -c 'document\.' native/dist/styled-components.native.cjs.js` must be 0. RN/Hermes 0.79+ fails at module evaluation time on `document` references.
-- Server detection requires three mechanisms combined: `__SERVER__` (build-time constant), `IS_RSC` (module-level constant), and `styleSheet.server` (runtime flag from `ServerStyleSheet`). Always use `__SERVER__ || IS_RSC || ssc.styleSheet.server`, with one deliberate exception: `createGlobalStyle`'s server-cache cleanup drops the `IS_RSC` term because the `IS_RSC` branch above it already handled and returned, so reaching that line under RSC means there was nothing to clean. `IS_RSC` is `true` at runtime in React 19 server components because React's `react-server` export condition serves a stripped build without `createContext`. Bundlers (Next.js/Turbopack) use this condition automatically.
-- Turbopack resolves the `browser` entry for SSR of client components, making `__SERVER__` false on the server. `styleSheet.server` is the runtime fallback.
-- `React.useRef` is `undefined` in RSC server components. Gate behind `__SERVER__` for dead-code elimination, never use `typeof React.useRef === 'function'` (runtime conditional hook).
-- `new Array(n)` creates HOLEY_ELEMENTS arrays that infect V8 type feedback -- 3.9x regression observed in GroupedTag.
+- NEVER use `precedence` or `href` on `<style>` elements. React 19 Float merges same-precedence tags,
+  strips custom `data-*` attributes, and hoists to `<head>` where source ordering is unpredictable.
+  See [docs/rsc-style-injection.md](docs/rsc-style-injection.md).
+- The native entry must NEVER transitively import DOM code via a value import. Use `import type` and
+  branded `Symbol.for()` checks instead of `instanceof`. Verify:
+  `grep -c 'document\.' native/dist/styled-components.native.cjs.js` must be 0.
+  See [docs/build-architecture.md](docs/build-architecture.md).
+- Server detection needs all three of `__SERVER__`, `IS_RSC` and `styleSheet.server`. Always write
+  `__SERVER__ || IS_RSC || ssc.styleSheet.server`. The one deliberate exception is documented in
+  [docs/build-architecture.md](docs/build-architecture.md), which also explains why each flag exists
+  and when each one lies.
+- NEVER gate paired cleanup (a `useLayoutEffect` and its teardown) on `__SERVER__` alone. Gate on
+  `styleSheet.server` or `IS_RSC`.
+- NEVER write `typeof React.useRef === 'function'`; that is a runtime conditional hook. Gate on
+  `__SERVER__`.
+- NEVER place a hook on one side of the render cache's hit/miss branch. The hook sequence must be
+  identical whether or not props changed. See
+  [docs/runtime-performance.md](docs/runtime-performance.md).
+- NEVER use `new Array(n)`. It creates HOLEY_ELEMENTS arrays that infect V8 type feedback.
+- NEVER mutate `rule.props` in place on a stylis AST node; allocate a fresh array.
 
 ## Mandates
 
 - React 16.8 compat
-- Always microbenchmark to validate optimizations -- and bench the realistic workload, not a synthetic best case. Revert changes that pessimize the path actual callers take, even if they win in isolation.
+- Always microbenchmark to validate optimizations, and bench the realistic workload rather than a
+  synthetic best case. Revert changes that pessimize the path actual callers take, even if they win in
+  isolation.
 - Optimize for low memory pressure and monomorphic functions
 
 ## Agent Rules
 
 - Create changesets only for user-visible changes (bug fixes, features, breaking changes). Skip internal refactors, build tooling, and test changes. Also skip changesets for fixes to code introduced within the same unreleased version (no user ever saw the bug).
-- Changeset descriptions AND PR descriptions are both consumer-facing. Write so someone who uses the library but hasn't read its source can understand the change -- describe what the user observes change in their app. NO internal API names (`rebuildGroup`, `clearRules`, `instanceRules`, `useLayoutEffect`, `rulesEqual`, etc.), NO mechanism descriptions ("the cleanup effect now runs on..."), NO references to specific code paths. Implementation details belong in commit message bodies and AGENTS.md, never in changesets or PR bodies.
+- Changeset descriptions AND PR descriptions are both consumer-facing. Write so someone who uses the library but hasn't read its source can understand the change -- describe what the user observes change in their app. NO internal API names (`rebuildGroup`, `clearRules`, `instanceRules`, `useLayoutEffect`, `rulesEqual`, etc.), NO mechanism descriptions ("the cleanup effect now runs on..."), NO references to specific code paths. Implementation details belong in commit message bodies and the `docs/` specifications, never in changesets or PR bodies.
 - Do not edit CHANGELOG.md -- it is auto-generated by changesets
 - Always run the formatter (`pnpm --filter styled-components prettier`) before committing code changes
-- Public-facing docs (README, `packages/*/README.md`, `docs/*`, FAQ, sandbox README) describe user-observable behavior only. Implementation details -- React Float/`precedence`, stylis internals, `React.cache`, V8 optimizations -- belong in AGENTS.md unless the answer to a user question specifically requires them.
+- Public-facing docs (README, `packages/*/README.md`, `packages/styled-components/docs/*`, FAQ, sandbox README) describe user-observable behavior only. Implementation details -- React Float/`precedence`, stylis internals, `React.cache`, V8 optimizations -- belong in the repo-root `docs/` specifications unless the answer to a user question specifically requires them.
 - Links to the site use the bare domain (`https://styled-components.com`). There is no `www` subdomain.
 - After editing `packages/styled-components/src/utils/errors.md`, run `pnpm --filter styled-components generateErrors` before tests -- Jest snapshots compare against the compiled error map and will fail silently otherwise.
 - The repo-root `src/utils/errors.md` is a frozen pre-monorepo stub, not a mirror. Nothing reads it: `generateErrorMap.js` and the production error URL both point at the canonical `packages/styled-components/src/utils/errors.md`. It stops at error 13 and its entry 2 already describes a different error than the one shipped, so do not consult it and do not treat it as authoritative. Update links in place if a link fix lands; never change its structure or error numbering. Whether it should exist at all is an open question for the maintainer, not a cleanup to do in passing.
@@ -49,188 +66,23 @@ NOTE: CLAUDE.md is a symlink to this file (AGENTS.md). Edit AGENTS.md directly.
 - `pnpm --filter styled-components bench:rsc` -- Run RSC benchmarks (renderToString + dedup + React baseline)
 - `pnpm test:prerelease-notes` -- Regenerate prerelease GitHub release-note markdown locally (set `GITHUB_REPOSITORY=owner/name`; optional `CHANGESET_NOTES_ROOT`, `RELEASE_NOTES_OUTDIR`)
 
-## Build Architecture
+## Specifications
 
-- `__SERVER__` is a build-time constant that enables dead-code elimination for SSR paths in browser builds. NEVER use `__SERVER__` as the sole gate for behavior that needs paired cleanup (e.g. `useLayoutEffect`). Jest resolves the server build (`main` field) in jsdom, where `__SERVER__=true` eliminates cleanup but DOM mutations still occur. Gate on `styleSheet.server` or `IS_RSC` instead.
-- `IS_BROWSER` (`typeof window !== 'undefined'`) is a runtime check -- bundlers CANNOT tree-shake code behind it
-- `IS_RSC` (`typeof React.createContext === 'undefined'`) is a module-level constant. React 19's `react-server` export condition strips `createContext` from the server build, so `IS_RSC` is `true` at runtime in server components. In browser/standalone/native builds, rollup replaces the expression with `false` for dead-code elimination.
-- The `browser` field in package.json maps server bundles to browser-specific alternatives. Preferred over `exports` (which caused TS2742 in composite projects).
-- CSS injection ordering: group IDs allocated at call time (when `styled()`, `createGlobalStyle()`, or `keyframes()` is called) -- lower ID = earlier in stylesheet
-- Keyframes eagerly register via `getGroupForId(this.id)` in constructor (not `StyleSheet.registerId`, to avoid DOM imports in native builds)
+Each document is the single home for its subject. A rule above that summarizes one of these points at
+it rather than restating it.
 
-## GlobalStyle Shared-Group Architecture
-
-- All instances of a `createGlobalStyle` share ONE stylesheet group, registered at `createGlobalStyle()` call time via `StyleSheet.registerId(componentId)`
-- The returned component is wrapped in `React.memo`
-- Instance IDs allocated via `allocateGSInstance`: server uses direct allocation (one-shot renders), client uses `useRef` for stability across re-renders
-- `instanceRules: Map<number, { name: string; rules: string[] }>` tracks each mount's compiled CSS on the module-level `GlobalStyle` object
-- `rebuildGroup()` clears the shared group and re-inserts from surviving instances -- O(N) where N is mounted instances (typically 1-3)
-- `computeRules()` flattens + compiles CSS and caches in `instanceRules` -- the single source of truth for rebuild
-- Inline rules-equality comparison skips CSSOM rebuild when CSS is unchanged, but ONLY on the client (`!styleSheet.server`). SSR `clearTag()` invalidates the DOM tag but NOT module-level caches (`instanceRules`), so cache-based fast-paths must check `!styleSheet.server`.
-- Server-side `instanceRules` entries must be explicitly deleted after style collection (no `useLayoutEffect` cleanup runs on server)
-- Client lifecycle uses TWO `useLayoutEffect`s: one runs `renderStyles` on render/dep change, a separate one holds the `removeStyles` cleanup keyed on `[instance, sheet, globalStyle]` so cleanup fires only on unmount/sheet-swap/HMR -- not on every prop change. A single effect with per-render cleanup wipes `instanceRules` before the rulesEqual fast-path can hit, causing a double `rebuildGroup` per render of every dynamic global style (see #5730).
-
-## RSC Style Injection
-
-- RSC components emit plain inline `<style data-styled>` tags (no `precedence`, no `href`). Server component output is NOT hydrated by React, so inline tags cause no hydration mismatch. The `data-styled` attribute is safe because Float only strips attrs during client hydration, which never runs on RSC output.
-- Inline body styles naturally appear after the registry's `<head>` styles in source order, so cross-boundary extensions (RSC extending a client component) win the cascade.
-- Base-level CSS in inheritance chains is wrapped in `:where()` for zero specificity. This prevents duplicate base CSS (from sibling extensions sharing a base) from overriding earlier extensions' styles.
-- No cleanup of RSC style tags is needed -- they are the sole source of CSS for server-only components.
-- RSC inline `<style>` tags are deduplicated per render via name-based tracking in a `React.cache`-scoped Set. Dedup hits skip CSS collection entirely (no getGroup, no :where() wrapping). Dynamic components with multiple variants only emit CSS for new names, not the full accumulated group. Compiled CSS is cached on ComponentStyle/Keyframes via WeakMap (persists across React.cache resets, dead-code eliminated in browser build).
-- Keyframe rules are emitted in a dedicated `<style>` tag, deduped separately by keyframe ID. They must NOT be prepended to component CSS strings--keyframes register mid-render, so prepending them causes inconsistent strings that break `getEmittedCSS` dedup.
-- `mainSheet` is reset once per server render via `React.cache` (clears `names`, `keyframeIds`, `tag`) to prevent stale CSS accumulating across HMR cycles. `keyframeIds` is safe to clear because components re-register keyframes via `keyframe.inject()` during render.
-- `StyleSheetManager` works in RSC via module-level `rscContextOverride` slot. Single-threaded RSC renders + `React.cache` reset per render make this safe. Nested SSMs inherit `stylisPlugins`, `shouldForwardProp`, and `nonce` from parent. `stylisPlugins={[]}` explicitly disables inheritance. `namespace` and `enableVendorPrefixes` are supported in RSC.
-- `stylisPluginRSC` is an opt-in stylis plugin that rewrites `:first-child`/`:last-child`/`:nth-child()` to exclude `style[data-styled]` from the child count using CSS Selectors L4 `of S` syntax. Exported from `index.ts` only (not `base.ts`) for UMD tree-shaking. Uses `/*#__PURE__*/ Object.defineProperty` for stable `.name` after minification.
-- RSC inline `<style>` tags break child-index pseudo-selectors because they become real DOM children. `:first-of-type`/`:nth-of-type()` are naturally immune (filter by tag name). The plugin is needed only for `:*-child` selectors.
-
-## createTheme
-
-- `createTheme(defaultTheme, options?)` returns an object where every leaf is `var(--prefix-path, fallback)` -- usable in both client and RSC styled components
-- Pass the contract to `ThemeProvider` for stable class name hashes across themes (no hydration mismatch on light/dark)
-- `resolve(el?)` reads computed CSS var values from the DOM -- client-only, returns plain object with resolved values
-- `raw` property holds the original theme object
-- `vars` property holds bare CSS custom property names (`--sc-path`) -- same shape as theme, use in `createGlobalStyle` for dark mode overrides: `${vars.colors.bg}: #111;`
-- Options: `prefix` (default `"sc"`), `selector` (default `":root"`, use `":host"` for Shadow DOM)
-- Dark mode: use `vars` + `css` partial for DRY overrides in `@media (prefers-color-scheme: dark)` and `.dark` class -- avoids hydration flash and hand-written var names
-- `reconstructWithOptions` must copy `keyframeIds` Set to the new sheet
-
-## attrs Behavior
-
-- attrs ALWAYS wins over directly passed props (by design)
-- The function form is the escape hatch: `.attrs(({ as }) => ({ as: as || "button" }))`
-- Exception: explicitly passing `undefined` for a prop prevents attrs from overwriting it (PR #5683)
-
-## Performance Patterns (microbenchmark-validated)
-
-| Pattern | Result |
-|---------|--------|
-| String `+=` vs `array.push()+join()` | `+=` is 3-4x faster at all scales (V8 cons string trees) |
-| Object creation | `{...props, theme}` is 4x faster than `Object.assign` or `for..in` copy |
-| Props iteration | `for..in` is 1.7x faster than `Object.keys()` + loop |
-| RegExp creation | Cache via Map is 5x faster; `indexOf` pre-check to skip entirely is 5x more |
-| Template literals | Manual `+` concat is 1.3x faster than `` `${a}${b}` `` in tight loops |
-| `React.createElement` | Raw element objects measure 60-120x faster, but are NOT used on this branch: `StyledComponent` calls React's own `createElement`. Measurement only, not an inventory entry |
-
-## Type Contracts
-
-`src/test/types.tsx` (web) and `src/test/types.native.tsx` (native) are compile-only files with no
-test runner: `test:types` type-checks everything under `src` except `*.test.ts(x)`, so a new
-non-`.test` file is picked up automatically. Most cases are drawn from reported issues and carry the
-issue number.
-
-- Every `@ts-expect-error` is a test, and the compiler already enforces that each one is live: a
-  directive with nothing to suppress is itself an error, `TS2578 Unused '@ts-expect-error'
-  directive`, so `test:types` fails on a dead one with no extra tooling. Do not build a harness to
-  re-check this; one was written here and deleted once TS2578 was measured doing the same job.
-  When TS2578 fires, rewrite the assertion rather than deleting it -- the behavior it described
-  changed, and that is worth a decision. Never delete or relax an existing directive to make a
-  change compile; that is the change being wrong, not the test.
-- TS2578 proves a directive suppresses *something*, not that it suppresses the *right* thing. A
-  directive can go on passing for a reason its comment does not describe: an assertion here about
-  arbitrary CSS being rejected kept passing only because a required field was missing. Name the
-  expected error in the comment, and when editing a case, re-read what it actually catches.
-- A case asserting a type did NOT widen to `any` needs a presence anchor, since `any` compiles
-  clean. Write a deliberate mismatch under `@ts-expect-error` so the widening surfaces as `TS2578`.
-- Never annotate a callback parameter whose inference is the thing under test. An annotation makes
-  the case pass whether or not inference works.
-- A `DefaultTheme` augmentation in a contract suite uses optional keys only. The library defaults the
-  theme to `EMPTY_OBJECT` internally, so a required key fails the library's own source rather than the
-  test file. Read through `NonNullable<...>` where a non-optional view is needed.
-- `tsc` emits semantic diagnostics only when there are zero syntactic ones, so a single syntax error
-  in a contract suite blanks the entire type check and the file reads as "clean except one typo".
-  Fix any syntax error first, then re-read the output before believing a pass.
-- Third-party shapes are hand-written stubs (Mantine's polymorphic factory, Next.js `Link`'s `Url`).
-  Annotate a stub with the package version it was verified against, and pin its premise with an
-  assertion where the stub's whole point is a property of the real type -- the Mantine stub asserts
-  its resolved props have no keys, so the case cannot pass against a stub that became
-  introspectable. Do not add the real package as a dependency to test a type.
-- Four reported issues cannot be pinned in-tree, because each is a union-explosion or
-  recursion-depth cliff that a simplified stub sits clear of and would pass vacuously: antd's
-  `Button` under `.attrs()` (#5725), react-bootstrap 2.8's `Button` (#4166), react-spring's
-  `animated` with the `css` prop (#3496), and preact/compat (#3773). They are verified out of tree
-  against the real packages at the versions reported. Re-verify them by hand when the polymorphic
-  call signature or `Interpolation` changes.
-
-## TypeScript Type Performance
-
-Consumer cost is budgeted in CI: `pnpm --filter styled-components type-perf` type-checks a generated
-fixture against the built `dist/*.d.ts` and fails when types, instantiations or memory drift past what
-`type-perf.budget.json` records. Measure there, not against `src`, since internal files don't reach
-consumers. Raise the budget with `--update` only after understanding why the cost grew.
-
-- The budget stores the measured figures plus a tolerance, not bare ceilings, so an improvement is
-  reported ("run `--update` to bank it") instead of silently becoming slack for the next regression.
-- Memory is budgeted alongside the counters because the counters alone would have read 6.4.4 as an
-  improvement: against the same fixture 6.4.4 has FEWER instantiations than 6.4.3 while using more
-  memory. Types and instantiations are bit-identical run to run; memory is the only host-sensitive
-  figure, which is why the script pins the V8 heap. No metric is wall-clock, so a slower CI box
-  measures the same numbers a laptop does.
-- The budget records the `typescript` and `@types/react` versions it was measured on and warns when
-  they differ, since a dependency bump moves every figure on its own.
-- `skipLibCheck: true` hides a broken `dist`: if the shipped declarations cannot resolve their own
-  dependencies, every export degrades to `any`, the fixture still compiles, and the run reports an
-  enormous fake win (measured: a degraded package reported 3,843 types where the healthy one reported
-  40,398). The fixture's `canary.tsx` is the guard -- `@ts-expect-error` directives that error only
-  while the types are intact, so a degraded package turns them into `TS2578` and fails the clean gate.
-  Verify any change to that file by pointing the fixture at a deliberately broken package.
-- The fixture covers the native entry too. `TargetProps` is shared by both, so a native-only type
-  regression is invisible to a web-only fixture and to `tsconfig.test-types.json`, which checks `src`
-  rather than what consumers resolve.
-
-- `TargetProps<R, T>` (`types.ts`) must stay ONE distributive conditional over `T`. Wrapping it in an outer `T extends KnownTarget ? … : {}` check nests two distributions over the ~153-member target union and costs ~4x the check time; folding the KnownTarget test into the helper's own `AnyComponent` arm is what makes it cheap. The `R` gate inside `ComponentTargetProps` is not that shape: it distributes over `Runtime`, not over `T`.
-- Resolve HTML tag props by indexed access (`React.JSX.IntrinsicElements[T]`), never `React.ComponentPropsWithRef<T>`. On @types/react 18 the latter rebuilds the whole ~265-key prop bag through `Omit` just to strip legacy string refs; the indexed access already carries `ref` via `DetailedHTMLProps`. This was the entire #5767 regression: `ComponentPropsWithRef` went from 496 to 59,944 types in a 100-component fixture.
-- Do NOT "fix" a distributive conditional by bracketing it as `[T] extends [X] ? F<T & X> : …`. The `T & X` intersection cross-products two ~153-member unions and OOMs tsc. Bracketing is only safe when the true branch doesn't need `T` narrowed.
-- The `.attrs()` re-resolution seam in `constructWithOptions` keeps `React.ComponentPropsWithRef<PrivateResolvedTarget>` and must NOT be switched to `TargetProps`, even though `TargetProps` is cheaper everywhere else. The function form `.attrs(({ as }) => ({ as: as || 'button' }))` makes the resolved target a union, and `TargetProps` is two conditionals, so it distributes inside the distribution that seam already performs. Measured on a three-line repro: 6.4.2 157K instantiations, `TargetProps` 6.9M, and TS2589 (excessively deep) with one more chained layer -- a hard failure against both 6.4.2 and 6.4.4, not a slowdown. `ComponentPropsWithRef` there costs ~2% instantiations on the consumer fixture and lands the same repro at 133K, below 6.4.2. Cheaper in count, deeper in nesting is a real trade and this one position is where nesting wins.
-- The `style` widening is web-only, gated on `TargetProps`' first parameter (`R extends Runtime`, deliberately undefaulted -- a default is what would let a native call site pick web CSS up by omission). Only `ComponentTargetProps` carries the gate: `NativeTarget` is `AnyComponent`, so the intrinsic arm is unreachable on native. The conditional is over `Runtime`, two members and concrete at every entry point, which is why it costs nothing measurable (+0.55% instantiations, +0.05% types, memory flat) where a conditional over the target union costs ~4x. Before this, `styled.View` accepted `float` and custom properties on 6.4.2 through 6.4.4 alike; both are pinned as `@ts-expect-error` in the native contract suite. `width: '3em'` is still accepted and is NOT ours -- `@types/react-native` 0.71 types `FlexStyle['width']` as `number | string`.
-- Known limitation, characterized in the contract suite: under `exactOptionalPropertyTypes`, a component declaring its own `style` rejects an explicit `style={undefined}`, because intersecting the declared type leaves no `undefined` arm. Omitting the prop is unaffected and `style?: X | undefined` restores it. Do not "fix" this by reintroducing a conditional in `MergeProps`; that shape measured +54% types. Accepted and documented in the changeset instead.
-- `PolymorphicComponentProps` merges rather than substitutes the `as`/`forwardedAs` target's props over `BaseProps`, so a declared `style` constraint is not escapable by rendering the same component through a different tag. Measured on the consumer fixture: +0.016% types, +0.48% instantiations, memory unchanged. This is the one place a per-JSX-site cost was accepted, and it was accepted only because it buys a contract `CustomStyle` otherwise states falsely.
-- A declared `style` merges rather than replaces, and the merge is an intersection, not a conditional: `MergeProps` simply does not omit `style` from the target, so `CSSPropertiesWithVars & { width: number }` narrows one field and keeps the rest. Both conditional spellings were measured and rejected -- testing `keyof A` tips tsc into TS2590 outright, and testing `keyof B` costs +54% types because it stays deferred while `B` is generic and the checker materializes both branches. `never` ablates a field and `CustomStyle` ablates everything unnamed, so full override stays expressible without making it the default.
-- `CSSProp`'s recursion through `RuleSet` is load-bearing and must not be flattened to "fix" #3496 (`css?: CSSProp` plus react-spring's recursive `animated` types tips TS2589). Ablated against the real packages: react-spring alone is fine and `css?: string` is fine, so the depth is ours, but every shallower `CSSProp` that fixes it also stops `css={cssHelperOutput}` being assignable, which is the primary use of the prop. It reproduces identically on 6.4.2 and 6.4.4, so it is a standing limitation rather than a regression.
-- Permissiveness for an un-introspectable target is decided from the TARGET's props, not from the finished prop bag. `WidenUntypedProps` asks whether the merged bag is empty, which stops being true as soon as a component adds a transient prop, so `styled(PolymorphicTarget)<{ $variant: string }>` silently lost the permissiveness and started rejecting `children` (#5756, on 6.4.2 and 6.4.4 alike). `WidenForUntypedTarget` tests `Target` instead. Applying it over an already-widened bag is a no-op, since the index signature makes `keyof` be `string`.
-- When a cost cliff appears after several changes land together, ablate to the cause before attributing it. The TS2589 above was blamed in turn on the `Exclude` inside `MergeProps` and on `MergeProps` itself; making `MergeProps` byte-identical to `Substitute` still reproduced it, which is what pointed at the `.attrs()` seam. A fix that makes the symptom go away is not evidence about the cause, and a comment recording the wrong cause outlives the session that guessed it.
-- The `style` widening applies once per render target inside `TargetProps`, never to a merged prop bag at a JSX call site. A target's props are shared by every component built on it, so the widening resolves once per tag rather than once per component; the call-site form was the largest single consumer cost (measured 5.2x the types). The cost is per component-type instantiation, not per JSX site: multiplying call sites sixfold moves it only a few percent, so a fixture that grows sites rather than components will not show the difference. Only the component arm (`ComponentTargetProps`) routes through the `OverrideStyle` guard; every intrinsic element provably declares `style` (the set of `React.JSX.IntrinsicElements` keys lacking it is `never`), so `IntrinsicProps` applies `WithCSSVars` directly rather than asking a question with one possible answer. Four things are load-bearing about the current shape, each found by measurement:
-  - The test is `'style' extends keyof P`, not `P extends { style?: infer S }`. `{}` vacuously satisfies the latter, which would hand every un-introspectable target a `style` key and defeat `WidenUntypedProps` (regresses #5756).
-  - `Attrs<Props>` does NOT re-apply it. `Props` already carries the widened style, and re-applying it stops `Attrs<any>` relating to `Attrs<OuterProps>` inside `StyledComponent`/`StyledNativeComponent`.
-  - The explicit `| undefined` keeps `style={undefined}` assignable under `exactOptionalPropertyTypes`, which the call-site form allowed.
-  - `Substitute`'s second parameter is deliberately unbounded. Bounding it to `BaseObject` forces callers to write `TargetProps<R, T> & BaseObject` to satisfy it, and `{}` is retained rather than reduced inside an intersection, so that one bound propagates an unreducible node through every prop bag downstream. Measured cost of adding it back: +47K types and +73% check time on a 100-component fixture. Never intersect `& {}` into a type that flows into prop bags.
-- Rejected alternative, do not re-explore: intersecting instead of omitting inside `OverrideStyle` (`P & { style?: … }`). It measured -33% types and -22% check time but is strictly worse than widening at the source and breaks a component's own narrow `style` type by narrowing rather than replacing it.
-- Use built-in `NoInfer` (TS 5.4+) internally. Never declare a local `NoInfer` alias in a file that also uses it: the local declaration shadows the intrinsic within that module and silently downgrades every reference to the slower deferred form. A re-export (`export type { NoInfer } from './utils/noInfer'`) introduces no local binding and is safe. Do NOT probe which form is in play by testing whether inference is blocked -- the deferred form blocks identically, so the test and its negative control both pass and the probe proves nothing. The only instrument that separates them is resolving the identifier through the compiler API and reading which file the symbol lands in (`lib.es5.d.ts` means the intrinsic).
-- Keep a conditional type's branches as named top-level aliases (`WithCSSVars`, `IntrinsicProps`, `ComponentTargetProps`, `Substituted`). A conditional alias loses its name the moment it resolves, because the checker returns the branch type and drops the `aliasSymbol`, so an inlined branch prints its whole expansion in every hover and error. Naming the branches took a styled component's displayed type from roughly 380 characters to 95 at no measurable cost. Do not inline them back for tidiness; the tidiness is the point.
-- Do NOT reach for the popular `Prettify<T> = { [K in keyof T]: T[K] } & {}` to clean up a displayed type here. It is a homomorphic mapped type (breaks JSX overload resolution) ending in the `& {}` that never reduces. It is fine on a leaf type a user hovers, and poison on anything that flows into prop bags.
-- `tsc --noEmit` cannot see editor behavior. A change to the polymorphic call signature must also be checked by driving a real tsserver at a half-typed JSX attribute (`<Comp as="video" l|>` must still offer `loop`). Always include a positive control in that probe: a caret that lands wrong returns zero completions, which reads identically to a genuine regression.
-- `FastOmit<A, K> & B` (intersection) is 2.4x fewer instantiations than a single mapped type with per-key conditionals
-- Homomorphic mapped types (`{ [K in keyof P]: ... }`) break React JSX overload resolution
-- Flattening nested `Substitute` into parallel `FastOmit`s increases instantiations — TS deduplicates nested structures better
-- Don't replace built-in `Omit` with `FastOmit` in `OverrideStyle` — built-in `Omit` (Pick + Exclude) is more optimized (+17% instantiations when replaced)
-- Variance annotations (`out`/`in out`) on `Styled`, `PolymorphicComponent`, `IStyledComponentBase`, etc. reduce variance computation (-72%) and memory (-16%)
-- `domElements.forEach` uses `(styled as any)` cast — types are already declared via mapped type on the styled const, avoiding one redundant `Styled<>` instantiation per element in `domElements`
-- Profile: `~/.claude/tools/tsc-perf.sh measure tsconfig.test-types.json` or `npx tsc --noEmit --extendedDiagnostics --project tsconfig.test-types.json`. Delete tsbuildinfo for clean measurement.
-- `npx @typescript/analyze-trace /tmp/tsc-perf-trace` detects hot spots and duplicate packages
-
-## V8 Gotchas
-
-- `private` modifier is not allowed on anonymous class expressions (`export const Foo = class { ... }`)
-- `import type * from 'stream'` still triggers bundler module resolution even though TypeScript strips it
-
-## Stylis AST
-
-- `stylis.compile()` can alias the same `props` array between a top-level rule and its `@media`-nested copy. Never mutate `rule.props` in place -- allocate a fresh array. `rule.value` is a plain string and safe to reassign.
-- Character code constants live in `src/utils/charCodes.ts`. Import from there rather than redefining local copies.
-
-## Dynamic Re-render Hot Path
-
-Cache hit (props+theme unchanged -- most common re-render):
-- `shallowEqualContext`: ~0.2us -- compares props via for-in + stored key count
-- Everything else skipped (resolveContext, flatten, hash, generateName, buildPropsForElement still runs)
-
-Cache miss (props changed):
-1. `resolveContext`: object spread + attrs evaluation
-2. `flatten()` fast path: inline function call for string-returning interpolations, ~0.05us each
-3. `dynamicNameCache` lookup: Map.get on CSS string -- O(1), skips phash+generateName on hit
-4. `phash()` + `generateName`: only on dynamicNameCache miss (first time seeing this CSS)
-5. `stylis` compile+serialize: only when `hasNameForId` misses (first injection of this class)
-6. `hasNameForId`: Map.has -- negligible
-
-## Rendering Flow
-
-See [docs/rendering-flow.md](docs/rendering-flow.md) for the full sequence diagram.
+- [docs/build-architecture.md](docs/build-architecture.md) -- build-time constants, the three server
+  detection mechanisms, native entry isolation, module resolution, CSS injection ordering
+- [docs/rendering-flow.md](docs/rendering-flow.md) -- the full render sequence diagram
+- [docs/runtime-performance.md](docs/runtime-performance.md) -- microbenchmark-validated patterns, the
+  dynamic re-render hot path and its render cache, V8 gotchas, stylis AST handling
+- [docs/global-styles.md](docs/global-styles.md) -- `createGlobalStyle`'s shared-group architecture,
+  instance lifecycle, rebuild fast path
+- [docs/rsc-style-injection.md](docs/rsc-style-injection.md) -- how styles reach the page from server
+  components, dedup, `:where()` wrapping, `stylisPluginRSC`
+- [docs/create-theme.md](docs/create-theme.md) -- the `createTheme` CSS-variable contract
+- [docs/attrs.md](docs/attrs.md) -- `attrs` precedence and its escape hatches
+- [docs/type-contracts.md](docs/type-contracts.md) -- how the compile-only type suites are written and
+  read
+- [docs/type-performance.md](docs/type-performance.md) -- the consumer type-check budget and every
+  load-bearing decision in `types.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+Read AGENTS.md for the rules. Nothing else is here.

--- a/docs/attrs.md
+++ b/docs/attrs.md
@@ -1,0 +1,12 @@
+# attrs Behavior
+
+`attrs` always wins over a directly passed prop. This is by design, not a precedence accident.
+
+The function form is the escape hatch when a caller's value should win:
+
+```js
+.attrs(({ as }) => ({ as: as || 'button' }))
+```
+
+One exception to attrs winning: explicitly passing `undefined` for a prop prevents attrs from
+overwriting it, which is how a caller signals intent to reset the value (#5683).

--- a/docs/build-architecture.md
+++ b/docs/build-architecture.md
@@ -1,0 +1,59 @@
+# Build Architecture
+
+How the package is built, which environment flags exist, and how CSS injection order is decided.
+
+## Environment flags
+
+Three separate mechanisms answer "are we on a server", and they are not interchangeable.
+
+`__SERVER__` is a build-time constant. Rollup replaces it per bundle, so a branch behind it is
+eliminated entirely from the browser build. It is the right gate for dead-code elimination and the
+wrong gate for anything needing paired cleanup: Jest resolves the server build through the `main`
+field in jsdom, where `__SERVER__` is `true`, so a `useLayoutEffect` gated on it is eliminated while
+the DOM mutations it was meant to clean up still happen. Gate cleanup on `styleSheet.server` or
+`IS_RSC` instead.
+
+`IS_RSC` is `typeof React.createContext === 'undefined'`, evaluated once at module level. React 19's
+`react-server` export condition serves a build stripped of `createContext`, so `IS_RSC` is `true` at
+runtime inside server components; bundlers such as Next.js and Turbopack select that condition
+automatically. In browser, standalone and native builds rollup replaces the expression with `false`
+for dead-code elimination. Because it is module-level rather than per-render, gating a hook behind it
+does not violate the rules of hooks.
+
+`styleSheet.server` is a runtime flag set by `ServerStyleSheet`. It exists because Turbopack resolves
+the `browser` entry when server-rendering client components, which makes `__SERVER__` false on the
+server; this flag is the fallback that still reports the truth there.
+
+Combine all three (`__SERVER__ || IS_RSC || ssc.styleSheet.server`) with one deliberate exception:
+`createGlobalStyle`'s server-cache cleanup drops the `IS_RSC` term, because the `IS_RSC` branch above
+it has already handled the render and returned, so reaching that line under RSC means there was
+nothing left to clean.
+
+`IS_BROWSER` is `typeof window !== 'undefined' && typeof document !== 'undefined'`. Both halves are
+needed: a non-browser host can define `window` without a DOM. It is a runtime check, so bundlers
+cannot tree-shake code behind it and it never substitutes for `__SERVER__`.
+
+`React.useRef` is `undefined` in RSC server components. Gate it behind `__SERVER__` so the call is
+eliminated; never write `typeof React.useRef === 'function'`, which is a runtime conditional hook.
+
+## Native entry isolation
+
+The native entry must never transitively import DOM code through a value import. Use `import type`,
+and branded `Symbol.for()` checks in place of `instanceof`. React Native on Hermes 0.79+ fails at
+module evaluation time on a bare `document` reference, so the failure is a hard crash rather than a
+degraded path.
+
+Verify with `grep -c 'document\.' native/dist/styled-components.native.cjs.js`, which must report 0.
+
+## Module resolution
+
+The `browser` field in `package.json` maps server bundles to their browser-specific alternatives. It
+is preferred over `exports`, which caused TS2742 in composite TypeScript projects.
+
+## CSS injection ordering
+
+Group IDs are allocated at call time, when `styled()`, `createGlobalStyle()` or `keyframes()` runs,
+and a lower ID sorts earlier in the stylesheet.
+
+Keyframes register eagerly via `getGroupForId(this.id)` in the constructor rather than through
+`StyleSheet.registerId`, which would pull DOM imports into native builds.

--- a/docs/create-theme.md
+++ b/docs/create-theme.md
@@ -1,0 +1,36 @@
+# createTheme
+
+`createTheme(defaultTheme, options?)` returns an object whose every leaf is
+`var(--prefix-path, fallback)`, so the same theme is usable from both client and RSC styled
+components. The returned object *is* that tree of variable references, with the members below
+assigned onto it, so `theme.colors.primary` reads as the `var(...)` string directly.
+
+Passing the contract to `ThemeProvider` keeps class name hashes stable across themes, which is what
+prevents a hydration mismatch when switching light and dark.
+
+## Members
+
+- `GlobalStyle` is a component that emits the variable declarations, and nothing renders the
+  variables until it is mounted. Mount it inside the `ThemeProvider` whose theme supplies the values;
+  changing that theme updates the declarations. Without it every leaf falls back to its default.
+- `raw` holds the original theme object.
+- `vars` holds the bare CSS custom property names (`--sc-path`), in the same shape as the theme. Use
+  it in `createGlobalStyle` for dark mode overrides: `${vars.colors.bg}: #111;`.
+- `resolve(el?)` reads the computed CSS variable values from the DOM, defaulting to
+  `document.documentElement`, and returns a plain object of resolved values. It is client-only and
+  throws rather than degrading when called outside a browser.
+
+## Options
+
+- `prefix` defaults to `"sc"`.
+- `selector` defaults to `":root"`; use `":host"` for Shadow DOM.
+
+## Dark mode
+
+Combine `vars` with a `css` partial to write the overrides once and reuse them in both
+`@media (prefers-color-scheme: dark)` and a `.dark` class. This avoids a hydration flash and avoids
+hand-written variable names drifting from the theme.
+
+## Implementation note
+
+`reconstructWithOptions` must copy the `keyframeIds` Set to the new sheet.

--- a/docs/global-styles.md
+++ b/docs/global-styles.md
@@ -1,0 +1,54 @@
+# GlobalStyle Shared-Group Architecture
+
+Every component returned by a single `createGlobalStyle` call shares one stylesheet group, registered
+at call time via `StyleSheet.registerId(componentId)`. The returned component is wrapped in
+`React.memo`.
+
+## Instance identity
+
+Each mount needs its own instance ID, allocated by `allocateGSInstance`. The server allocates
+directly, since a server render is one-shot. The client allocates through a `useRef` so the ID stays
+stable across re-renders.
+
+`instanceRules`, a `Map<number, { name: string; rules: string[] }>` on the module-level `GlobalStyle`
+object, tracks each mount's compiled CSS. `computeRules()` flattens and compiles the CSS and caches it
+there under the name `componentId + instance`, making `instanceRules` the single source of truth for a
+rebuild.
+
+`rebuildGroup()` clears the shared group and re-inserts from the surviving instances. It is O(N) in
+mounted instances, which is typically one to three.
+
+## Static and dynamic rules take different paths
+
+`renderStyles` branches on `isStatic`, and the two branches share almost nothing.
+
+Static rules never rebuild. The branch checks `hasNameForId(id, id + instance)` and inserts only on a
+miss. On a hit it still calls `computeRules` when `instanceRules` has no entry for the instance: that
+is the rehydration case, where the CSS is already in the DOM from the server but the module-level
+cache is empty, and populating it is what lets `rebuildGroup` restore this instance if a sibling
+unmounts later.
+
+Dynamic rules recompute on every render, then compare. `computeRules` overwrites the entry first, so
+the comparison is against the previous entry captured beforehand; if the rule arrays are the same
+length and element-wise equal, the CSSOM rebuild is skipped. That fast path is client-only
+(`!styleSheet.server`): server-side `clearTag()` invalidates the DOM tag and not the module-level
+caches, so a cache-based fast path would skip a rebuild the DOM still needs. Any new fast path here
+must make the same check.
+
+Server-side `instanceRules` entries must be deleted explicitly once styles are collected, because no
+`useLayoutEffect` cleanup runs on the server.
+
+`rebuildGroup` must run synchronously. Nothing may yield between `clearRules` and the re-insert loop,
+or the group is observable while empty.
+
+## Client lifecycle
+
+The client uses two separate `useLayoutEffect`s:
+
+1. One runs `renderStyles` on render and on dependency change.
+2. A second holds the `removeStyles` cleanup, keyed on `[instance, sheet, globalStyle]`, so cleanup
+   fires only on unmount, sheet swap or HMR.
+
+Collapsing these into a single effect with per-render cleanup wipes `instanceRules` before the
+rules-equality fast path can hit, which costs a double `rebuildGroup` on every render of every
+dynamic global style (#5730).

--- a/docs/rsc-style-injection.md
+++ b/docs/rsc-style-injection.md
@@ -1,0 +1,89 @@
+# RSC Style Injection
+
+How styles reach the page from React Server Components.
+
+## Plain inline style tags
+
+RSC components emit plain inline `<style data-styled>` tags, with no `precedence` and no `href`.
+Server component output is not hydrated by React, so an inline tag causes no hydration mismatch. The
+`data-styled` attribute survives because React Float only strips attributes during client hydration,
+which never runs over RSC output.
+
+Inline body styles land after the registry's `<head>` styles in source order, so a cross-boundary
+extension (an RSC component extending a client component) wins the cascade.
+
+No cleanup of RSC style tags is needed: they are the sole source of CSS for server-only components.
+
+## Specificity in inheritance chains
+
+Base-level CSS in an inheritance chain is wrapped in `:where()` for zero specificity. Without it,
+duplicate base CSS from sibling extensions sharing a base would override an earlier extension's
+styles.
+
+## Deduplication
+
+Inline `<style>` tags are deduplicated per render through name-based tracking in a `React.cache`-scoped
+Set. A dedup hit skips CSS collection entirely: no `getGroup`, no `:where()` wrapping. A dynamic
+component with several variants therefore emits CSS only for new names rather than for the full
+accumulated group. Compiled CSS is cached on `ComponentStyle` and `Keyframes` through a `WeakMap`,
+which persists across `React.cache` resets and is dead-code eliminated in the browser build.
+
+Keyframe rules are deduplicated separately, by keyframe ID rather than by class name, against the same
+per-render Set. On this branch they are concatenated ahead of the component CSS and emitted in the
+*same* `<style>` tag: a styled component renders at most one style element, as
+`Fragment(styleElement, element)`. Dedup survives the concatenation because each keyframe ID is
+recorded as it is emitted, so a keyframe already written this render contributes nothing to the next
+component's string.
+
+## Per-render reset
+
+`mainSheet` is reset once per server render via `React.cache`, clearing `names`, `keyframeIds` and the
+tag, so stale CSS cannot accumulate across HMR cycles. Clearing `keyframeIds` is safe because
+components re-register keyframes through `keyframe.inject()` during render.
+
+## StyleSheetManager under RSC
+
+`StyleSheetManager` works in RSC through a module-level `rscContextOverride` slot. Single-threaded RSC
+renders plus the per-render `React.cache` reset make this safe.
+
+The override carries exactly four things: `shouldForwardProp`, `styleSheet`, `stylis` and
+`stylisPlugins`. A nested manager inherits `stylisPlugins` and `shouldForwardProp` from its parent
+when it omits them, which is what lets an inner manager set `namespace` or `enableVendorPrefixes`
+while keeping the outer plugins. Passing `stylisPlugins={[]}` explicitly opts out and falls back to
+the default stylis instance. When neither a custom stylis instance nor a `shouldForwardProp` survives
+resolution, the override is cleared to `null` rather than set to a redundant object.
+
+`nonce` is not part of that override. It is a sheet option, resolved by `getNonce()` in priority
+order: `<meta property="csp-nonce">` (Vite, which puts the value in the `nonce` attribute and exposes
+it only through the DOM property), then `<meta name="sc-nonce">` (the styled-components convention,
+value in `content`), then the legacy `__webpack_nonce__` global. Header-based nonces, as used by
+Next.js and Remix, are not auto-detectable and must be passed explicitly to `StyleSheetManager` or
+`ServerStyleSheet`.
+
+## Selectors broken by inline style tags
+
+Inline `<style>` tags are real DOM children, so they perturb any selector that counts children or
+walks siblings. `:first-of-type` and `:nth-of-type()` are naturally immune because they filter by tag
+name.
+
+`stylisPluginRSC` is the opt-in stylis plugin that repairs the rest. It is exported from `index.ts`
+only, not `base.ts`, so UMD builds can tree-shake it, and it uses `/*#__PURE__*/
+Object.defineProperty` to keep a stable `.name` after minification. It does two separate jobs.
+
+**Child-index pseudo-selectors.** `:first-child`, `:last-child`, `:only-child`, `:nth-child()` and
+`:nth-last-child()` are rewritten with CSS Selectors Level 4 `of S` syntax to exclude
+`style[data-styled]` from the count. `:only-child` becomes the conjunction of a first and a last test.
+An `:nth-child()`/`:nth-last-child()` that already carries its own ` of ` clause is left alone rather
+than double-wrapped. This is a precise, spec-level fix, and it requires browser support for `of S`
+(Chrome 111+, Firefox 113+, Safari 9+).
+
+**Adjacent sibling combinators.** A `+` is expanded with fallback selectors that also match when one
+or two `style[data-styled]` tags sit between the siblings. Two known limitations: a `+` inside a
+pseudo-function (`:is()`, `:has()`, `:where()`, `:not()`) is not expanded, so prefer
+`:first-of-type`/`:nth-of-type` or the general sibling combinator `~` there; and each `+` adds two
+fallback selectors, growing the CSS output.
+
+The two-tag bound on that expansion is stated in the plugin as `Fragment[kfStyle?, compStyle?,
+element]` per component. The emitter on this branch produces a single combined style tag per
+component, so the bound is conservative rather than tight. Re-derive it before relying on it if the
+emitter changes.

--- a/docs/runtime-performance.md
+++ b/docs/runtime-performance.md
@@ -1,0 +1,71 @@
+# Runtime Performance
+
+Measured patterns, engine gotchas and the shape of the hot path. Every entry here was validated by
+microbenchmark against the realistic workload, not a synthetic best case.
+
+## Validated patterns
+
+| Pattern | Result |
+|---------|--------|
+| String `+=` vs `array.push()+join()` | `+=` is 3-4x faster at all scales (V8 cons string trees) |
+| Object creation | `{...props, theme}` is 4x faster than `Object.assign` or `for..in` copy |
+| Props iteration | `for..in` is 1.7x faster than `Object.keys()` + loop |
+| RegExp creation | Cache via Map is 5x faster; `indexOf` pre-check to skip entirely is 5x more |
+| Template literals | Manual `+` concat is 1.3x faster than `` `${a}${b}` `` in tight loops |
+| `React.createElement` | Raw element objects measure 60-120x faster, but are NOT used on this branch: `StyledComponent` calls React's own `createElement`. Measurement only, not an inventory entry |
+
+## Dynamic re-render hot path
+
+On a cache hit, meaning props and theme are unchanged and this is the most common re-render:
+
+- `shallowEqualContext` costs roughly 0.2us, comparing props by `for..in` against a stored key count.
+- Everything else is skipped: `resolveContext`, flatten, hash and `generateName`.
+  `buildPropsForElement` still runs.
+
+On a cache miss, meaning props changed:
+
+1. `resolveContext`: object spread plus attrs evaluation.
+2. `flatten()` fast path: an inline function call for string-returning interpolations, roughly 0.05us
+   each.
+3. `dynamicNameCache` lookup: a `Map.get` on the CSS string, O(1), which skips `phash` and
+   `generateName` on a hit.
+4. `phash()` and `generateName`: only on a `dynamicNameCache` miss, the first time this CSS is seen.
+5. `stylis` compile and serialize: only when `hasNameForId` misses, the first injection of this class.
+6. `hasNameForId`: a `Map.has`, negligible.
+
+The render cache splits this path in two, and only the miss side runs the style work. Any hook placed
+on one side of that split is called on a miss and skipped on a hit, which makes the component emit a
+different hook sequence depending on whether its props happened to change. React rejects that outright
+(#5788). `memoization.test.tsx` records the hook sequence across both cache states and asserts they
+match, so a hook added inside the branch fails there rather than in a consumer's app.
+
+## V8 gotchas
+
+`new Array(n)` creates HOLEY_ELEMENTS arrays, which infect V8 type feedback. A 3.9x regression was
+observed in `GroupedTag` from this alone.
+
+The `private` modifier is not allowed on anonymous class expressions
+(`export const Foo = class { ... }`).
+
+`import type * from 'stream'` still triggers bundler module resolution even though TypeScript strips
+it.
+
+## Stylis AST
+
+`stylis.compile()` gives a rule nested inside an at-rule the *same* `props` array object as its
+enclosing scope. In stylis's parser the nested `ruleset()` call is handed the parent's `rules` array
+as its `props` argument, and that array is stored on the node unchanged, so the two nodes share one
+array rather than holding equal copies.
+
+Verified on stylis 4.3.6: compiling `.a, .b { color: red; @media (min-width: 1px) { color: blue; } }`
+yields two `rule` nodes whose `props` are the identical object, and assigning to `props[0]` on the
+nested node changes the top-level node's selector too.
+
+So never mutate `rule.props` in place; allocate a replacement array, as `recursivelySetNamespace`
+does. `rule.value` is a plain string and is safe to reassign.
+
+That namespacing walk also skips `@keyframes` children when it recurses, since keyframe selectors
+(`from`, `0%`) are offsets rather than selectors and must not be prefixed.
+
+Character code constants live in `src/utils/charCodes.ts`. Import from there rather than redefining
+local copies.

--- a/docs/type-contracts.md
+++ b/docs/type-contracts.md
@@ -1,0 +1,60 @@
+# Type Contracts
+
+`src/test/types.tsx` (web) and `src/test/types.native.tsx` (native) are compile-only files with no test
+runner. `test:types` type-checks everything under `src` except `*.test.ts(x)`, so a new non-`.test`
+file is picked up automatically. Most cases are drawn from reported issues and carry the issue number.
+
+## Writing a case
+
+Every `@ts-expect-error` is a test, and the compiler already enforces that each one is live: a
+directive with nothing to suppress is itself an error, `TS2578 Unused '@ts-expect-error' directive`, so
+`test:types` fails on a dead one with no extra tooling. Do not build a harness to re-check this; one
+was written here and deleted once TS2578 was measured doing the same job.
+
+When TS2578 fires, rewrite the assertion rather than deleting it. The behavior it described changed,
+and that is worth a decision. Never delete or relax an existing directive to make a change compile;
+that is the change being wrong, not the test.
+
+TS2578 proves a directive suppresses *something*, not that it suppresses the *right* thing. A
+directive can go on passing for a reason its comment does not describe: an assertion here about
+arbitrary CSS being rejected kept passing only because a required field was missing. Name the expected
+error in the comment, and when editing a case, re-read what it actually catches.
+
+A case asserting a type did not widen to `any` needs a presence anchor, since `any` compiles clean.
+Write a deliberate mismatch under `@ts-expect-error` so the widening surfaces as TS2578. The same
+applies to a union: a transform that widened props to an index signature accepts everything, so pair
+each accepted prop with a rejected one.
+
+Never annotate a callback parameter whose inference is the thing under test. An annotation makes the
+case pass whether or not inference works.
+
+A `DefaultTheme` augmentation in a contract suite uses optional keys only. The library defaults the
+theme to `EMPTY_OBJECT` internally, so a required key fails the library's own source rather than the
+test file. Read through `NonNullable<...>` where a non-optional view is needed.
+
+## Reading the output
+
+`tsc` emits semantic diagnostics only when there are zero syntactic ones, so a single syntax error in a
+contract suite blanks the entire type check and the file reads as "clean except one typo". Fix any
+syntax error first, then re-read the output before believing a pass.
+
+## Third-party shapes
+
+Third-party shapes are hand-written stubs, such as Mantine's polymorphic factory and Next.js `Link`'s
+`Url`. Annotate a stub with the package version it was verified against, and pin its premise with an
+assertion where the stub's whole point is a property of the real type: the Mantine stub asserts its
+resolved props have no keys, so the case cannot pass against a stub that became introspectable. Do not
+add the real package as a dependency to test a type.
+
+## Verified out of tree
+
+Four reported issues cannot be pinned in-tree, because each is a union-explosion or recursion-depth
+cliff that a simplified stub sits clear of and would pass vacuously:
+
+- antd's `Button` under `.attrs()` (#5725)
+- react-bootstrap 2.8's `Button` (#4166)
+- react-spring's `animated` with the `css` prop (#3496)
+- preact/compat (#3773)
+
+They are verified out of tree against the real packages at the versions reported. Re-verify them by
+hand when the polymorphic call signature or `Interpolation` changes.

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -35,10 +35,14 @@ rather than what consumers resolve.
 The `unionTarget` kind wraps a component whose props are a union and passes a member-specific prop at
 the call site. It prices the distributive path in `OverrideStyle`, and because the run fails on any
 fixture compile error it also fails outright if that union ever collapses again (#5787), making it a
-correctness canary sitting inside the perf gate. Adding it moved the recorded budget on its own
-(instantiations 699,924 to 850,438 at 100 components); that jump is fixture growth, not a regression. A
-kind added or a weight changed here changes what the budget means, so re-measure with `--update` and
-say in the commit that the fixture, not the cost, is what moved.
+correctness canary sitting inside the perf gate. It is also the single most expensive kind per
+component, by a wide margin, so adding it moved the recorded budget substantially on its own. That jump
+was fixture growth, not a regression.
+
+A kind added or a weight changed here changes what the budget means, so re-measure with `--update` and
+say in the commit that the fixture, not the cost, is what moved. `type-perf.budget.json` is the live
+figure; `pnpm --filter styled-components type-perf` prints the current one. Do not restate either here,
+since a number copied into prose is a number that silently goes stale.
 
 ## Target prop resolution
 

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -1,0 +1,241 @@
+# TypeScript Type Performance
+
+Consumer type-check cost is budgeted in CI. `pnpm --filter styled-components type-perf` type-checks a
+generated fixture against the built `dist/*.d.ts` and fails when types, instantiations or memory drift
+past what `type-perf.budget.json` records. Measure there rather than against `src`, since internal
+files never reach consumers. Raise the budget with `--update` only once the growth is understood.
+
+## The budget
+
+The budget stores the measured figures plus a tolerance rather than bare ceilings, so an improvement is
+reported ("run `--update` to bank it") instead of silently becoming slack for the next regression.
+
+Memory is budgeted alongside the counters because the counters alone would have read 6.4.4 as an
+improvement: against the same fixture 6.4.4 has fewer instantiations than 6.4.3 while using more
+memory. Types and instantiations are bit-identical run to run; memory is the only host-sensitive
+figure, which is why the script pins the V8 heap. No metric is wall-clock, so a slower CI box measures
+the same numbers a laptop does.
+
+The budget records the `typescript` and `@types/react` versions it was measured on and warns when they
+differ, since a dependency bump moves every figure on its own.
+
+## What the fixture guards
+
+`skipLibCheck: true` hides a broken `dist`: if the shipped declarations cannot resolve their own
+dependencies, every export degrades to `any`, the fixture still compiles, and the run reports an
+enormous fake win (measured: a degraded package reported 3,843 types where the healthy one reported
+40,398). The fixture's `canary.tsx` is the guard, holding `@ts-expect-error` directives that error only
+while the types are intact, so a degraded package turns them into TS2578 and fails the clean gate.
+Verify any change to that file by pointing the fixture at a deliberately broken package.
+
+The fixture covers the native entry too. `TargetProps` is shared by both entries, so a native-only type
+regression is invisible to a web-only fixture and to `tsconfig.test-types.json`, which checks `src`
+rather than what consumers resolve.
+
+The `unionTarget` kind wraps a component whose props are a union and passes a member-specific prop at
+the call site. It prices the distributive path in `OverrideStyle`, and because the run fails on any
+fixture compile error it also fails outright if that union ever collapses again (#5787), making it a
+correctness canary sitting inside the perf gate. Adding it moved the recorded budget on its own
+(instantiations 699,924 to 850,438 at 100 components); that jump is fixture growth, not a regression. A
+kind added or a weight changed here changes what the budget means, so re-measure with `--update` and
+say in the commit that the fixture, not the cost, is what moved.
+
+## Target prop resolution
+
+`TargetProps<R, T>` (`types.ts`) must stay ONE distributive conditional over `T`. Wrapping it in an
+outer `T extends KnownTarget ? … : {}` check nests two distributions over the ~153-member target union
+and costs ~4x the check time; folding the KnownTarget test into the helper's own `AnyComponent` arm is
+what makes it cheap. The `R` gate inside `ComponentTargetProps` is not that shape: it distributes over
+`Runtime`, not over `T`.
+
+Resolve HTML tag props by indexed access (`React.JSX.IntrinsicElements[T]`), never
+`React.ComponentPropsWithRef<T>`. On @types/react 18 the latter rebuilds the whole ~265-key prop bag
+through `Omit` just to strip legacy string refs; the indexed access already carries `ref` via
+`DetailedHTMLProps`. This was the entire #5767 regression: `ComponentPropsWithRef` went from 496 to
+59,944 types in a 100-component fixture.
+
+Do NOT "fix" a distributive conditional by bracketing it as `[T] extends [X] ? F<T & X> : …`. The
+`T & X` intersection cross-products two ~153-member unions and OOMs tsc. Bracketing is only safe when
+the true branch does not need `T` narrowed.
+
+The `.attrs()` re-resolution seam in `constructWithOptions` keeps
+`React.ComponentPropsWithRef<PrivateResolvedTarget>` and must NOT be switched to `TargetProps`, even
+though `TargetProps` is cheaper everywhere else. The function form
+`.attrs(({ as }) => ({ as: as || 'button' }))` makes the resolved target a union, and `TargetProps` is
+two conditionals, so it distributes inside the distribution that seam already performs. Measured on a
+three-line repro: 6.4.2 157K instantiations, `TargetProps` 6.9M, and TS2589 (excessively deep) with one
+more chained layer, a hard failure against both 6.4.2 and 6.4.4 rather than a slowdown.
+`ComponentPropsWithRef` there costs ~2% instantiations on the consumer fixture and lands the same repro
+at 133K, below 6.4.2. Cheaper in count but deeper in nesting is a real trade, and this one position is
+where nesting wins.
+
+## The style widening
+
+The widening is web-only, gated on `TargetProps`' first parameter (`R extends Runtime`, deliberately
+undefaulted, since a default is what would let a native call site pick web CSS up by omission). Only
+`ComponentTargetProps` carries the gate: `NativeTarget` is `AnyComponent`, so the intrinsic arm is
+unreachable on native. The conditional is over `Runtime`, two members and concrete at every entry
+point, which is why it costs nothing measurable (+0.55% instantiations, +0.05% types, memory flat)
+where a conditional over the target union costs ~4x. Before this, `styled.View` accepted `float` and
+custom properties on 6.4.2 through 6.4.4 alike; both are pinned as `@ts-expect-error` in the native
+contract suite. `width: '3em'` is still accepted and is NOT ours: `@types/react-native` 0.71 types
+`FlexStyle['width']` as `number | string`.
+
+It applies once per render target inside `TargetProps`, never to a merged prop bag at a JSX call site.
+A target's props are shared by every component built on it, so the widening resolves once per tag
+rather than once per component; the call-site form was the largest single consumer cost (measured 5.2x
+the types). The cost is per component-type instantiation, not per JSX site: multiplying call sites
+sixfold moves it only a few percent, so a fixture that grows sites rather than components will not show
+the difference. Only the component arm (`ComponentTargetProps`) routes through the `OverrideStyle`
+guard; every intrinsic element provably declares `style` (the set of `React.JSX.IntrinsicElements` keys
+lacking it is `never`), so `IntrinsicProps` applies `WithCSSVars` directly rather than asking a question
+with one possible answer.
+
+Five things are load-bearing about the current shape, each found by measurement:
+
+- The test is `'style' extends keyof P`, not `P extends { style?: infer S }`. `{}` vacuously satisfies
+  the latter, which would hand every un-introspectable target a `style` key and defeat
+  `WidenUntypedProps` (regresses #5756).
+- It must still distribute over `P`, via the outer `P extends unknown`. `keyof` a union is the keys
+  *common* to every member, so an undistributed pass widens `A | B` against the shared keys alone and
+  silently drops every member-specific prop: `styled(C)` where `C` takes `ButtonProps | AnchorProps`
+  stops accepting `href` (#5787). The earlier `P extends { style?: infer S }` spelling distributed for
+  free because `P` was naked; moving the test to `keyof P` removed the distribution along with it,
+  which is how 6.5.0 shipped the collapse. Measured cost of restoring it: +22 instantiations on the
+  100-component fixture, types and memory flat.
+- `Attrs<Props>` does NOT re-apply it. `Props` already carries the widened style, and re-applying it
+  stops `Attrs<any>` relating to `Attrs<OuterProps>` inside `StyledComponent`/`StyledNativeComponent`.
+- The explicit `| undefined` keeps `style={undefined}` assignable under `exactOptionalPropertyTypes`,
+  which the call-site form allowed.
+- `Substitute`'s second parameter is deliberately unbounded. Bounding it to `BaseObject` forces callers
+  to write `TargetProps<R, T> & BaseObject` to satisfy it, and `{}` is retained rather than reduced
+  inside an intersection, so that one bound propagates an unreducible node through every prop bag
+  downstream. Measured cost of adding it back: +47K types and +73% check time on a 100-component
+  fixture. Never intersect `& {}` into a type that flows into prop bags.
+
+## The empty-prop-bag guard in Substitute and MergeProps
+
+Both aliases short-circuit to `A` when `B` contributes nothing, which keeps `FastOmit<A, never> & {}`
+out of every prop bag (`TargetProps` returns `{}` for a non-target, and `Props` defaults to
+`BaseObject`). The test cannot be `keyof B extends never` alone: `keyof` a union is the keys common to
+every member, so a union of disjoint shapes reports `never` while being a real prop bag, and the fast
+path dropped it wholesale. `styled.div<{ a: string } | { b: number }>` rejected both `a` and `b`, as did
+`as` pointing at such a component. This predates 6.5.0 and is a different mechanism from the
+`OverrideStyle` collapse above, which is why the `ButtonProps | AnchorProps` cases cannot catch it:
+those members share most of their keys, so `keyof` is never `never` and the guard is never consulted.
+
+The guard is now `keyof B extends never ? ({} extends B ? A : Substituted<A, B>) : Substituted<A, B>`.
+`{}` is assignable to an empty bag and not to a union whose members each require a key, which separates
+the two states. The taken branch needs no distribution of its own, since `FastOmit<A, never> & B` is an
+intersection and an intersection over a union distributes already. Measured: +0.04% instantiations,
+memory flat.
+
+Do NOT replace that test with a per-member re-ask (`B extends unknown ?` nested inside the guard). It is
+the more complete fix and it was measured as fatal: it tips tsc into TS2589 against a caller that
+spreads props carrying `as?: WebTarget`, because the added distribution nests inside the one the
+polymorphic call signature already performs over that ~153-member union. The `#4112` case in the
+contract suite is what fails.
+
+Accepted limitation, pinned in the contract suite: a disjoint union whose members are all-optional still
+collapses, because `{}` is assignable to every member. Such a union accepts `{}` regardless, so the
+flattened all-optional object is equivalent and works.
+
+Rejected alternative, do not re-explore: intersecting instead of omitting inside `OverrideStyle`
+(`P & { style?: … }`). It measured -33% types and -22% check time but is strictly worse than widening
+at the source, and it breaks a component's own narrow `style` type by narrowing rather than replacing
+it.
+
+## Declared style props
+
+A declared `style` merges rather than replaces, and the merge is an intersection, not a conditional:
+`MergeProps` simply does not omit `style` from the target, so `CSSPropertiesWithVars & { width: number }`
+narrows one field and keeps the rest. Both conditional spellings were measured and rejected. Testing
+`keyof A` tips tsc into TS2590 outright, and testing `keyof B` costs +54% types because it stays
+deferred while `B` is generic and the checker materializes both branches. `never` ablates a field and
+`CustomStyle` ablates everything unnamed, so full override stays expressible without making it the
+default.
+
+`PolymorphicComponentProps` merges rather than substitutes the `as`/`forwardedAs` target's props over
+`BaseProps`, so a declared `style` constraint is not escapable by rendering the same component through
+a different tag. Measured on the consumer fixture: +0.016% types, +0.48% instantiations, memory
+unchanged. This is the one place a per-JSX-site cost was accepted, and it was accepted only because it
+buys a contract `CustomStyle` otherwise states falsely.
+
+Known limitation, characterized in the contract suite: under `exactOptionalPropertyTypes`, a component
+declaring its own `style` rejects an explicit `style={undefined}`, because intersecting the declared
+type leaves no `undefined` arm. Omitting the prop is unaffected and `style?: X | undefined` restores it.
+Do not "fix" this by reintroducing a conditional in `MergeProps`; that shape measured +54% types.
+Accepted and documented in the changeset instead.
+
+## Standing limitations
+
+`CSSProp`'s recursion through `RuleSet` is load-bearing and must not be flattened to "fix" #3496
+(`css?: CSSProp` plus react-spring's recursive `animated` types tips TS2589). Ablated against the real
+packages: react-spring alone is fine and `css?: string` is fine, so the depth is ours, but every
+shallower `CSSProp` that fixes it also stops `css={cssHelperOutput}` being assignable, which is the
+primary use of the prop. It reproduces identically on 6.4.2 and 6.4.4, so it is a standing limitation
+rather than a regression.
+
+## Permissiveness for un-introspectable targets
+
+Permissiveness is decided from the TARGET's props, not from the finished prop bag. `WidenUntypedProps`
+asks whether the merged bag is empty, which stops being true as soon as a component adds a transient
+prop, so `styled(PolymorphicTarget)<{ $variant: string }>` silently lost the permissiveness and started
+rejecting `children` (#5756, on 6.4.2 and 6.4.4 alike). `WidenForUntypedTarget` tests `Target` instead.
+Applying it over an already-widened bag is a no-op, since the index signature makes `keyof` be `string`.
+
+## Attribution discipline
+
+When a cost cliff appears after several changes land together, ablate to the cause before attributing
+it. The TS2589 above was blamed in turn on the `Exclude` inside `MergeProps` and on `MergeProps`
+itself; making `MergeProps` byte-identical to `Substitute` still reproduced it, which is what pointed at
+the `.attrs()` seam. A fix that makes the symptom go away is not evidence about the cause, and a comment
+recording the wrong cause outlives the session that guessed it.
+
+## Type-level idioms
+
+Use built-in `NoInfer` (TS 5.4+) internally. Never declare a local `NoInfer` alias in a file that also
+uses it: the local declaration shadows the intrinsic within that module and silently downgrades every
+reference to the slower deferred form. A re-export (`export type { NoInfer } from './utils/noInfer'`)
+introduces no local binding and is safe. Do NOT probe which form is in play by testing whether inference
+is blocked, since the deferred form blocks identically and both the test and its negative control pass.
+The only instrument that separates them is resolving the identifier through the compiler API and reading
+which file the symbol lands in (`lib.es5.d.ts` means the intrinsic).
+
+Keep a conditional type's branches as named top-level aliases (`WithCSSVars`, `IntrinsicProps`,
+`ComponentTargetProps`, `Substituted`). A conditional alias loses its name the moment it resolves,
+because the checker returns the branch type and drops the `aliasSymbol`, so an inlined branch prints its
+whole expansion in every hover and error. Naming the branches took a styled component's displayed type
+from roughly 380 characters to 95 at no measurable cost. Do not inline them back for tidiness; the
+tidiness is the point.
+
+Do NOT reach for the popular `Prettify<T> = { [K in keyof T]: T[K] } & {}` to clean up a displayed type
+here. It is a homomorphic mapped type (which breaks JSX overload resolution) ending in the `& {}` that
+never reduces. It is fine on a leaf type a user hovers, and poison on anything that flows into prop bags.
+
+Further measured results:
+
+- `FastOmit<A, K> & B` (intersection) is 2.4x fewer instantiations than a single mapped type with
+  per-key conditionals.
+- Homomorphic mapped types (`{ [K in keyof P]: ... }`) break React JSX overload resolution.
+- Flattening nested `Substitute` into parallel `FastOmit`s increases instantiations, because TS
+  deduplicates nested structures better.
+- Do not replace built-in `Omit` with `FastOmit` in `OverrideStyle`. Built-in `Omit` (Pick + Exclude) is
+  more optimized, measuring +17% instantiations when replaced.
+- Variance annotations (`out`/`in out`) on `Styled`, `PolymorphicComponent`, `IStyledComponentBase` and
+  friends reduce variance computation (-72%) and memory (-16%).
+- `domElements.forEach` uses a `(styled as any)` cast. The types are already declared via a mapped type
+  on the `styled` const, which avoids one redundant `Styled<>` instantiation per element in
+  `domElements`.
+
+## Profiling
+
+`tsc --noEmit` cannot see editor behavior. A change to the polymorphic call signature must also be
+checked by driving a real tsserver at a half-typed JSX attribute (`<Comp as="video" l|>` must still
+offer `loop`). Always include a positive control in that probe: a caret that lands wrong returns zero
+completions, which reads identically to a genuine regression.
+
+- `~/.claude/tools/tsc-perf.sh measure tsconfig.test-types.json`, or
+  `npx tsc --noEmit --extendedDiagnostics --project tsconfig.test-types.json`. Delete `tsbuildinfo`
+  first for a clean measurement.
+- `npx @typescript/analyze-trace /tmp/tsc-perf-trace` detects hot spots and duplicate packages.

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -88,6 +88,10 @@ const AS_TAGS = ['a', 'button', 'label', 'section', 'video', 'ul'];
 // Declaration mix per PER_FILE-sized cycle, weighted toward what large apps
 // actually contain. Adjusting a weight changes what the committed budget means,
 // so the numbers must be re-measured with --update afterwards.
+// `unionTarget` prices the distributive prop path (#5787). Without it nothing
+// here contains a union-typed target, so the distribution that keeps `A | B`
+// from collapsing to its shared keys costs nothing measurable -- and the next
+// pass over this area reads "free to remove" off a fixture that never used it.
 const KIND_WEIGHTS = [
   ['plainTag', 8],
   ['wrapComponent', 5],
@@ -95,6 +99,7 @@ const KIND_WEIGHTS = [
   ['attrsTag', 2],
   ['attrsWrap', 1],
   ['genericWrapper', 1],
+  ['unionTarget', 1],
 ];
 const PER_FILE = KIND_WEIGHTS.reduce((sum, [, weight]) => sum + weight, 0);
 
@@ -123,15 +128,21 @@ const Plain = (props: BaseProps & { className?: string; children?: React.ReactNo
 
 const Other = (props: { href?: string; children?: React.ReactNode }) => <a {...props} />;
 
+type PressableProps =
+  | React.ButtonHTMLAttributes<HTMLButtonElement>
+  | React.AnchorHTMLAttributes<HTMLAnchorElement>;
+const Pressable = (_props: PressableProps) => null;
+
 const spreadProps = { className: 'x', id: 'y' };
 `;
 
 function unit(i) {
   const tag = TAGS[i % TAGS.length];
   const N = `C${i}`;
+  const kind = kindOf(i);
   let decl;
 
-  switch (kindOf(i)) {
+  switch (kind) {
     case 'plainTag':
       decl = `const ${N} = styled.${tag}<{ $a${i}?: number; $b${i}?: string; $c${i}?: boolean }>\`
   color: \${p => (p.$c${i} ? 'red' : 'blue')};
@@ -161,6 +172,11 @@ function unit(i) {
   height: \${p => p.$size}px;
 \`;`;
       break;
+    case 'unionTarget':
+      decl = `const ${N} = styled(Pressable)<{ $a${i}?: number }>\`
+  padding: \${p => p.$a${i} ?? 0}px;
+\`;`;
+      break;
     default:
       // Generic wrapper: the shape behind #4246/#1803, where a styled component
       // is consumed through a caller's own type parameter.
@@ -173,10 +189,14 @@ function ${N}<T extends BaseProps>({ item, ...rest }: { item: T } & React.Compon
       break;
   }
 
-  const generic = kindOf(i) === 'genericWrapper';
+  const generic = kind === 'genericWrapper';
   const sites = generic
     ? [`<${N} item={{ label: 'l' }} />`, `<${N} item={{ label: 'l' }} className="x" />`]
     : [`<${N} />`, `<${N} className="x">{'t'}</${N}>`];
+
+  // A member-specific prop is the whole point of the union fixture: a plain call
+  // site resolves against the shared keys and would price the same either way.
+  if (kind === 'unionTarget') sites.push(`<${N} href="/x" />`);
 
   if (!generic) {
     if (i % 5 === 0) sites.push(`<${N} {...spreadProps} />`);

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -93,7 +93,7 @@ export interface Styled<
           // `ComponentPropsWithRef` rather than `TargetProps` is the one place
           // that stays: a function-form `.attrs` makes this target a union, and
           // `TargetProps` distributing inside that measured as TS2589. Both in
-          // AGENTS.md.
+          // docs/type-performance.md.
           MergeProps<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
           Props
         >

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -18,7 +18,7 @@ let rscContextOverride: IStyleSheetContext | null = null;
 let rscLastPlugins: stylis.Middleware[] | undefined;
 let rscCachedStylis: Stringifier = mainStylis;
 
-/** Per-render reset to prevent HMR accumulation (see AGENTS.md § RSC Style Injection). */
+/** Per-render reset to prevent HMR accumulation (see docs/rsc-style-injection.md). */
 const ensureSheetReset: (() => void) | null = IS_RSC
   ? (((React as any).cache as (<T extends (...args: any[]) => any>(fn: T) => T) | undefined)?.(
       () => {

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -88,21 +88,6 @@ function shallowEqualContext(prev: object, next: object, prevKeyCount: number): 
   return nextKeyCount === prevKeyCount;
 }
 
-function useInjectedStyle<T extends ExecutionContext>(
-  componentStyle: ComponentStyle,
-  resolvedAttrs: T,
-  styleSheet: StyleSheet,
-  stylis: Stringifier
-): string {
-  const className = componentStyle.generateAndInjectStyles(resolvedAttrs, styleSheet, stylis);
-
-  if (process.env.NODE_ENV !== 'production' && React.useDebugValue) {
-    React.useDebugValue(className);
-  }
-
-  return className;
-}
-
 // Cached render inputs + style result: [prevProps, prevTheme, prevStyleSheet, prevStylis,
 // prevPropsKeyCount, cachedContext, cachedClassName]
 type RenderCache = [
@@ -273,8 +258,11 @@ function useStyledComponentImpl<Props extends BaseObject>(
       generatedClassName = prev[6];
     } else {
       context = resolveContext<Props>(componentAttrs, props, theme);
-      generatedClassName = useInjectedStyle(componentStyle, context, ssc.styleSheet, ssc.stylis);
-
+      generatedClassName = componentStyle.generateAndInjectStyles(
+        context,
+        ssc.styleSheet,
+        ssc.stylis
+      );
       let propsKeyCount = 0;
       for (const key in props) {
         if (hasOwn.call(props, key)) propsKeyCount++;
@@ -292,7 +280,17 @@ function useStyledComponentImpl<Props extends BaseObject>(
     }
   } else {
     context = resolveContext<Props>(componentAttrs, props, theme);
-    generatedClassName = useInjectedStyle(componentStyle, context, ssc.styleSheet, ssc.stylis);
+    generatedClassName = componentStyle.generateAndInjectStyles(
+      context,
+      ssc.styleSheet,
+      ssc.stylis
+    );
+  }
+
+  // Outside the render-cache branch: a hook skipped on a cache hit is a hook
+  // count that changes between renders, which React rejects outright (#5788).
+  if (process.env.NODE_ENV !== 'production' && React.useDebugValue) {
+    React.useDebugValue(generatedClassName);
   }
 
   if (process.env.NODE_ENV !== 'production' && forwardedComponent.warnTooManyClasses) {

--- a/packages/styled-components/src/test/memoization.test.tsx
+++ b/packages/styled-components/src/test/memoization.test.tsx
@@ -391,9 +391,13 @@ describe('memoization correctness', () => {
     function record<T>(render: () => T): [T, string[]] {
       const calls: string[] = [];
       recording = calls;
-      const result = render();
-      recording = null;
-      return [result, calls];
+      try {
+        return [render(), calls];
+      } finally {
+        // Cleared even when the render throws, so a later render cannot append
+        // to a dead array and turn one failure into a confusing second one.
+        recording = null;
+      }
     }
 
     try {

--- a/packages/styled-components/src/test/memoization.test.tsx
+++ b/packages/styled-components/src/test/memoization.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Tests for useInjectedStyle memoization.
+ * Tests for the styled component render cache.
  *
  * Verifies that the useRef-based shallow context comparison correctly
- * caches and invalidates under various scenarios.
+ * caches and invalidates under various scenarios, and that the cache's
+ * hit/miss branch does not change the component's hook sequence.
  */
 import React, { useState } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
@@ -355,5 +356,74 @@ describe('memoization correctness', () => {
 
     renderer.unmount();
     warnSpy.mockRestore();
+  });
+
+  /**
+   * The render cache splits the render path in two, and only one side runs the
+   * style work. Any hook that ends up on one side of that split is called on a
+   * cache miss and skipped on a cache hit, so the component emits a different
+   * hook sequence depending on whether its props happened to change -- exactly
+   * the shape React rejects with "Rendered fewer hooks than expected" (#5788).
+   *
+   * Asserting the sequence rather than a count: a swap of two hooks keeps the
+   * count identical and still breaks React's ordering rule. The recording is
+   * done by wrapping React's own `use*` exports, so a hook added to the render
+   * path in future is picked up without this test being told about it.
+   */
+  it('emits an identical hook sequence on cache-hit and cache-miss renders', () => {
+    // React's module namespace, typed as what it is here: a bag of hook
+    // functions keyed by name. Spelling it once keeps the casts out of the body.
+    const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
+    const hookNames = Object.keys(React).filter(
+      key => key.startsWith('use') && typeof reactHooks[key] === 'function'
+    );
+    // Positive control: if the wrapping ever stops seeing React's hooks, every
+    // sequence below is trivially empty and the comparison passes vacuously.
+    expect(hookNames).toContain('useRef');
+
+    let recording: string[] | null = null;
+    // Restored in `finally`, which the install loop is inside: a throw partway
+    // through installation must not leave React half-patched for later tests.
+    const originals = new Map<string, (...args: unknown[]) => unknown>();
+
+    // Returns what the render produced alongside the hooks it called, so the
+    // renderer needs no `let` declared ahead of its assignment.
+    function record<T>(render: () => T): [T, string[]] {
+      const calls: string[] = [];
+      recording = calls;
+      const result = render();
+      recording = null;
+      return [result, calls];
+    }
+
+    try {
+      for (const name of hookNames) {
+        const original = reactHooks[name];
+        originals.set(name, original);
+        reactHooks[name] = (...args) => {
+          if (recording) recording.push(name);
+          return original(...args);
+        };
+      }
+
+      const Comp = styled.div<{ $color: string }>`
+        color: ${p => p.$color};
+      `;
+
+      // Rendered as the root so every recorded hook belongs to this component.
+      const [renderer, mount] = record(() => TestRenderer.create(<Comp $color="red" />));
+      // Identical props: the render cache hits and skips the style work.
+      const [, cacheHit] = record(() => renderer.update(<Comp $color="red" />));
+      // Changed props: the cache misses and the style work runs again.
+      const [, cacheMiss] = record(() => renderer.update(<Comp $color="blue" />));
+
+      expect(mount.length).toBeGreaterThan(0);
+      expect(cacheHit).toEqual(cacheMiss);
+      expect(mount).toEqual(cacheHit);
+
+      renderer.unmount();
+    } finally {
+      for (const [name, original] of originals) reactHooks[name] = original;
+    }
   });
 });

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -1496,3 +1496,122 @@ const StyledGenericList = styled(GenericList)`
   // @ts-expect-error T is lost through styled(), so props degrades to unknown
   renderChild={props => <p key={`I_${props.id}`}>{props.value}</p>}
 />;
+
+/**
+ * #5787 -- a component whose props are a union keeps every member's props
+ * through `styled()`. `keyof` a union is the keys *common* to every member, so a
+ * prop transform that does not distribute silently narrows `A | B` to their
+ * shared keys and rejects the rest.
+ *
+ * Every accepted prop below is paired with a rejected one. Without the negative
+ * controls, a transform that widened these props to an index signature (the
+ * `WidenUntypedProps` path) would accept everything and pass this whole section
+ * while the union was in fact gone.
+ */
+type UnionButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+type UnionAnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement>;
+type PressableProps = UnionButtonProps | UnionAnchorProps;
+
+const Pressable = (_props: PressableProps) => null;
+const StyledPressable = styled(Pressable)`
+  color: red;
+`;
+
+// Positive control: the unwrapped component accepts both members' props, so a
+// failure below is styled()'s doing and not the union's.
+<Pressable href="/x" />;
+<Pressable type="submit" />;
+
+// Anchor-only and button-only props both survive styled().
+<StyledPressable href="/x">link</StyledPressable>;
+<StyledPressable type="submit">button</StyledPressable>;
+// @ts-expect-error `notAProp` belongs to neither union member
+<StyledPressable notAProp="x" />;
+
+// The `style` widening still applies to each member, custom properties included.
+<StyledPressable style={{ '--x': '1px', color: 'red' }} />;
+// @ts-expect-error `color` still has to be a valid CSS value
+<StyledPressable style={{ color: 4 }} />;
+
+// A component's own declared props merge over a union target.
+const StyledPressableWithProps = styled(Pressable)<{ $tone: 'warn' | 'ok' }>`
+  color: ${p => (p.$tone === 'warn' ? 'red' : 'green')};
+`;
+<StyledPressableWithProps $tone="warn" href="/x" />;
+// @ts-expect-error $tone is constrained to the declared union
+<StyledPressableWithProps $tone="nope" href="/x" />;
+
+// attrs on a union-props target.
+const AttrsPressable = styled(Pressable).attrs({ role: 'button' })``;
+<AttrsPressable href="/x" />;
+// @ts-expect-error still not a prop of either member
+<AttrsPressable notAProp="x" />;
+
+// Wrapping a styled union component again keeps the union.
+const ChainedPressable = styled(StyledPressable)`
+  opacity: 0.5;
+`;
+<ChainedPressable href="/x" />;
+// @ts-expect-error still not a prop of either member
+<ChainedPressable notAProp="x" />;
+
+// `as` pointing at a union-props component.
+const AsUnion = styled.div``;
+<AsUnion as={Pressable} href="/x" />;
+// @ts-expect-error still not a prop of either member
+<AsUnion as={Pressable} notAProp="x" />;
+
+/**
+ * #5787, sibling case: a union whose members share NO keys. `keyof` such a union
+ * is `never`, which is also how `Substitute`/`MergeProps` recognize an empty prop
+ * bag, so the fast path used to drop the union wholesale. The union above cannot
+ * catch this: `ButtonHTMLAttributes | AnchorHTMLAttributes` share most of their
+ * keys, so `keyof` is never `never` and the guard is never consulted.
+ *
+ * Predates 6.5.0. Reachable three ways, all pinned here.
+ */
+type DisjointProps = { onlyA: string } | { onlyB: number };
+const Disjoint = (_props: DisjointProps) => null;
+
+// Positive control: unwrapped, both members' props are accepted.
+<Disjoint onlyA="x" />;
+<Disjoint onlyB={1} />;
+
+// Wrapping a disjoint-union target.
+const StyledDisjoint = styled(Disjoint)``;
+<StyledDisjoint onlyA="x" />;
+<StyledDisjoint onlyB={1} />;
+// @ts-expect-error on neither member
+<StyledDisjoint notAProp="x" />;
+
+// Declaring disjoint-union props. This is the path that routes through
+// `Substitute`'s guard directly.
+const DeclaredDisjoint = styled.div<DisjointProps>``;
+<DeclaredDisjoint onlyA="x" />;
+<DeclaredDisjoint onlyB={1} />;
+// the target's own props still merge over the declaration
+<DeclaredDisjoint onlyA="x" id="d" />;
+// @ts-expect-error on neither member
+<DeclaredDisjoint notAProp="x" />;
+// @ts-expect-error a member still requires its own key
+<DeclaredDisjoint id="d" />;
+
+// `as` pointing at a disjoint-union component, which nests the guard inside
+// `MergeProps`.
+<AsUnion as={Disjoint} onlyA="x" />;
+// @ts-expect-error on neither member
+<AsUnion as={Disjoint} notAProp="x" />;
+
+/**
+ * Accepted limitation, characterized rather than fixed: a disjoint union whose
+ * members are ALL-optional still collapses, because `{}` is assignable to every
+ * member and so cannot be told apart from a genuinely empty prop bag. The
+ * complete fix (re-asking `keyof` per member) tips `tsc` into TS2589 against a
+ * caller spreading `as?: WebTarget`. Such a union accepts `{}` regardless, so
+ * declaring the flattened `{ onlyA?: string; onlyB?: number }` is equivalent and
+ * works.
+ */
+type AllOptionalDisjoint = { onlyA?: string } | { onlyB?: number };
+const AllOptional = styled.div<AllOptionalDisjoint>``;
+// @ts-expect-error known limitation: an all-optional disjoint union collapses
+<AllOptional onlyA="x" />;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -203,7 +203,7 @@ interface ThemedExecutionProps {
  * The `style` widening happens here, once per target, rather than at every JSX
  * call site -- directly via {@link WithCSSVars} on the intrinsic arm, which
  * needs no guard, and via {@link OverrideStyle} on the component arm, which
- * does. See AGENTS.md before changing any of it.
+ * does. See docs/type-performance.md before changing any of it.
  *
  * `R` carries the runtime so the widening stays web-only; it is deliberately
  * undefaulted, since a default is what would let a native call site pick up web
@@ -483,8 +483,19 @@ type WithCSSVars<P extends BaseObject> = Omit<P, 'style'> & {
  * targets that expose no props at all and defeat `WidenUntypedProps` (#5756).
  * Only {@link ComponentTargetProps} needs the guard; every intrinsic element
  * declares `style`, so {@link IntrinsicProps} applies `WithCSSVars` directly.
+ *
+ * The outer `P extends unknown` is what makes this distribute over a union of
+ * prop shapes, and it is load-bearing (#5787). `keyof` a union is the keys
+ * *common* to every member, so an undistributed pass widens `A | B` against the
+ * shared keys alone and drops every member-specific prop -- a component typed
+ * `ButtonProps | AnchorProps` stops accepting `href`. Widening member by member
+ * keeps the union intact.
  */
-type OverrideStyle<P extends BaseObject> = 'style' extends keyof P ? WithCSSVars<P> : P;
+type OverrideStyle<P extends BaseObject> = P extends unknown
+  ? 'style' extends keyof P
+    ? WithCSSVars<P>
+    : P
+  : never;
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };
 
@@ -546,7 +557,30 @@ export type Substituted<A extends BaseObject, B> = FastOmit<A, keyof B> & B;
 // prop bags: TargetProps returns `{}` for every non-target and `Props` defaults
 // to BaseObject, so without it both cases resolve to `FastOmit<A, never> & {}`,
 // the unreducible node the paragraph above is about.
-export type Substitute<A extends BaseObject, B> = keyof B extends never ? A : Substituted<A, B>;
+//
+// `keyof B extends never` alone cannot carry that guard, because `keyof` a union
+// is the keys *common* to every member: a union of disjoint shapes reports
+// `never` while being a perfectly real prop bag, and the fast path then dropped
+// it wholesale. `{} extends B` separates the two, since an empty object is
+// assignable to `{}` but not to a union whose members each require a key. The
+// taken branch needs no distribution of its own, because `FastOmit<A, never> & B`
+// is an intersection and an intersection over a union distributes already.
+//
+// Do NOT instead re-ask `keyof` per member (`B extends unknown ? …` inside this
+// guard). It is more complete, and it tips `tsc` into TS2589 where a caller
+// spreads props carrying `as?: WebTarget`: the added distribution nests inside
+// the one the polymorphic signature already performs over that ~153-member
+// union. Measured cost of the spelling below: +0.04% instantiations.
+//
+// Known limitation, accepted: a union whose members are ALL-optional (`{a?: 1} |
+// {b?: 2}`) still takes the fast path, because `{}` is assignable to each member.
+// Such a union accepts `{}` anyway, so it is nearly indistinguishable from the
+// flattened `{a?: 1, b?: 2}` that does work.
+export type Substitute<A extends BaseObject, B> = keyof B extends never
+  ? {} extends B
+    ? A
+    : Substituted<A, B>
+  : Substituted<A, B>;
 
 /**
  * A component's own props over its target's props, with `style` merged rather
@@ -559,9 +593,13 @@ export type Substitute<A extends BaseObject, B> = keyof B extends never ? A : Su
  * `style?: X | undefined` to allow it. Omitting the prop is unaffected.
  *
  * Both conditional spellings of this were measured and rejected, one of them
- * fatal. Keep it an intersection; see AGENTS.md before changing the shape.
+ * fatal. Keep it an intersection; see docs/type-performance.md before changing the shape.
  */
-export type MergeProps<A extends BaseObject, B> = keyof B extends never ? A : Merged<A, B>;
+export type MergeProps<A extends BaseObject, B> = keyof B extends never
+  ? {} extends B
+    ? A
+    : Merged<A, B>
+  : Merged<A, B>;
 
 /** The taken branch of {@link MergeProps}, named so hovers print a name rather
  * than the expansion. Keep it named; see {@link Substituted}. */

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,9 +1,9 @@
 {
   "count": 100,
   "measured": {
-    "instantiations": 696087,
-    "memoryKb": 189091,
-    "types": 31431
+    "instantiations": 850743,
+    "memoryKb": 197127,
+    "types": 30449
   },
   "tolerancePct": {
     "instantiations": 10,


### PR DESCRIPTION
Closes #5787. Also addresses #5788, with a correction to its stated cause (below).

## Union props survive `styled()` again (#5787)

A component typed `ButtonProps | AnchorProps` stopped accepting `href` once wrapped, accepting only the props common to every member of the union.

`OverrideStyle` used to test `P extends { style?: infer S }`, a naked type parameter, which distributes over a union for free. #5784 rewrote the test as `'style' extends keyof P`, which inspects `P` rather than checking it, and distribution went with it. `keyof` a union is the keys *common* to every member, so an undistributed pass rebuilt `A | B` from the shared keys alone. Restored with an outer `P extends unknown`.

## The same bug, one seam over

Auditing the siblings turned up a second instance that predates 6.5.0. `Substitute` and `MergeProps` recognize an empty prop bag with `keyof B extends never`, and a union of disjoint shapes satisfies that too, so the fast path dropped it wholesale:

```tsx
const Box = styled.div<{ onlyA: string } | { onlyB: number }>``
<Box onlyA="x" />   // rejected: both members' props were gone
```

Now discriminated with `{} extends B`, which an empty bag satisfies and a union of required-key members does not. The complete fix (re-asking `keyof` per member) is measured as fatal: it tips `tsc` into TS2589 against a caller spreading `as?: WebTarget`, because the added distribution nests inside the one the polymorphic signature already performs over that ~153-member union. The residue, an all-optional disjoint union, is pinned in the contract suite as a known limitation rather than left silent.

## Hook sequence (#5788)

`useDebugValue` sat inside the render cache's miss branch, so it ran on a cache miss and was skipped on a cache hit. Moved past the if/else. The `use`-prefixed `useInjectedStyle` wrapper it lived in called no hooks of its own, so it is inlined; the seam that made a conditional call look safe is gone.

**Correction to the issue's stated cause.** #5788 attributes a `Rendered fewer hooks than expected` crash to this call. It cannot produce that error. In React 19.2.3 the throw is guarded solely by `currentHook !== null && currentHook.next !== null`, and `useDebugValue` only feeds `hookTypesDev`, which backs a warning; `useContext` allocates no slot either. A 6.4.x styled component therefore has exactly one hook slot (`useRef`) where 6.3.12 had none, and going from one slot to zero cannot trip that condition. A MUI DataGrid + `@mui/styled-engine-sc` + React 19.2.8 reproduction did not crash, with or without StrictMode. This change is still correct, but the reporter's crash is unexplained and I would keep #5788 open pending a runnable repro.

## Guardrails

- Contract-suite cases across every union surface (plain, `as`, `forwardedAs`, `.attrs`, chained, disjoint). Every accepted prop is paired with a rejected one, so a transform that widened props to an index signature cannot pass the section with the union destroyed.
- A runtime test that records the hook sequence by wrapping React's own `use*` exports and asserts cache-hit and cache-miss renders match. It picks up any hook added to the render path later without being told about it.
- A `unionTarget` kind in the consumer type-check fixture. The budget existed to catch exactly this class and missed it because no fixture component had union props. It now prices the distributive path and, since the run fails on any fixture compile error, fails outright if the union collapses again.

Each guardrail was validated red against the unfixed code before being kept.

## Cost

+0.04% instantiations, types and memory flat. The recorded budget moved because the fixture grew, not because the cost did.

## Docs

Separate first commit: AGENTS.md had grown to hold both the rules and every subsystem's full specification, so it is now the rules plus a map, with one home per subject under `docs/`. Tracing the moved text against the source corrected six claims that no longer described 6.x, including a keyframes section describing v7 behavior and citing a symbol absent from this branch.