### PR TITLE
fix(types): cheaper annotated declaration sites, and sound generic polymorphic props

### DIFF
--- a/.changeset/attrs-target-unchanged-fast-path.md
+++ b/.changeset/attrs-target-unchanged-fast-path.md
@@ -2,6 +2,6 @@
 'styled-components': patch
 ---
 
-`.attrs()` on an element tag is cheaper to type-check.
+`.attrs()` is cheaper to type-check.
 
-Object-form `.attrs()` leaves the rendered target unchanged, but the types still re-resolved that target's whole prop bag on every `.attrs` call, which made `.attrs` on an HTML or SVG tag far more expensive to check than on a wrapped component. It now reuses the props already resolved for the tag, cutting consumer type-check instantiations measurably with no change to the resulting component's accepted props. Redirecting the target with `.attrs({ as })`, including the function form, is unaffected.
+Two costs on the `.attrs` path are gone. Object-form `.attrs()` left the rendered target unchanged but still re-resolved that target's whole prop bag on every call, making `.attrs` on an HTML or SVG tag far costlier than on a wrapped component; it now reuses the props already resolved for the tag. Separately, making attrs-provided keys optional ran an avoidably expensive pass over the target's full prop set on every attrs component. Together these cut consumer type-check work measurably across every `.attrs` form, with no change to the resulting component's accepted props. Redirecting the target with `.attrs({ as })`, including the function form, is unaffected.

--- a/.changeset/attrs-target-unchanged-fast-path.md
+++ b/.changeset/attrs-target-unchanged-fast-path.md
@@ -1,0 +1,7 @@
+---
+'styled-components': patch
+---
+
+`.attrs()` on an element tag is cheaper to type-check.
+
+Object-form `.attrs()` leaves the rendered target unchanged, but the types still re-resolved that target's whole prop bag on every `.attrs` call, which made `.attrs` on an HTML or SVG tag far more expensive to check than on a wrapped component. It now reuses the props already resolved for the tag, cutting consumer type-check instantiations measurably with no change to the resulting component's accepted props. Redirecting the target with `.attrs({ as })`, including the function form, is unaffected.

--- a/.changeset/faster-annotated-styled-components.md
+++ b/.changeset/faster-annotated-styled-components.md
@@ -1,0 +1,9 @@
+---
+'styled-components': patch
+---
+
+Explicitly annotated styled components type-check faster.
+
+Assigning a styled component to an explicit type, as `isolatedDeclarations` and any package that emits `.d.ts` files must (`const Button: IStyledComponentBase<'web', ...> = styled.button``), used to be several times more expensive to check than an inferred one, because the annotation's `style` and the component's widened `style` were two different csstype representations that the checker compared property by property.
+
+The inline `style` widening now builds on React's own `CSSProperties`, the same type a hand-written annotation carries, so that comparison short-circuits. On a 40-component fixture this cut the types created for the annotated pattern by about 21%, with no change to what `style` accepts: CSS custom properties, a component's own narrow `style`, and `style={undefined}` all behave exactly as before.

--- a/.changeset/styled-generic-polymorphic-narrows-props.md
+++ b/.changeset/styled-generic-polymorphic-narrows-props.md
@@ -1,0 +1,7 @@
+---
+'styled-components': patch
+---
+
+`styled()` wrapping a generic polymorphic component keeps its declared props narrow.
+
+Wrapping a component whose props are generic over an element type, such as the common `<C extends React.ElementType>(props: PolymorphicProps<C, OwnProps>)` pattern, used to let the styled result accept prop values the component itself rejects: `styled(Button)` would take `variant="anything"` even though `<Button variant="anything">` is a type error. The wrapper now narrows those props exactly as the direct component does, so a bad value is caught in both places. Valid props, children, and plain (non-generic) targets are unaffected.

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -47,6 +47,18 @@ bag is hand-written instead of the shape the library computes. This is what isol
 that deepened that relation would move nothing here. Like `unionTarget` it is expensive per component,
 so it too moved the recorded budget on its own -- fixture growth, not a regression.
 
+Four exotic kinds each price a `types.ts` conditional arm no other kind reaches, and each also fails the
+clean-compile gate if its mechanism regresses, so they are correctness canaries sitting inside the perf
+gate the way `unionTarget` is: `permissiveFactory` (a Mantine-style un-introspectable target, the
+"Permissiveness for un-introspectable targets" section), `genericPoly` (a generic polymorphic target, the
+`string extends keyof P` gate under "The style widening"), `attrsAsRedirect` (function-form `.attrs` that
+redirects the target, the TS2589-sensitive seam under "Target prop resolution"), and `disjointTarget` (a
+no-shared-keys union target, "The empty-prop-bag guard"). Two call-site variants on `plainTag` price a
+relation no site otherwise triggers: passing `style` (the widening, from the call-site direction) and a
+`ref` callback (contextual inference, #5687). `canary.tsx` additionally pins the two soundness properties
+a cost kind cannot catch on its own: a `genericPoly` bad value is rejected, and a `permissiveFactory`
+arbitrary prop is accepted.
+
 A kind added or a weight changed here changes what the budget means, so re-measure with `--update` and
 say in the commit that the fixture, not the cost, is what moved. `type-perf.budget.json` is the live
 figure; `pnpm --filter styled-components type-perf` prints the current one. Do not restate either here,
@@ -80,6 +92,16 @@ more chained layer, a hard failure against both 6.4.2 and 6.4.4 rather than a sl
 `ComponentPropsWithRef` there costs ~2% instantiations on the consumer fixture and lands the same repro
 at 133K, below 6.4.2. Cheaper in count but deeper in nesting is a real trade, and this one position is
 where nesting wins.
+
+That `ComponentPropsWithRef` re-merge runs only when `.attrs()` redirects the target. Object-form
+`.attrs()` (the common case) leaves the target unchanged, so `AttrsTarget` returns `Target`,
+`OuterProps` already equals `TargetProps<R, Target>`, and re-merging `ComponentPropsWithRef<Target>`
+rebuilds the ~265-key intrinsic bag only to reproduce what `OuterProps` held. A `[PrivateResolvedTarget]
+extends [Target]` fast path returns `MergeProps<OuterProps, Props>` directly for that case, keeping the
+function-form union on the `ComponentPropsWithRef` branch (the bracket stops it distributing here). It
+is the single largest per-kind cost in the fixture (`.attrs` on an intrinsic priced 27x `.attrs` on a
+component before this), and the fast path measured -6.8% instantiations on the 100-component fixture with
+the contract suite and every `.attrs` behavior unchanged.
 
 ## The style widening
 

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -39,6 +39,14 @@ correctness canary sitting inside the perf gate. It is also the single most expe
 component, by a wide margin, so adding it moved the recorded budget substantially on its own. That jump
 was fixture growth, not a regression.
 
+The `annotated` kind prices the declaration site rather than the call site: a `styled.div` result
+assigned to an explicit `IStyledComponent<'web', FastOmit<DivProps, never> & …>` annotation whose prop
+bag is hand-written instead of the shape the library computes. This is what isolatedDeclarations and any
+`.d.ts`-emitting package produce, and it is the one place the style widening costs rather than saves
+(see "The declaration-site relation" below). No other kind annotates a result, so without it a change
+that deepened that relation would move nothing here. Like `unionTarget` it is expensive per component,
+so it too moved the recorded budget on its own -- fixture growth, not a regression.
+
 A kind added or a weight changed here changes what the budget means, so re-measure with `--update` and
 say in the commit that the fixture, not the cost, is what moved. `type-perf.budget.json` is the live
 figure; `pnpm --filter styled-components type-perf` prints the current one. Do not restate either here,
@@ -95,8 +103,20 @@ guard; every intrinsic element provably declares `style` (the set of `React.JSX.
 lacking it is `never`), so `IntrinsicProps` applies `WithCSSVars` directly rather than asking a question
 with one possible answer.
 
