### PR TITLE
fix: support template index signatures

### DIFF
--- a/.changeset/fuzzy-ravens-smile.md
+++ b/.changeset/fuzzy-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+'styled-components': patch
+---
+
+Fix TypeScript errors in projects that augment React HTML props with a `data-*` template-literal index signature.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
       # Guards consumer type-check cost against the built .d.ts. Regressions here
       # are invisible to the unit and type-contract suites (see #5767).
       - run: pnpm --filter styled-components type-perf
+      # The `data-*`-augmented path has its own cost and budget (see #5796).
+      - run: pnpm --filter styled-components type-perf:augment
   test:
     runs-on: ubuntu-latest
     steps:

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -25,6 +25,7 @@
     "test": "pnpm run test:web && pnpm run test:native && pnpm run test:types",
     "test:types": "tsc --noEmit --project tsconfig.test-types.json && tsc --noEmit --project tsconfig.test-template-index.json",
     "type-perf": "node scripts/typePerf.mjs",
+    "type-perf:augment": "node scripts/typePerf.mjs --augment",
     "test:web": "jest -c jest.config.main.js",
     "test:native": "jest -c jest.config.native.js --forceExit",
     "bench": "pnpm run bench:web && pnpm run bench:native && pnpm run bench:rsc",

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -23,7 +23,7 @@
     "test:build": "jest -c jest.config.build.js",
     "pretest": "pnpm run generateErrors",
     "test": "pnpm run test:web && pnpm run test:native && pnpm run test:types",
-    "test:types": "tsc --noEmit --project tsconfig.test-types.json",
+    "test:types": "tsc --noEmit --project tsconfig.test-types.json && tsc --noEmit --project tsconfig.test-template-index.json",
     "type-perf": "node scripts/typePerf.mjs",
     "test:web": "jest -c jest.config.main.js",
     "test:native": "jest -c jest.config.native.js --forceExit",

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -14,11 +14,26 @@
  *   node scripts/typePerf.mjs            check against the budget
  *   node scripts/typePerf.mjs --update   rewrite the budget from this run
  *   node scripts/typePerf.mjs --count 500