-Five things are load-bearing about the current shape, each found by measurement:
+Six things are load-bearing about the current shape, each found by measurement:
 
+- `string extends keyof P` gates the widening off entirely for a prop bag carrying a `[k: string]: any`
+  index signature, returning `P` untouched. A generic polymorphic component
+  (`<C extends ElementType>(p: … & ComponentProps<C>)`) introspects at the `ElementType` constraint,
+  where `ComponentProps<ElementType>` is `any`, so its extracted bag gains that index alongside its
+  narrow props. `WithCSSVars`' `Omit<P, 'style'>` (`Pick<P, Exclude<keyof P, 'style'>>`) would then
+  collapse every narrow key into the index (`keyof P` is `string`, `Exclude<string, 'style'>` is still
+  `string`), widening a declared `variant: 'a' | 'b'` to `any` so `styled(Button)` accepts props the
+  component itself rejects (#5756). Declining to widen keeps the narrow props; the only thing given up is
+  custom-property widening on a `style` that is already `any`, which is moot. The key-preserving
+  alternative, `FastOmit` in `WithCSSVars`, measured ~+11% instantiations on the 100-component fixture
+  (the homomorphic-mapped-type price the intrinsic path avoids) and is rejected for that reason; the gate
+  is instantiation-flat.
 - The test is `'style' extends keyof P`, not `P extends { style?: infer S }`. `{}` vacuously satisfies
   the latter, which would hand every un-introspectable target a `style` key and defeat
   `WidenUntypedProps` (regresses #5756).
@@ -116,6 +136,48 @@ Five things are load-bearing about the current shape, each found by measurement:
   inside an intersection, so that one bound propagates an unreducible node through every prop bag
   downstream. Measured cost of adding it back: +47K types and +73% check time on a 100-component
   fixture. Never intersect `& {}` into a type that flows into prop bags.
+
+## The declaration-site relation
+
+Assigning a `styled` result to an explicit annotation --
+`const X: IStyledComponent<'web', FastOmit<DivProps, never> & P> = styled.div<P>` -- forces an
+assignability check between the inferred component and the hand-written type. The two prop bags differ in
+exactly one field, `style`: the widened `style` a `styled` result carries versus the plain `style` a
+consumer writes. `Props` is invariant (`in out`), so the check relates the two `style` types both ways,
+and the reverse direction is where the cost sits.
+
+Keeping the widened `style` and a hand annotation's `style` on the SAME csstype instantiation is what
+makes that reverse relation cheap. {@link CSSPropertiesWithVars} bases on `React.CSSProperties` -- which
+is what a hand-written `style` is -- so `React.CSSProperties & Vars` relates to `React.CSSProperties` by
+the intersection-member fast path. Before this, the widened style based on the library's `CSSProperties`
+(`CSS.Properties<number | (string & {})>`), a different instantiation than the annotation's
+`CSS.Properties<string | number>`, so the checker walked `StandardProperties` / `VendorLonghandProperties`
+member by member, once per component. That was the whole of the 6.5.0 report from isolatedDeclarations
+packages. On a 40-component fixture the naive annotation cost 8,281 types before the rebase and 6,552
+after (−21%; instantiations 32,651 → 28,731), TS 5.9.3 / @types/react 18, with the call-site budget and
+the web+native type tests unmoved and every widening behavior preserved (custom properties,
+`style={undefined}` under `exactOptionalPropertyTypes`, a component's own narrow `style`, value
+rejection). Only the inline `style` prop rebases; object styles keep the richer numeric
+{@link CSSProperties} base.
+
+Change ONLY the cached base. Rebasing it and also reshaping `WithCSSVars` in the same pass -- dropping the
+`(P[keyof P & 'style'] & {})` union arm, or swapping the `Omit<…, 'style'>` for a raw
+`IntrinsicElements[T] & { style }` intersection -- regresses declaration-site instantiations sharply
+(measured ~+46% and higher, a net loss) because the union arm is the forward-direction identity anchor
+and the `Omit` is what removes the target's own `style` before the widened one is added. The rebase wins
+on its own; the reshape does not, and the two were conflated in the pass that first tried this and wrongly
+recorded the whole idea as rejected.
+
+The rebase narrows the divergence but cannot erase it: a divergent hand annotation cannot reach
+inferred-baseline cost, which needs reference-identity (annotating with `typeof` the component is free).
+Ablation on the same fixture: dropping the widening entirely
+(`IntrinsicProps = React.JSX.IntrinsicElements[T]`) lands at 2,385, so the residual over that floor is the
+`Omit` walk of the ~250 `HTMLAttributes` keys, inherent to any structural relation between two
+differently-built-but-equal bags. A consumer who still annotates explicitly should use the exact shape the
+constructor emits, `IStyledComponent<'web', MergeProps<TargetProps<'web', Tag>, P>>` -- not `Substitute`,
+which omits `style` and lands further from identity -- for an identity-cheap relation, but the rebase
+means plain hand annotations no longer need it. The `annotated` fixture kind guards the axis so a future
+deepening of this relation is caught.
 
 ## The empty-prop-bag guard in Substitute and MergeProps
 

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -103,6 +103,20 @@ is the single largest per-kind cost in the fixture (`.attrs` on an intrinsic pri
 component before this), and the fast path measured -6.8% instantiations on the 100-component fixture with
 the contract suite and every `.attrs` behavior unchanged.
 
+The seam is not the largest part of the `.attrs` cost. Decomposing the chain, the `.attrs()` call itself
+is cheap; the explosion is in the final `IStyledComponent` production, where `MakeAttrsOptional` runs a
+mapped pass over the ~266-key widened intrinsic bag to make attrs-provided keys optional, per
+structurally-unique component (each bag differs by its own prop names, so nothing caches) -- about 30% of
+the types an `.attrs`-on-a-tag component creates. Its taken branch uses built-in `Omit` distributed
+through an outer `P extends unknown`, not `FastOmit`: built-in `Omit` is the more optimized here (the
+same result the `OverrideStyle` note records), and the distribution runs it per union member so a
+union-props attrs target (`styled(Pressable).attrs(...)`) keeps its member-specific keys rather than
+collapsing to the union's common ones (a bare undistributed `Omit` drops `href`). Measured: -7.5% types,
+-4.1% instantiations on the consumer fixture, memory flat, contract suite and every `.attrs` form
+unchanged. Note the union redirect above is NOT where the cost is: a union redirect and a single-concrete
+redirect price identically, and collapsing the `ComponentPropsWithRef` re-merge moves ~6 types while
+breaking four redirect contracts, so it stays.
+
 ## The style widening
 
 The widening is web-only, gated on `TargetProps`' first parameter (`R extends Runtime`, deliberately

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -92,11 +92,24 @@ const AS_TAGS = ['a', 'button', 'label', 'section', 'video', 'ul'];
 // here contains a union-typed target, so the distribution that keeps `A | B`
 // from collapsing to its shared keys costs nothing measurable -- and the next
 // pass over this area reads "free to remove" off a fixture that never used it.
+// `annotated` prices the declaration site: a styled result assigned to an
+// explicit `IStyledComponent<...>` annotation whose prop bag is hand-written
+// (`FastOmit<DivProps, never> & …`) rather than the shape the library computes.
+// isolatedDeclarations and `.d.ts`-emitting packages write this, and it is the
+// one place the 6.5 style widening costs rather than saves: the annotation's
+// plain `style` diverges from the widened `style` on the styled result, forcing
+// a full csstype relation per component (~3x the types of an inferred site, and
+// the whole of the reported 6.5.0 regression on that pattern). Nothing else here
+// annotates a result, so without this the axis is unguarded and a change that
+// deepened that relation would be invisible. Like `unionTarget`, it is expensive
+// per component, so adding it moved the recorded budget on its own -- that jump
+// is fixture growth, not a regression.
 const KIND_WEIGHTS = [
   ['plainTag', 8],
   ['wrapComponent', 5],
   ['chained', 3],
   ['attrsTag', 2],
+  ['annotated', 1],
   ['attrsWrap', 1],
   ['genericWrapper', 1],
   ['unionTarget', 1],
@@ -113,7 +126,9 @@ function kindOf(i) {
 }
 
 const HEADER = `import * as React from 'react';
-import styled from 'styled-components';
+import styled, { type FastOmit, type IStyledComponent } from 'styled-components';
+
+type DivProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
 interface BaseProps {
   $variant?: 'primary' | 'secondary';
@@ -165,6 +180,16 @@ function unit(i) {
     case 'attrsTag':
       decl = `const ${N} = styled.${tag}.attrs<{ $a${i}?: number }>({ $a${i}: ${i} })\`
   width: \${p => p.$a${i}}px;
+\`;`;
+      break;
+    case 'annotated':
+      // Explicit declaration-site annotation with a hand-written prop bag (see
+      // KIND_WEIGHTS). Always `styled.div` so the annotation's `DivProps` matches
+      // the target and the fixture compiles clean; the cost is the relation, not
+      // a mismatch. `IStyledComponent<'web', P>` is `IStyledComponentBase<'web', P>
+      // & string`, the public spelling of the type the report annotates against.
+      decl = `const ${N}: IStyledComponent<'web', FastOmit<DivProps, never> & { $a${i}?: number }> = styled.div<{ $a${i}?: number }>\`
+  color: \${p => (p.$a${i} ? 'red' : 'blue')};
 \`;`;
       break;
     case 'attrsWrap':

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -104,6 +104,17 @@ const AS_TAGS = ['a', 'button', 'label', 'section', 'video', 'ul'];
 // deepened that relation would be invisible. Like `unionTarget`, it is expensive
 // per component, so adding it moved the recorded budget on its own -- that jump
 // is fixture growth, not a regression.
+// The four exotic kinds below each price a `types.ts` conditional arm no other
+// kind reaches, and each doubles as a correctness canary (the run fails on any
+// fixture compile error): `permissiveFactory` the un-introspectable
+// `WidenUntypedProps` fallback (#5756); `genericPoly` the `string extends keyof P`
+// OverrideStyle gate that keeps a generic polymorphic target's declared props
+// narrow (#5756); `attrsAsRedirect` the function-form `.attrs` union-target seam
+// that stays on the `ComponentPropsWithRef` branch (NOT the target-unchanged fast
+// path) and is TS2589-sensitive; `disjointTarget` the `keyof B extends never`
+// empty-bag guard a shared-key union never consults (#5787 sibling). Like
+// `unionTarget` they are expensive per component, so each moved the budget on its
+// own -- fixture growth, not a regression.
 const KIND_WEIGHTS = [
   ['plainTag', 8],
   ['wrapComponent', 5],
@@ -113,6 +124,10 @@ const KIND_WEIGHTS = [
   ['attrsWrap', 1],
   ['genericWrapper', 1],
   ['unionTarget', 1],
+  ['permissiveFactory', 1],
+  ['genericPoly', 1],
+  ['attrsAsRedirect', 1],
+  ['disjointTarget', 1],
 ];
 const PER_FILE = KIND_WEIGHTS.reduce((sum, [, weight]) => sum + weight, 0);
 
@@ -149,6 +164,41 @@ type PressableProps =
 const Pressable = (_props: PressableProps) => null;
 
 const spreadProps = { className: 'x', id: 'y' };
+
+// Un-introspectable polymorphic-factory target (Mantine v7 shape). Its generic
+// callable signature makes React.ComponentPropsWithRef resolve to {}, so styled()
+// routes it through the permissive WidenUntypedProps fallback. Verified against
+// @mantine/core@7 in test/types.tsx.
+type FactoryProps<C, P = {}> = C extends React.ElementType
+  ? (Omit<React.ComponentProps<C>, keyof P> & P & { component?: C }) & { ref?: any }
+  : P & { component: React.ElementType };
+interface FactoryOwnProps {
+  variant?: string;
+  children?: React.ReactNode;
+}
+type PolymorphicFactory = (<C = 'button'>(
+  props: FactoryProps<C, FactoryOwnProps>
+) => React.ReactElement) &
+  Omit<React.FunctionComponent<FactoryProps<any, FactoryOwnProps>>, never> & {
+    extend: (p: any) => any;
+  };
+declare const Factory: PolymorphicFactory;
+
+// Generic polymorphic component (#5756). Introspecting it at the ElementType
+// constraint yields an index-signature bag alongside its narrow props; the
+// OverrideStyle string-index gate keeps \`variant\` narrow through styled().
+type PolyProps<C extends React.ElementType, P = object> = React.PropsWithChildren<P & { as?: C }> &
+  Omit<React.ComponentPropsWithoutRef<C>, keyof (P & { as?: C })>;
+interface GenericPolyOwnProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+const GenericPoly = <C extends React.ElementType = 'button'>(_p: PolyProps<C, GenericPolyOwnProps>) =>
+  null;
+
+// Disjoint (no-shared-keys) union target (#5787 sibling). Routes through the
+// \`keyof B extends never\` empty-bag guard in Substitute/MergeProps that a
+// shared-key union never reaches.
+const Disjoint = (_p: { onlyA: string } | { onlyB: number }) => null;
 `;
 
 function unit(i) {
@@ -202,6 +252,30 @@ function unit(i) {
   padding: \${p => p.$a${i} ?? 0}px;
 \`;`;
       break;
+    case 'permissiveFactory':
+      decl = `const ${N} = styled(Factory)<{ $a${i}?: number }>\`
+  color: \${p => (p.$a${i} ? 'red' : 'blue')};
+\`;`;
+      break;
+    case 'genericPoly':
+      decl = `const ${N} = styled(GenericPoly)<{ $a${i}?: number }>\`
+  color: \${p => (p.$a${i} ? 'red' : 'blue')};
+\`;`;
+      break;
+    case 'attrsAsRedirect':
+      // Function-form `.attrs` that redirects the target: the resolved target
+      // becomes a union, so this stays on the `ComponentPropsWithRef` branch (the
+      // target-unchanged fast path deliberately does not take it) and is the
+      // TS2589-sensitive seam. See docs/type-performance.md.
+      decl = `const ${N} = styled.button.attrs<{ $a${i}?: number }>(({ as }) => ({ as: as || 'button', $a${i}: ${i} }))\`
+  width: \${p => p.$a${i} ?? 0}px;
+\`;`;
+      break;
+    case 'disjointTarget':
+      decl = `const ${N} = styled(Disjoint)<{ $a${i}?: number }>\`
+  color: \${p => (p.$a${i} ? 'red' : 'blue')};
+\`;`;
+      break;
     default:
       // Generic wrapper: the shape behind #4246/#1803, where a styled component
       // is consumed through a caller's own type parameter.
@@ -214,20 +288,39 @@ function ${N}<T extends BaseProps>({ item, ...rest }: { item: T } & React.Compon
       break;
   }
 
-  const generic = kind === 'genericWrapper';
-  const sites = generic
-    ? [`<${N} item={{ label: 'l' }} />`, `<${N} item={{ label: 'l' }} className="x" />`]
-    : [`<${N} />`, `<${N} className="x">{'t'}</${N}>`];
-
-  // A member-specific prop is the whole point of the union fixture: a plain call
-  // site resolves against the shared keys and would price the same either way.
-  if (kind === 'unionTarget') sites.push(`<${N} href="/x" />`);
-
-  if (!generic) {
+  // Kinds whose target does not accept the default `className`/childless sites
+  // (or whose member-specific props are the whole point) get bespoke sites; the
+  // rest share the default two plus the spread/as/style/ref variants below.
+  let sites;
+  if (kind === 'genericWrapper') {
+    sites = [`<${N} item={{ label: 'l' }} />`, `<${N} item={{ label: 'l' }} className="x" />`];
+  } else if (kind === 'disjointTarget') {
+    // A disjoint union's members are required and share no keys, so a childless
+    // or `className` site would not compile: pass each member specifically. This
+    // is what exercises the `keyof B extends never` guard (#5787 sibling).
+    sites = [`<${N} onlyA="x" />`, `<${N} onlyB={1} />`];
+  } else if (kind === 'genericPoly') {
+    sites = [`<${N} variant="primary" />`, `<${N} className="x">{'t'}</${N}>`];
+  } else if (kind === 'permissiveFactory') {
+    // An arbitrary prop is accepted only while the permissive fallback holds.
+    sites = [`<${N} arbitraryProp={${i}} />`, `<${N} className="x">{'t'}</${N}>`];
+  } else {
+    sites = [`<${N} />`, `<${N} className="x">{'t'}</${N}>`];
+    // A member-specific prop is the whole point of the union fixture: a plain
+    // call site resolves against the shared keys and would price the same either way.
+    if (kind === 'unionTarget') sites.push(`<${N} href="/x" />`);
     if (i % 5 === 0) sites.push(`<${N} {...spreadProps} />`);
     if (i % 10 === 0) sites.push(`<${N} as="${AS_TAGS[i % AS_TAGS.length]}" />`);
     if (i % 33 === 0) sites.push(`<${N} as={Other} href="/x" />`);
     if (i % 50 === 0) sites.push(`<${N} forwardedAs="ul" />`);
+    // Price the `style` widening and ref-callback inference from the call-site
+    // direction; no other site passes either. Scoped to `plainTag` (a real
+    // intrinsic tag) so the widened `style` accepts a custom property and the
+    // ref is forwarded, keeping the fixture clean.
+    if (kind === 'plainTag' && i % 7 === 0) {
+      sites.push(`<${N} style={{ color: 'red', '--v': ${i} }} />`);
+    }
+    if (kind === 'plainTag' && i % 11 === 0) sites.push(`<${N} ref={el => { void el; }} />`);
   }
 
   return `${decl}
@@ -254,6 +347,37 @@ const Canary = styled.button<{ $ok?: boolean }>\`\`;
 export const CanaryProp = <Canary notAPropOfButton={1} />;
 // @ts-expect-error 'loop' belongs to video, not to the button this renders as
 export const CanaryAs = <Canary loop />;
+
+// #5756 soundness: the OverrideStyle string-index gate keeps a generic
+// polymorphic target's declared props narrow through styled(), so a valid value
+// compiles and a bad one is rejected. If the gate regresses to accepting the bad
+// value, the directive below goes unused (TS2578) and fails the clean gate.
+type CanaryPolyProps<C extends React.ElementType> = React.PropsWithChildren<{
+  as?: C;
+  variant?: 'a' | 'b';
+}> &
+  Omit<React.ComponentPropsWithoutRef<C>, 'as' | 'variant'>;
+const CanaryPoly = <C extends React.ElementType = 'button'>(_p: CanaryPolyProps<C>) => null;
+const StyledCanaryPoly = styled(CanaryPoly)\`\`;
+export const CanaryPolyOk = <StyledCanaryPoly variant="a" />;
+// @ts-expect-error the gate keeps variant narrow, so a bad value is rejected
+export const CanaryPolyBad = <StyledCanaryPoly variant="fake" />;
+
+// #5756 soundness: an un-introspectable factory target stays permissive, so an
+// arbitrary prop and children are accepted. If the fallback regresses to a closed
+// {}, this must-compile line fails and the clean gate catches it.
+type CanaryFactoryProps<C, P = {}> = C extends React.ElementType
+  ? (Omit<React.ComponentProps<C>, keyof P> & P & { component?: C }) & { ref?: any }
+  : P & { component: React.ElementType };
+type CanaryFactory = (<C = 'button'>(
+  p: CanaryFactoryProps<C, { children?: React.ReactNode }>
+) => React.ReactElement) &
+  Omit<React.FunctionComponent<CanaryFactoryProps<any, { children?: React.ReactNode }>>, never> & {
+    extend: (p: any) => any;
+  };
+declare const canaryFactory: CanaryFactory;
+const StyledCanaryFactory = styled(canaryFactory)\`\`;
+export const CanaryFactoryOk = <StyledCanaryFactory arbitraryProp={1}>{'ok'}</StyledCanaryFactory>;
 
 // Native shares TargetProps with the web entry, so a native-only regression is
 // invisible to a web-only fixture.

--- a/packages/styled-components/src/constructors/constructWithOptions.ts
+++ b/packages/styled-components/src/constructors/constructWithOptions.ts
@@ -86,18 +86,26 @@ export interface Styled<
   ) => Styled<
     R,
     PrivateResolvedTarget,
-    PrivateResolvedTarget extends KnownTarget
-      ? MergeProps<
-          // `MergeProps` keeps the CSS-variable widening `OuterProps` carries,
-          // which substituting the target's unwidened `style` would drop.
-          // `ComponentPropsWithRef` rather than `TargetProps` is the one place
-          // that stays: a function-form `.attrs` makes this target a union, and
-          // `TargetProps` distributing inside that measured as TS2589. Both in
-          // docs/type-performance.md.
-          MergeProps<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-          Props
-        >
-      : PrivateMergedProps,
+    // Target-unchanged fast path: when object-form `.attrs` leaves the target
+    // as-is, `OuterProps` already equals `TargetProps<R, Target>`, so re-merging
+    // `ComponentPropsWithRef<Target>` only rebuilds the ~265-key intrinsic bag
+    // the #5767 indexed access avoids. `MergeProps<OuterProps, Props>` is the
+    // same result. The bracket keeps a function-form `.attrs` (union target) off
+    // this branch, preserving its TS2589-avoidance; see docs/type-performance.md.
+    [PrivateResolvedTarget] extends [Target]
+      ? PrivateMergedProps
+      : PrivateResolvedTarget extends KnownTarget
+        ? MergeProps<
+            // `MergeProps` keeps the CSS-variable widening `OuterProps` carries,
+            // which substituting the target's unwidened `style` would drop.
+            // `ComponentPropsWithRef` rather than `TargetProps` is the one place
+            // that stays: a function-form `.attrs` makes this target a union, and
+            // `TargetProps` distributing inside that measured as TS2589. Both in
+            // docs/type-performance.md.
+            MergeProps<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
+            Props
+          >
+        : PrivateMergedProps,
     OuterStatics,
     AttrsKeys | keyof AttrsResult<PrivateAttrsArg>
   >;
@@ -159,12 +167,21 @@ export default function constructWithOptions<
     constructWithOptions<
       R,
       PrivateResolvedTarget,
-      PrivateResolvedTarget extends KnownTarget
-        ? MergeProps<
-            MergeProps<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
-            Props
-          >
-        : PrivateMergedProps,
+      // Target-unchanged fast path: object-form `.attrs` leaves the target as-is
+      // (`AttrsTarget` returns `Target`), so `OuterProps` already carries the
+      // target's props (`TargetProps<R, Target>`) and re-resolving them through
+      // `ComponentPropsWithRef` only rebuilds the ~265-key intrinsic bag the
+      // #5767 indexed access was written to avoid. The bracket keeps a
+      // function-form `.attrs` (resolved target is a union) off this branch so it
+      // does not distribute here; see docs/type-performance.md.
+      [PrivateResolvedTarget] extends [Target]
+        ? PrivateMergedProps
+        : PrivateResolvedTarget extends KnownTarget
+          ? MergeProps<
+              MergeProps<OuterProps, React.ComponentPropsWithRef<PrivateResolvedTarget>>,
+              Props
+            >
+          : PrivateMergedProps,
       OuterStatics,
       AttrsKeys | keyof AttrsResult<PrivateAttrsArg>
     >(componentConstructor, tag, {

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -1052,12 +1052,13 @@ const BareRefWrapper = styled.div``;
 />;
 
 /**
- * #5756 (kkwasny-rtbh) -- BASELINE-PIN. A generic polymorphic component's props
- * collapse to `{}` under introspection, so the styled wrapper accepts a prop
- * value the direct call site rejects. #5758 documents this as unavoidable: with
- * no base type to substitute against, the prop bag must stay permissive. The
- * direct call below is the positive control -- if it ever stops erroring, its
- * unused directive fires and the pin has moved.
+ * #5756 (kkwasny-rtbh). A generic polymorphic component introspects at its
+ * `ElementType` constraint, where `React.ComponentProps<ElementType>` is `any`,
+ * so the extracted bag gains a `[k: string]: any` index signature alongside its
+ * narrow props. `OverrideStyle` declines to widen a bag carrying that index
+ * (types.ts), which keeps the narrow props intact, so the styled wrapper rejects
+ * a bad `variant` exactly as the direct call does. Both directives below are
+ * positive controls: the direct call and the wrapped call must each reject.
  */
 type GenericAsProp<C extends React.ElementType> = { as?: C };
 type GenericPolyProps<C extends React.ElementType, P = object> = React.PropsWithChildren<
@@ -1073,8 +1074,10 @@ const GenericPolyButton = <C extends React.ElementType = 'button'>(
 // @ts-expect-error the direct call site narrows `variant` and rejects this
 <GenericPolyButton variant="totally-fake">x</GenericPolyButton>;
 const StyledGenericPolyButton = styled(GenericPolyButton)``;
-// Pinned: accepted today, because the target carries no introspectable props.
+// @ts-expect-error the wrapper keeps `variant` narrow too and rejects this (#5756)
 <StyledGenericPolyButton variant="totally-fake">x</StyledGenericPolyButton>;
+// a valid variant and children still compile
+<StyledGenericPolyButton variant="primary">x</StyledGenericPolyButton>;
 
 /**
  * #5760: the destructured parameter of `styled.<tag>(fn)` must keep its declared

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -427,7 +427,23 @@ export interface IInlineStyle<Props extends BaseObject> {
 
 export type CSSProperties = CSS.Properties<number | (string & {})>;
 
-export type CSSPropertiesWithVars = CSSProperties & {
+/**
+ * The widened inline `style` prop: every CSS property plus CSS custom properties.
+ *
+ * The base is `React.CSSProperties`, not the library's {@link CSSProperties}
+ * (`CSS.Properties<number | (string & {})>`), on purpose. The two are different
+ * csstype instantiations, and the `style` a consumer hand-writes in a declaration
+ * annotation (`IStyledComponentBase<'web', … & { style?: React.CSSProperties }>`)
+ * is React's. Sharing React's interface lets that assignability check take the
+ * intersection-member fast path (`React.CSSProperties & Vars` relates to
+ * `React.CSSProperties` without walking csstype) instead of relating two csstype
+ * instantiations member by member, once per component -- the declaration-site cost
+ * in docs/type-performance.md. Rebase only this cached base; do NOT also reshape
+ * {@link WithCSSVars}, which regresses instantiations (measured there). Object
+ * styles keep the richer numeric base via {@link CSSProperties}; only the inline
+ * `style` prop widens off React's.
+ */
+export type CSSPropertiesWithVars = React.CSSProperties & {
   [key: `--${string}`]: string | number | undefined;
 };
 
@@ -490,11 +506,28 @@ type WithCSSVars<P extends BaseObject> = Omit<P, 'style'> & {
  * shared keys alone and drops every member-specific prop -- a component typed
  * `ButtonProps | AnchorProps` stops accepting `href`. Widening member by member
  * keeps the union intact.
+ *
+ * `string extends keyof P` gates out a prop bag carrying a string index signature
+ * (`[k: string]: any`), returning it untouched. A generic polymorphic component
+ * (`<C extends ElementType>(p: PropsWithChildren<P & { as?: C }> & ComponentProps<C>)`)
+ * introspects at the `ElementType` constraint, where `ComponentProps<ElementType>`
+ * is `any`, so its extracted bag gains that index. {@link WithCSSVars}' `Omit`
+ * (`Pick<P, Exclude<keyof P, 'style'>>`) would then collapse every narrow named
+ * prop into the index -- `keyof P` is `string`, `Exclude<string, 'style'>` is
+ * still `string` -- widening a declared `variant: 'a' | 'b'` to `any` and letting
+ * `styled(Button)` accept props the component itself rejects (#5756). Declining to
+ * widen such a bag keeps the narrow props; the only thing given up is
+ * custom-property widening on a `style` that is already `any`, which is moot. A
+ * key-preserving `FastOmit` here would instead cost ~+11% instantiations (the
+ * homomorphic-mapped-type price the intrinsic path avoids); see
+ * docs/type-performance.md.
  */
 type OverrideStyle<P extends BaseObject> = P extends unknown
-  ? 'style' extends keyof P
-    ? WithCSSVars<P>
-    : P
+  ? string extends keyof P
+    ? P
+    : 'style' extends keyof P
+      ? WithCSSVars<P>
+      : P
   : never;
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject };

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -648,9 +648,21 @@ export type Merged<A extends BaseObject, B> = FastOmit<A, Exclude<keyof B, 'styl
  * old spelling never short-circuited. Every such component paid an omit plus a
  * `Partial<Pick<...>>` that removed and re-added nothing, and carried both in its
  * displayed type.
+ *
+ * The taken branch distributes over `P` with built-in `Omit`, not `FastOmit`.
+ * This mapped pass over the ~266-key widened intrinsic bag is the largest single
+ * cost of `.attrs` on a tag (measured ~30% of that kind's types); built-in `Omit`
+ * (Pick + Exclude) is more optimized than `FastOmit` here, the same result the
+ * `OverrideStyle` note records. The distribution is load-bearing: a bare
+ * `Omit<A | B, K>` reads `keyof` as the union's *common* keys and collapses a
+ * union-props target (`styled(Pressable).attrs(...)` drops `href`), so the outer
+ * `P extends unknown` runs the omit per member and keeps the union intact. Do NOT
+ * spell it `FastOmit` (slower) or a bare undistributed `Omit` (unsound).
  */
 export type MakeAttrsOptional<P extends BaseObject, K extends keyof any> = [K] extends [never]
   ? P
-  : FastOmit<P, K & keyof P> & Partial<Pick<P, K & keyof P>>;
+  : P extends unknown
+    ? Omit<P, K & keyof P> & Partial<Pick<P, K & keyof P>>
+    : never;
 
 export type InsertionTarget = HTMLElement | ShadowRoot;

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,9 +1,9 @@
 {
   "count": 100,
   "measured": {
-    "instantiations": 936809,
-    "memoryKb": 197097,
-    "types": 34797
+    "instantiations": 926001,
+    "memoryKb": 207173,
+    "types": 42528
   },
   "tolerancePct": {
     "instantiations": 10,

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,9 +1,9 @@
 {
   "count": 100,
   "measured": {
-    "instantiations": 926001,
-    "memoryKb": 207173,
-    "types": 42528
+    "instantiations": 888000,
+    "memoryKb": 205788,
+    "types": 39346
   },
   "tolerancePct": {
     "instantiations": 10,

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,9 +1,9 @@
 {
   "count": 100,
   "measured": {
-    "instantiations": 850743,
-    "memoryKb": 197127,
-    "types": 30449
+    "instantiations": 936809,
+    "memoryKb": 197097,
+    "types": 34797
   },
   "tolerancePct": {
     "instantiations": 10,


### PR DESCRIPTION
Type-only work on the 6.x type surface: two consumer-facing fixes, `.attrs` type-check speedups, and broadened perf coverage. No runtime change; the consumer type-perf budget and the web + native type-test suites stay green.

## 1. Explicitly annotated styled components type-check faster

Assigning a styled component to an explicit type, as `isolatedDeclarations` and any package that emits `.d.ts` files must (`const Button: IStyledComponentBase<'web', ...> = styled.button\`\``), used to cost several times more to check than an inferred one: the annotation's `style` and the component's widened `style` were two different csstype representations compared property by property. The inline `style` widening now builds on React's own `CSSProperties`, the same type a hand-written annotation carries, so the comparison short-circuits (~21% fewer types created for that pattern on a 40-component fixture), with no change to what `style` accepts. Adds a declaration-site (`annotated`) kind to the type-perf fixture so the axis is guarded.

## 2. `styled()` on a generic polymorphic component keeps its props narrow (#5756)

Wrapping a component whose props are generic over an element type (`<C extends React.ElementType>(props: PolymorphicProps<C, OwnProps>)`) used to let the styled result accept prop values the component itself rejects: `styled(Button)` would take `variant="anything"` even though `<Button variant="anything">` is a type error. Introspecting such a component resolves props at the `React.ElementType` constraint, where the bag picks up a `[key: string]: any` index signature; the style widening's `Omit` then collapsed the declared narrow props into that index. The widening now leaves an index-signature bag untouched, so the narrow props survive and a bad value is caught in the wrapper too. Valid props, children, and plain targets are unaffected.

## 3. `.attrs()` is cheaper to type-check

Two costs on the `.attrs` path are removed. Object-form `.attrs()` leaves the rendered target unchanged but still re-resolved that target's whole prop bag on every call, so `.attrs` on an HTML/SVG tag cost far more than on a wrapped component; it now reuses the props already resolved for the tag. And making attrs-provided keys optional ran an avoidably expensive mapped pass over the target's full prop set; switching that to a distributed built-in `Omit` cuts it further while keeping a union-props attrs target's member-specific props intact. Net on the consumer fixture: about 4% fewer instantiations and 7.5% fewer types created versus the start of this PR, with every `.attrs` form (object, function, `as`-redirect, chained) behaving identically.

## Broadened perf coverage (no runtime effect)

The type-perf fixture gained four exotic kinds, each pricing a distinct type-system code path and each doubling as a compile-fail canary: an un-introspectable polymorphic-factory target, a generic polymorphic target (guards fix #2), a function-form `.attrs` target redirect, and a no-shared-keys union target. Plus `style`/`ref` call-site variants and canary pins for the #5756 soundness properties. Each is a changeset-free fixture change; the budget was re-measured.