+ *   node scripts/typePerf.mjs --augment  measure the `data-*`-augmented path
+ *
+ * `--augment` injects the `data-${string}` template-literal index signature onto
+ * `HTMLAttributes` that large apps add for arbitrary data attributes. That routes
+ * every intrinsic element through a distinct `style` widening (#5796), a cost the
+ * default fixture never exercises. It checks against its own budget file, so the
+ * two paths are guarded independently.
  *
  * Requires `pnpm build` first.
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,7 +42,6 @@ import { parseArgs } from 'node:util';
 const require = createRequire(import.meta.url);
 const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workDir = join(pkgRoot, '.type-perf');
-const budgetFile = join(pkgRoot, 'type-perf.budget.json');
 
 // parseArgs over hand-rolled indexOf: it accepts `--count=500` as well as
 // `--count 500`, and throws on an unknown flag or a valueless one instead of
@@ -36,7 +50,11 @@ const budgetFile = join(pkgRoot, 'type-perf.budget.json');
 let parsed;
 try {
   parsed = parseArgs({
-    options: { count: { type: 'string', default: '100' }, update: { type: 'boolean' } },
+    options: {
+      augment: { type: 'boolean' },
+      count: { type: 'string', default: '100' },
+      update: { type: 'boolean' },
+    },
     strict: true,
   });
 } catch (error) {
@@ -45,11 +63,20 @@ try {
 }
 
 const update = parsed.values.update === true;
+const augment = parsed.values.augment === true;
 const count = Number(parsed.values.count);
 if (!Number.isInteger(count) || count < 1) {
   console.error(`type-perf: --count needs a positive integer, got ${parsed.values.count}`);
   process.exit(1);
 }
+
+// The augmented and default paths have different costs and different baselines,
+// so they keep separate budget files; one run never clobbers the other.
+const budgetFile = join(
+  pkgRoot,
+  augment ? 'type-perf.augment.budget.json' : 'type-perf.budget.json'
+);
+const updateHint = augment ? '--augment --update' : '--update';
 
 const distEntry = join(pkgRoot, 'dist', 'index.d.ts');
 if (!existsSync(distEntry)) {
@@ -63,7 +90,10 @@ if (!existsSync(distEntry)) {
 // `test/` never reaches dist, and `utils/errors.ts` is generated -- the test run
 // rewrites it, so counting either would report a stale dist after every
 // `pnpm test` and train everyone to ignore the warning.
-const IGNORED_SOURCES = new Set([join(pkgRoot, 'src', 'test'), join(pkgRoot, 'src', 'utils', 'errors.ts')]);
+const IGNORED_SOURCES = new Set([
+  join(pkgRoot, 'src', 'test'),
+  join(pkgRoot, 'src', 'utils', 'errors.ts'),
+]);
 
 const newestSource = (function newest(dir) {
   let latest = 0;
@@ -387,6 +417,18 @@ export const CanaryNative = <NativeCanary notAPropOfView={1} />;
 export const NativeOk = <NativeCanary testID="ok" />;
 `;
 
+// The `data-*` template-literal augmentation from #5796. A separate module (an
+// `import` makes it one) so the `declare module` merges into every fixture file
+// without editing the shared HEADER. Only written under `--augment`.
+const AUGMENT = `import 'react';
+
+declare module 'react' {
+  interface HTMLAttributes<T> {
+    [dataAttribute: \`data-\${string}\`]: string | undefined;
+  }
+}
+`;
+
 rmSync(workDir, { recursive: true, force: true });
 mkdirSync(join(workDir, 'src'), { recursive: true });
 
@@ -396,6 +438,7 @@ for (let start = 0, f = 0; start < count; start += PER_FILE, f++) {
   writeFileSync(join(workDir, 'src', `mod${f}.tsx`), `${HEADER}\n${body.join('\n')}`);
 }
 writeFileSync(join(workDir, 'src', 'canary.tsx'), CANARY);
+if (augment) writeFileSync(join(workDir, 'src', '_augment.d.ts'), AUGMENT);
 
 writeFileSync(
   join(workDir, 'tsconfig.json'),
@@ -484,7 +527,10 @@ const versions = {
   typesReact: require('@types/react/package.json').version,
 };
 
-console.log(`type-perf: ${count} components, TypeScript ${versions.typescript}, @types/react ${versions.typesReact}`);
+console.log(
+  `type-perf${augment ? ' (augmented)' : ''}: ${count} components, ` +
+    `TypeScript ${versions.typescript}, @types/react ${versions.typesReact}`
+);
 console.log(`  types:          ${measured.types.toLocaleString()}`);
 console.log(`  instantiations: ${measured.instantiations.toLocaleString()}`);
 console.log(`  memory:         ${Math.round(measured.memoryKb / 1024).toLocaleString()} MB`);
@@ -505,9 +551,14 @@ if (update) {
   process.exit(0);
 }
 
+if (!existsSync(budgetFile)) {
+  console.error(`type-perf: ${budgetFile} does not exist -- run with ${updateHint} to create it.`);
+  process.exit(1);
+}
+
 const budget = JSON.parse(readFileSync(budgetFile, 'utf8'));
 if (!budget.measured || !budget.tolerancePct) {
-  console.error(`type-perf: ${budgetFile} is not in the expected shape -- run with --update.`);
+  console.error(`type-perf: ${budgetFile} is not in the expected shape -- run with ${updateHint}.`);
   process.exit(1);
 }
 
@@ -517,7 +568,9 @@ if (!budget.measured || !budget.tolerancePct) {
 // to enforce. Any budget written before a metric existed has exactly this shape.
 for (const metric of Object.keys(TOLERANCE_PCT)) {
   if (!Number.isFinite(budget.measured[metric]) || !Number.isFinite(budget.tolerancePct[metric])) {
-    console.error(`type-perf: budget is missing '${metric}' -- run with --update to re-measure.`);
+    console.error(
+      `type-perf: budget is missing '${metric}' -- run with ${updateHint} to re-measure.`
+    );
     process.exit(1);
   }
 }
@@ -558,7 +611,7 @@ if (over.length > 0) {
   }
   console.error(
     'Consumer type-check cost grew. Find the cause before raising the budget; ' +
-      'run with --update only when the increase is understood and intended.'
+      `run with ${updateHint} only when the increase is understood and intended.`
   );
   process.exit(1);
 }
@@ -566,7 +619,7 @@ if (over.length > 0) {
 for (const [label, actual, baseline] of under) {
   console.log(
     `type-perf: ${label} improved ${Math.round((1 - actual / baseline) * 100)}% ` +
-      `(${baseline.toLocaleString()} -> ${actual.toLocaleString()}); run --update to bank it`
+      `(${baseline.toLocaleString()} -> ${actual.toLocaleString()}); run ${updateHint} to bank it`
   );
 }
 

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -223,12 +223,26 @@ export type TargetProps<R extends Runtime, T> = T extends keyof React.JSX.Intrin
  * instead of the full expansion of every tag attribute. See {@link WithCSSVars}
  * for why a conditional's inline branch cannot keep a name.
  *
- * Applies the widening directly rather than through {@link OverrideStyle}: every
- * intrinsic element declares `style`, so the guard has nothing to decide here.
+ * Applies the widening directly unless the props carry a `data-*` index
+ * signature. Running `Omit` over that template-literal key for every intrinsic
+ * element exceeds TypeScript's union complexity limit (#5796).
  */
-type IntrinsicProps<T extends keyof React.JSX.IntrinsicElements> = WithCSSVars<
-  React.JSX.IntrinsicElements[T]
->;
+type IntrinsicElementsHaveDataIndex =
+  keyof DataAttributes extends keyof React.JSX.IntrinsicElements['div'] ? true : false;
+
+/**
+ * Preserves custom-property support without mapping over a template-literal key.
+ * The intersection is confined to the augmented fallback; using it for every
+ * intrinsic element regresses the normal declaration-site relation.
+ */
+type WithCSSVarsForDataIndex<P extends BaseObject> = P & {
+  style?: CSSPropertiesWithVars | undefined;
+};
+
+type IntrinsicProps<T extends keyof React.JSX.IntrinsicElements> =
+  IntrinsicElementsHaveDataIndex extends true
+    ? WithCSSVarsForDataIndex<React.JSX.IntrinsicElements[T]>
+    : WithCSSVars<React.JSX.IntrinsicElements[T]>;
 
 /**
  * Props of a component render target. Named for the same reason as {@link IntrinsicProps}.

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -216,6 +216,36 @@ export type TargetProps<R extends Runtime, T> = T extends keyof React.JSX.Intrin
     : {};
 
 /**
+ * True when an application has augmented `React.HTMLAttributes` with a `data-*`
+ * template-literal index signature, the common pattern for allowing arbitrary
+ * data attributes. Detected by testing whether {@link DataAttributes}' key is
+ * already a key of a stock intrinsic element.
+ *
+ * Scope is exactly `data-${string}`: an `aria-${string}` or other custom-prefix
+ * template augmentation is not detected and still hits the {@link WithCSSVars}
+ * path (#5796). `data-*` is the dominant augmentation, so the narrow probe buys
+ * the common case; widening it means OR-ing another literal prefix in here.
+ */
+type IntrinsicElementsHaveDataIndex =
+  keyof DataAttributes extends keyof React.JSX.IntrinsicElements['div'] ? true : false;
+
+/**
+ * {@link WithCSSVars} for the augmented intrinsic path. Identical widening, but
+ * filters `style` with {@link FastOmit}'s mapped-type `as` clause instead of the
+ * built-in `Omit`. `Omit<P, 'style'>` is `Pick<P, Exclude<keyof P, 'style'>>`,
+ * and distributing that `Exclude` over a template-literal key across every
+ * intrinsic element exceeds TypeScript's union complexity limit (#5796);
+ * `FastOmit` drops the key without the distribution.
+ *
+ * Kept off the normal path: `FastOmit` costs materially more instantiations at
+ * that scale, and the union `style` member (mirroring {@link WithCSSVars}) is
+ * what preserves the declaration-site relation a plain intersection regresses.
+ */
+type WithCSSVarsForDataIndex<P extends BaseObject> = FastOmit<P, 'style'> & {
+  style?: CSSPropertiesWithVars | (P[keyof P & 'style'] & {}) | undefined;
+};
+
+/**
  * Props of an HTML or SVG tag.
  *
  * Both branches of {@link TargetProps} are named rather than inlined, so a
@@ -223,22 +253,11 @@ export type TargetProps<R extends Runtime, T> = T extends keyof React.JSX.Intrin
  * instead of the full expansion of every tag attribute. See {@link WithCSSVars}
  * for why a conditional's inline branch cannot keep a name.
  *
- * Applies the widening directly unless the props carry a `data-*` index
- * signature. Running `Omit` over that template-literal key for every intrinsic
- * element exceeds TypeScript's union complexity limit (#5796).
+ * Applies {@link WithCSSVars} directly except under a `data-*` augmentation,
+ * where {@link WithCSSVarsForDataIndex} avoids the `Omit` that would blow the
+ * union complexity limit. The probe is a global constant, so the common path is
+ * untouched.
  */
-type IntrinsicElementsHaveDataIndex =
-  keyof DataAttributes extends keyof React.JSX.IntrinsicElements['div'] ? true : false;
-
-/**
- * Preserves custom-property support without mapping over a template-literal key.
- * The intersection is confined to the augmented fallback; using it for every
- * intrinsic element regresses the normal declaration-site relation.
- */
-type WithCSSVarsForDataIndex<P extends BaseObject> = P & {
-  style?: CSSPropertiesWithVars | undefined;
-};
-
 type IntrinsicProps<T extends keyof React.JSX.IntrinsicElements> =
   IntrinsicElementsHaveDataIndex extends true
     ? WithCSSVarsForDataIndex<React.JSX.IntrinsicElements[T]>

--- a/packages/styled-components/test-types/template-index-signature.tsx
+++ b/packages/styled-components/test-types/template-index-signature.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from '../src';
+
+declare module 'react' {
+  interface HTMLAttributes<T> {
+    [dataAttribute: `data-${string}`]: string | undefined;
+  }
+}
+
+const Example = styled.div``;
+
+<Example data-role="test" style={{ '--accent': 'tomato' }} />;
+
+// @ts-expect-error data attribute values retain the augmented string type
+const invalidAttrs: React.HTMLAttributes<HTMLDivElement> = { 'data-role': 42 };

--- a/packages/styled-components/test-types/template-index-signature.tsx
+++ b/packages/styled-components/test-types/template-index-signature.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styled from '../src';
+import styled, { IStyledComponent } from '../src';
+import { FastOmit } from '../src/types';
 
 declare module 'react' {
   interface HTMLAttributes<T> {
@@ -13,3 +14,33 @@ const Example = styled.div``;
 
 // @ts-expect-error data attribute values retain the augmented string type
 const invalidAttrs: React.HTMLAttributes<HTMLDivElement> = { 'data-role': 42 };
+
+/**
+ * Conditionally selecting between two styled components produced TS2590 at the
+ * JSX call site even with `skipLibCheck` on (#5796): the union of the two
+ * component types re-ran the widening the declaration escaped. Rendering the
+ * picked component must type-check.
+ */
+const Tiny = styled.div``;
+const Wide = styled.div``;
+
+const Conditional = ({ tiny }: { tiny: boolean }) => {
+  const Wrapper = tiny ? Tiny : Wide;
+  return <Wrapper data-role="conditional" style={{ '--accent': 'tomato' }} />;
+};
+
+<Conditional tiny />;
+
+/**
+ * The augmented intrinsic widening must keep an explicit declaration-site
+ * annotation relatable. An intersection that requires the custom-property index
+ * on `style` breaks assignment from a `styled.div` whose annotated bag carries
+ * plain `CSSProperties`; the union widening preserves it (#5796).
+ */
+type DivProps = React.JSX.IntrinsicElements['div'];
+
+const Annotated: IStyledComponent<'web', FastOmit<DivProps, never> & { $a?: number }> = styled.div<{
+  $a?: number;
+}>``;
+
+void Annotated;

--- a/packages/styled-components/tsconfig.test-template-index.json
+++ b/packages/styled-components/tsconfig.test-template-index.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false,
+    "noUnusedLocals": false,
+    "skipLibCheck": true
+  },
+  "include": ["test-types/template-index-signature.tsx"]
+}

--- a/packages/styled-components/type-perf.augment.budget.json
+++ b/packages/styled-components/type-perf.augment.budget.json
@@ -1,0 +1,17 @@
+{
+  "count": 100,
+  "measured": {
+    "instantiations": 965491,
+    "memoryKb": 206495,
+    "types": 39584
+  },
+  "tolerancePct": {
+    "instantiations": 10,
+    "memoryKb": 12,
+    "types": 10
+  },
+  "versions": {
+    "typescript": "5.9.3",
+    "typesReact": "18.3.28"
+  }
+}


### PR DESCRIPTION
## Summary

Fix TypeScript's `TS2590` error when applications extend React HTML props with a `data-*` template-literal index signature. Styled intrinsic elements continue to accept the augmented data attributes and CSS custom properties.

Fixes #5796

## Testing

- `pnpm --filter styled-components test:types`
- `pnpm build`
- `pnpm --filter styled-components type-perf`
- `pnpm test`
- `pnpm --filter styled-components prettier`
- `git diff --check`

An AI coding assistant helped investigate the type regression and prepare the patch. I reviewed the resulting diff and verification output.