### PR TITLE
feat(types): add StyledComponent for explicit export annotations

### DIFF
--- a/.changeset/public-styled-component-annotation.md
+++ b/.changeset/public-styled-component-annotation.md
@@ -4,9 +4,9 @@
 
 Added a `StyledComponent<Target, Props>` type for annotating explicitly-typed styled component exports.
 
-Packages that emit their own declaration files, including any project using TypeScript's `isolatedDeclarations`, must give every exported styled component a written type annotation, because inference alone does not survive declaration emit. There was no public type for this, so consumers reached into internal paths (`styled-components/dist/types`) or hand-assembled an approximation that quietly dropped members such as a wrapped component's hoisted statics.
+Packages that emit their own declaration files, including any project using `isolatedDeclarations`, must annotate every exported styled component, and there was no public type for it: consumers reached into internal paths or hand-assembled one that dropped members like a wrapped component's hoisted statics.
 
-`StyledComponent` is now exported from both the web and React Native entries. You write it by naming the target and props exactly as you passed them to `styled`:
+`StyledComponent` is exported from the web and native entries. Name the target and props as you passed them to `styled`:
 
 ```tsx
 import styled, { type StyledComponent } from 'styled-components';
@@ -15,4 +15,4 @@ export const Card: StyledComponent<'div', { $active?: boolean }> = styled.div<{ 
 export const CloseButton: StyledComponent<typeof IconButton> = styled(IconButton)`...`;
 ```
 
-It resolves to the exact type `styled(Target)<Props>` produces, so the annotation is not lossy and the check against the inferred component stays cheap.
+It resolves to the exact type `styled(Target)<Props>` produces, so the annotation is not lossy.

--- a/.changeset/public-styled-component-annotation.md
+++ b/.changeset/public-styled-component-annotation.md
@@ -1,0 +1,18 @@
+---
+"styled-components": minor
+---
+
+Added a `StyledComponent<Target, Props>` type for annotating explicitly-typed styled component exports.
+
+Packages that emit their own declaration files, including any project using TypeScript's `isolatedDeclarations`, must give every exported styled component a written type annotation, because inference alone does not survive declaration emit. There was no public type for this, so consumers reached into internal paths (`styled-components/dist/types`) or hand-assembled an approximation that quietly dropped members such as a wrapped component's hoisted statics.
+
+`StyledComponent` is now exported from both the web and React Native entries. You write it by naming the target and props exactly as you passed them to `styled`:
+
+```tsx
+import styled, { type StyledComponent } from 'styled-components';
+
+export const Card: StyledComponent<'div', { $active?: boolean }> = styled.div<{ $active?: boolean }>`...`;
+export const CloseButton: StyledComponent<typeof IconButton> = styled(IconButton)`...`;
+```
+
+It resolves to the exact type `styled(Target)<Props>` produces, so the annotation is not lossy and the check against the inferred component stays cheap.

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -48,14 +48,11 @@ that deepened that relation would move nothing here. Like `unionTarget` it is ex
 so it too moved the recorded budget on its own -- fixture growth, not a regression.
 
 Three `annotatedPublic*` kinds price the same declaration site with the public `StyledComponent<Target,
-Props>` alias in place of the hand-written bag, the annotation isolatedDeclarations consumers are told to
-write. They cover the alias's three structurally-distinct construction arms: `annotatedPublic` an
-intrinsic tag, `annotatedPublicWrap` the hoisted-statics intersection a wrapped component adds, and
-`annotatedPublicFactory` the `WidenForUntypedTarget` arm an un-introspectable target takes. `StyledComponent`
-resolves to the exact shape the constructor emits, so the relation stays identity-cheap; a change to it,
-`MergeProps`, `TargetProps`, or `WidenForUntypedTarget` that reintroduced a divergent bag would regress
-these and nothing else. Each is expensive per component like `annotated`, so each moved the budget on its
-own -- fixture growth, not a regression.
+Props>` alias in place of the hand-written bag. They cover its distinct construction arms so a change to
+`StyledComponent`, `MergeProps`, `TargetProps`, or `WidenForUntypedTarget` that reintroduced a divergent
+bag would regress them: `annotatedPublic` an intrinsic tag, `annotatedPublicWrap` the hoisted-statics
+intersection, `annotatedPublicFactory` the `WidenForUntypedTarget` arm. Each is expensive per component,
+so each moved the budget on its own -- fixture growth, not a regression.
 
 Four exotic kinds each price a `types.ts` conditional arm no other kind reaches, and each also fails the
 clean-compile gate if its mechanism regresses, so they are correctness canaries sitting inside the perf

--- a/docs/type-performance.md
+++ b/docs/type-performance.md
@@ -47,6 +47,16 @@ bag is hand-written instead of the shape the library computes. This is what isol
 that deepened that relation would move nothing here. Like `unionTarget` it is expensive per component,
 so it too moved the recorded budget on its own -- fixture growth, not a regression.
 
+Three `annotatedPublic*` kinds price the same declaration site with the public `StyledComponent<Target,
+Props>` alias in place of the hand-written bag, the annotation isolatedDeclarations consumers are told to
+write. They cover the alias's three structurally-distinct construction arms: `annotatedPublic` an
+intrinsic tag, `annotatedPublicWrap` the hoisted-statics intersection a wrapped component adds, and
+`annotatedPublicFactory` the `WidenForUntypedTarget` arm an un-introspectable target takes. `StyledComponent`
+resolves to the exact shape the constructor emits, so the relation stays identity-cheap; a change to it,
+`MergeProps`, `TargetProps`, or `WidenForUntypedTarget` that reintroduced a divergent bag would regress
+these and nothing else. Each is expensive per component like `annotated`, so each moved the budget on its
+own -- fixture growth, not a regression.
+
 Four exotic kinds each price a `types.ts` conditional arm no other kind reaches, and each also fails the
 clean-compile gate if its mechanism regresses, so they are correctness canaries sitting inside the perf
 gate the way `unionTarget` is: `permissiveFactory` (a Mantine-style un-introspectable target, the

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -134,18 +134,14 @@ const AS_TAGS = ['a', 'button', 'label', 'section', 'video', 'ul'];
 // deepened that relation would be invisible. Like `unionTarget`, it is expensive
 // per component, so adding it moved the recorded budget on its own -- that jump
 // is fixture growth, not a regression.
-// `annotatedPublic*` price the same declaration site as `annotated`, but written
-// with the public `StyledComponent<Target, Props>` alias instead of a hand-assembled
-// `IStyledComponent<'web', …>` bag -- the pattern isolatedDeclarations consumers are
-// told to use. `StyledComponent` resolves to the exact shape the constructor emits,
-// so the relation should stay identity-cheap; a change to `StyledComponent`,
+// `annotatedPublic*` price the same declaration site with the public
+// `StyledComponent<Target, Props>` alias instead of a hand-assembled bag. The three
+// cover its distinct construction arms so a change to `StyledComponent`,
 // `MergeProps`, `TargetProps`, or `WidenForUntypedTarget` that reintroduced a
-// divergent bag would regress these and nothing else. The three cover the alias's
-// three structurally-distinct construction arms: `annotatedPublic` an intrinsic tag,
-// `annotatedPublicWrap` the hoisted-statics intersection a wrapped component adds,
-// and `annotatedPublicFactory` the `WidenForUntypedTarget` arm an un-introspectable
-// target takes. Each is expensive per component like `annotated`, so each moved the
-// budget on its own -- fixture growth, not a regression.
+// divergent bag regresses them: `annotatedPublic` an intrinsic tag,
+// `annotatedPublicWrap` the hoisted-statics intersection, `annotatedPublicFactory`
+// the `WidenForUntypedTarget` arm. Expensive per component, so each moved the budget
+// on its own -- fixture growth, not a regression.
 // The four exotic kinds below each price a `types.ts` conditional arm no other
 // kind reaches, and each doubles as a correctness canary (the run fails on any
 // fixture compile error): `permissiveFactory` the un-introspectable
@@ -288,26 +284,19 @@ function unit(i) {
 \`;`;
       break;
     case 'annotatedPublic':
-      // The public annotation an isolatedDeclarations consumer writes for an
-      // intrinsic tag: `StyledComponent<'div', Props>` in place of the
-      // hand-assembled bag `annotated` uses. Same target and props, so it
-      // compiles clean and the cost measured is the relation, not a mismatch.
+      // Public annotation on an intrinsic tag (see KIND_WEIGHTS).
       decl = `const ${N}: StyledComponent<'div', { $a${i}?: number }> = styled.div<{ $a${i}?: number }>\`
   color: \${p => (p.$a${i} ? 'red' : 'blue')};
 \`;`;
       break;
     case 'annotatedPublicWrap':
-      // The wrapped-component variant: `StyledComponent<typeof Plain, Props>`
-      // routes through the hoisted-statics intersection an intrinsic tag never
-      // reaches, so it prices that arm of the alias situationally.
+      // Public annotation on a wrapped component: the hoisted-statics arm.
       decl = `const ${N}: StyledComponent<typeof Plain, { $a${i}?: number }> = styled(Plain)<{ $a${i}?: number }>\`
   margin: \${p => p.$a${i} ?? 0}px;
 \`;`;
       break;
     case 'annotatedPublicFactory':
-      // The un-introspectable factory variant: `StyledComponent<typeof Factory>`
-      // prices the `WidenForUntypedTarget` arm at a declaration site, the third
-      // distinct construction path an intrinsic tag and a plain wrap never reach.
+      // Public annotation on an un-introspectable target: the widening arm.
       decl = `const ${N}: StyledComponent<typeof Factory> = styled(Factory)\`
   color: ${i % 2 ? 'red' : 'blue'};
 \`;`;

--- a/packages/styled-components/scripts/typePerf.mjs
+++ b/packages/styled-components/scripts/typePerf.mjs
@@ -134,6 +134,18 @@ const AS_TAGS = ['a', 'button', 'label', 'section', 'video', 'ul'];
 // deepened that relation would be invisible. Like `unionTarget`, it is expensive
 // per component, so adding it moved the recorded budget on its own -- that jump
 // is fixture growth, not a regression.
+// `annotatedPublic*` price the same declaration site as `annotated`, but written
+// with the public `StyledComponent<Target, Props>` alias instead of a hand-assembled
+// `IStyledComponent<'web', …>` bag -- the pattern isolatedDeclarations consumers are
+// told to use. `StyledComponent` resolves to the exact shape the constructor emits,
+// so the relation should stay identity-cheap; a change to `StyledComponent`,
+// `MergeProps`, `TargetProps`, or `WidenForUntypedTarget` that reintroduced a
+// divergent bag would regress these and nothing else. The three cover the alias's
+// three structurally-distinct construction arms: `annotatedPublic` an intrinsic tag,
+// `annotatedPublicWrap` the hoisted-statics intersection a wrapped component adds,
+// and `annotatedPublicFactory` the `WidenForUntypedTarget` arm an un-introspectable
+// target takes. Each is expensive per component like `annotated`, so each moved the
+// budget on its own -- fixture growth, not a regression.
 // The four exotic kinds below each price a `types.ts` conditional arm no other
 // kind reaches, and each doubles as a correctness canary (the run fails on any
 // fixture compile error): `permissiveFactory` the un-introspectable
@@ -151,6 +163,9 @@ const KIND_WEIGHTS = [
   ['chained', 3],
   ['attrsTag', 2],
   ['annotated', 1],
+  ['annotatedPublic', 1],
+  ['annotatedPublicWrap', 1],
+  ['annotatedPublicFactory', 1],
   ['attrsWrap', 1],
   ['genericWrapper', 1],
   ['unionTarget', 1],
@@ -171,7 +186,7 @@ function kindOf(i) {
 }
 
 const HEADER = `import * as React from 'react';
-import styled, { type FastOmit, type IStyledComponent } from 'styled-components';
+import styled, { type FastOmit, type IStyledComponent, type StyledComponent } from 'styled-components';
 
 type DivProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
@@ -270,6 +285,31 @@ function unit(i) {
       // & string`, the public spelling of the type the report annotates against.
       decl = `const ${N}: IStyledComponent<'web', FastOmit<DivProps, never> & { $a${i}?: number }> = styled.div<{ $a${i}?: number }>\`
   color: \${p => (p.$a${i} ? 'red' : 'blue')};
+\`;`;
+      break;
+    case 'annotatedPublic':
+      // The public annotation an isolatedDeclarations consumer writes for an
+      // intrinsic tag: `StyledComponent<'div', Props>` in place of the
+      // hand-assembled bag `annotated` uses. Same target and props, so it
+      // compiles clean and the cost measured is the relation, not a mismatch.
+      decl = `const ${N}: StyledComponent<'div', { $a${i}?: number }> = styled.div<{ $a${i}?: number }>\`
+  color: \${p => (p.$a${i} ? 'red' : 'blue')};
+\`;`;
+      break;
+    case 'annotatedPublicWrap':
+      // The wrapped-component variant: `StyledComponent<typeof Plain, Props>`
+      // routes through the hoisted-statics intersection an intrinsic tag never
+      // reaches, so it prices that arm of the alias situationally.
+      decl = `const ${N}: StyledComponent<typeof Plain, { $a${i}?: number }> = styled(Plain)<{ $a${i}?: number }>\`
+  margin: \${p => p.$a${i} ?? 0}px;
+\`;`;
+      break;
+    case 'annotatedPublicFactory':
+      // The un-introspectable factory variant: `StyledComponent<typeof Factory>`
+      // prices the `WidenForUntypedTarget` arm at a declaration site, the third
+      // distinct construction path an intrinsic tag and a plain wrap never reach.
+      decl = `const ${N}: StyledComponent<typeof Factory> = styled(Factory)\`
+  color: ${i % 2 ? 'red' : 'blue'};
 \`;`;
       break;
     case 'attrsWrap':

--- a/packages/styled-components/src/index.ts
+++ b/packages/styled-components/src/index.ts
@@ -22,6 +22,7 @@ export {
   PolymorphicComponentProps,
   RuleSet,
   Runtime,
+  StyledComponent,
   StyledObject,
   StyledOptions,
   StyleFunction,

--- a/packages/styled-components/src/native/index.ts
+++ b/packages/styled-components/src/native/index.ts
@@ -108,6 +108,7 @@ export {
   IStyledComponent,
   IStyledComponentFactory,
   IStyledStatics,
+  NativeStyledComponent as StyledComponent,
   NativeTarget,
   PolymorphicComponent,
   PolymorphicComponentProps,

--- a/packages/styled-components/src/test/types.native.tsx
+++ b/packages/styled-components/src/test/types.native.tsx
@@ -31,7 +31,7 @@ import React, { useRef } from 'react';
 import { Text, TextInput, View } from 'react-native';
 import type { PropsWithChildren } from 'react';
 import type { TextProps as RNTextProps, ViewProps as RNViewProps } from 'react-native';
-import styled, { DefaultTheme } from '../native';
+import styled, { DefaultTheme, StyledComponent } from '../native';
 
 /**
  * Augment DefaultTheme so tests can reference theme properties. This is the
@@ -363,3 +363,27 @@ const extractedNumberOfLines: ExtractedTextProps['numberOfLines'] = 3;
 void extractedNumberOfLines;
 const extractedTargetProps: RNTextProps['ellipsizeMode'] = 'tail';
 void extractedTargetProps;
+
+/* ------------------------------------------------------------------------- *
+ * `StyledComponent<Target, Props>` from the native entry annotates a native
+ * styled-component export the same way the web entry's does. As on web, the
+ * annotation is proven to be the exact type `styled(Target)<Props>` produces:
+ * the inferred component assigns to the annotation and back. Native carries no
+ * hoisted-statics intersection, so a target-wrap case exercises that difference.
+ * ------------------------------------------------------------------------- */
+const _scNativeTag = styled.View<{ $active?: boolean }>``;
+const _scNativeTagAnnotated: StyledComponent<typeof View, { $active?: boolean }> = _scNativeTag;
+const _scNativeTagBack: typeof _scNativeTag = _scNativeTagAnnotated;
+void _scNativeTagBack;
+
+const _scNativeWrap = styled(TextInput)``;
+const _scNativeWrapAnnotated: StyledComponent<typeof TextInput> = _scNativeWrap;
+const _scNativeWrapBack: typeof _scNativeWrap = _scNativeWrapAnnotated;
+void _scNativeWrapBack;
+
+// `.attrs()` follows the same rules as web: an already-optional backfilled prop
+// leaves the type unchanged.
+const _scNativeAttrs = styled.TextInput.attrs({ editable: true })<{ $x?: number }>``;
+const _scNativeAttrsAnnotated: StyledComponent<typeof TextInput, { $x?: number }> = _scNativeAttrs;
+const _scNativeAttrsBack: typeof _scNativeAttrs = _scNativeAttrsAnnotated;
+void _scNativeAttrsBack;

--- a/packages/styled-components/src/test/types.native.tsx
+++ b/packages/styled-components/src/test/types.native.tsx
@@ -365,11 +365,9 @@ const extractedTargetProps: RNTextProps['ellipsizeMode'] = 'tail';
 void extractedTargetProps;
 
 /* ------------------------------------------------------------------------- *
- * `StyledComponent<Target, Props>` from the native entry annotates a native
- * styled-component export the same way the web entry's does. As on web, the
- * annotation is proven to be the exact type `styled(Target)<Props>` produces:
- * the inferred component assigns to the annotation and back. Native carries no
- * hoisted-statics intersection, so a target-wrap case exercises that difference.
+ * `StyledComponent<Target, Props>` from the native entry, proven exact the same
+ * way as web (assign both directions). Native carries no hoisted-statics
+ * intersection, so a target-wrap case exercises that difference.
  * ------------------------------------------------------------------------- */
 const _scNativeTag = styled.View<{ $active?: boolean }>``;
 const _scNativeTagAnnotated: StyledComponent<typeof View, { $active?: boolean }> = _scNativeTag;

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -11,6 +11,7 @@ import {
   Interpolation,
   IStyledComponent,
   RuleSet,
+  StyledComponent,
   StyledObject,
   WebTarget,
   withTheme,
@@ -626,6 +627,161 @@ const StyledNoStyleTarget = styled(NoStyleTarget)``;
 
 /** `style={undefined}` stays assignable under exactOptionalPropertyTypes. */
 <DivWithCSSVariable style={undefined} />;
+
+/**
+ * `StyledComponent<Target, Props>` is the public annotation for an explicit
+ * styled-component export, the shape `isolatedDeclarations` and `.d.ts`-emitting
+ * packages must write. The block below is the foolproofing contract: it proves
+ * the alias resolves to the *exact* type `styled(Target)<Props>` produces across
+ * every target kind and construction form, so a consumer who names the target and
+ * props the way they wrote them to `styled` gets the real type, never a lossy
+ * approximation that drops members (the failure mode of hand-assembling the type).
+ *
+ * The core guarantee is `_scExact`: it compiles only when the two types are
+ * mutually assignable. `Props` is invariant (`in out`), so mutual assignability is
+ * identity, not mere one-way compatibility -- a drift between this alias and the
+ * constructor's return breaks it. The headline cases below also keep the explicit
+ * `const X: StyledComponent<...> = styled...` form, the real-world usage and the
+ * exact direction declaration emit exercises.
+ *
+ * Scope and the two `.attrs()` rules are documented on the type itself in
+ * `types.ts`; the cases here enumerate them so a regression in any one fails.
+ */
+type _ScExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const _scExact = <_T extends true>(): void => {};
+
+/* Headline forms: explicit annotation, both assignment directions. */
+const _scPlain = styled.div<{ $active?: boolean }>``;
+const _scPlainAnnotated: StyledComponent<'div', { $active?: boolean }> = _scPlain;
+const _scPlainBack: typeof _scPlain = _scPlainAnnotated;
+void _scPlainBack;
+
+/** Wrapping a component: hoisted target statics survive into the annotation. */
+function IconButtonBase(props: { label: string; className?: string }) {
+  return <button className={props.className}>{props.label}</button>;
+}
+IconButtonBase.displayName = 'IconButton';
+const _scWrap = styled(IconButtonBase)``;
+const _scWrapAnnotated: StyledComponent<typeof IconButtonBase> = _scWrap;
+const _scWrapBack: typeof _scWrap = _scWrapAnnotated;
+void _scWrapBack;
+
+const _scWrapProps = styled(IconButtonBase)<{ $tone?: 'a' | 'b' }>``;
+const _scWrapPropsAnnotated: StyledComponent<typeof IconButtonBase, { $tone?: 'a' | 'b' }> =
+  _scWrapProps;
+const _scWrapPropsBack: typeof _scWrapProps = _scWrapPropsAnnotated;
+void _scWrapPropsBack;
+
+/* Breadth: every distinct target kind resolves exactly. */
+const _scCustomEl = styled('my-element')``;
+_scExact<_ScExact<typeof _scCustomEl, StyledComponent<'my-element'>>>();
+
+class _ScCls extends React.Component<{ label: string; className?: string }> {
+  render() {
+    return <div className={this.props.className}>{this.props.label}</div>;
+  }
+}
+const _scClass = styled(_ScCls)``;
+_scExact<_ScExact<typeof _scClass, StyledComponent<typeof _ScCls>>>();
+
+const _ScFwd = React.forwardRef<HTMLDivElement, { label: string }>((p, ref) => (
+  <div ref={ref}>{p.label}</div>
+));
+const _scFwd = styled(_ScFwd)``;
+_scExact<_ScExact<typeof _scFwd, StyledComponent<typeof _ScFwd>>>();
+
+const _ScMemo = React.memo(IconButtonBase);
+const _scMemo = styled(_ScMemo)``;
+_scExact<_ScExact<typeof _scMemo, StyledComponent<typeof _ScMemo>>>();
+
+/** styled-of-styled: the wrapped styled component's statics chain through. */
+const _ScBase = styled.button<{ $v?: number }>``;
+const _scOfStyled = styled(_ScBase)<{ $w?: string }>``;
+_scExact<_ScExact<typeof _scOfStyled, StyledComponent<typeof _ScBase, { $w?: string }>>>();
+
+/** union-props target (#5787). */
+const _ScPressable = (
+  _p: React.ButtonHTMLAttributes<HTMLButtonElement> | React.AnchorHTMLAttributes<HTMLAnchorElement>
+) => null;
+const _scUnion = styled(_ScPressable)<{ $x?: number }>``;
+_scExact<_ScExact<typeof _scUnion, StyledComponent<typeof _ScPressable, { $x?: number }>>>();
+
+/** generic polymorphic target (#5756). */
+type _ScPolyProps<C extends React.ElementType, P = object> = React.PropsWithChildren<
+  P & { as?: C }
+> &
+  Omit<React.ComponentPropsWithoutRef<C>, keyof (P & { as?: C })>;
+const _ScPoly = <C extends React.ElementType = 'button'>(
+  _p: _ScPolyProps<C, { variant?: 'primary' | 'secondary' }>
+) => null;
+const _scPoly = styled(_ScPoly)<{ $x?: number }>``;
+_scExact<_ScExact<typeof _scPoly, StyledComponent<typeof _ScPoly, { $x?: number }>>>();
+
+/** disjoint-union target (#5787 sibling). */
+const _ScDisjoint = (_p: { onlyA: string } | { onlyB: number }) => null;
+const _scDisjoint = styled(_ScDisjoint)``;
+_scExact<_ScExact<typeof _scDisjoint, StyledComponent<typeof _ScDisjoint>>>();
+
+/** `.withConfig()` leaves the type unchanged. */
+const _scWithConfig = styled.div.withConfig({ displayName: 'X' })<{ $x?: number }>``;
+_scExact<_ScExact<typeof _scWithConfig, StyledComponent<'div', { $x?: number }>>>();
+
+/**
+ * Un-introspectable factory target (Mantine v7 shape): the annotation carries the
+ * same permissive widening the constructor applies, through `WidenForUntypedTarget`.
+ */
+type SCFactoryProps<C, P = {}> = C extends React.ElementType
+  ? Omit<React.ComponentProps<C>, keyof P> & P & { component?: C } & { ref?: any }
+  : P & { component: React.ElementType };
+type SCFactory = (<C = 'button'>(
+  p: SCFactoryProps<C, { children?: React.ReactNode }>
+) => React.ReactElement) &
+  Omit<React.FunctionComponent<SCFactoryProps<any, { children?: React.ReactNode }>>, never> & {
+    extend: (p: any) => any;
+  };
+declare const scFactory: SCFactory;
+const _scFactory = styled(scFactory)``;
+const _scFactoryAnnotated: StyledComponent<typeof scFactory> = _scFactory;
+const _scFactoryBack: typeof _scFactory = _scFactoryAnnotated;
+void _scFactoryBack;
+
+/**
+ * `.attrs()` rules. Attrs data (which keys are backfilled, and a target redirect)
+ * lives only in the runtime value, so it is not derivable from `<Target, Props>`.
+ * Two spellings cover it, both documented on the type:
+ *
+ * 1. Backfilling a prop that was required makes it optional on the component, so
+ *    declare that prop optional in `Props`.
+ * 2. An object-form `as` redirect keeps the base target's props and adds the
+ *    resolved target's, so pass the resolved target's props as `Props`.
+ *
+ * Attrs that only backfill already-optional props (the common case) need neither
+ * rule -- the type is unchanged.
+ */
+const _scAttrsPlain = styled.input.attrs({ type: 'text' })<{ $x?: number }>``;
+_scExact<_ScExact<typeof _scAttrsPlain, StyledComponent<'input', { $x?: number }>>>();
+
+const _scAttrsBackfill = styled(IconButtonBase).attrs({ label: 'x' })``;
+_scExact<
+  _ScExact<typeof _scAttrsBackfill, StyledComponent<typeof IconButtonBase, { label?: string }>>
+>();
+
+const _scAttrsRedirect = styled.button.attrs({ as: 'a' })``;
+_scExact<
+  _ScExact<typeof _scAttrsRedirect, StyledComponent<'button', React.ComponentPropsWithRef<'a'>>>
+>();
+
+/**
+ * Foolproofing floor: any annotation that *compiles* is the exact emitted type or
+ * a structural equal of it (identical call-site behavior). A genuinely different
+ * required prop is rejected -- never silently accepted, and never silently
+ * dropped. Structural equivalences (an optional-only prop difference, two
+ * intrinsic tags with identical prop shapes like div/span) are inherent to TS and
+ * harmless, since equal shapes accept and reject the same props.
+ */
+// @ts-expect-error the real required prop is $y; annotating a required $x is rejected
+const _scWrongReq: StyledComponent<'div', { $x: number }> = styled.div<{ $y: number }>``;
+void _scWrongReq;
 
 /** Widening is visible through prop extraction, not only at the call site. */
 const StyleExtractionTarget = styled.div``;

--- a/packages/styled-components/src/test/types.tsx
+++ b/packages/styled-components/src/test/types.tsx
@@ -629,23 +629,12 @@ const StyledNoStyleTarget = styled(NoStyleTarget)``;
 <DivWithCSSVariable style={undefined} />;
 
 /**
- * `StyledComponent<Target, Props>` is the public annotation for an explicit
- * styled-component export, the shape `isolatedDeclarations` and `.d.ts`-emitting
- * packages must write. The block below is the foolproofing contract: it proves
- * the alias resolves to the *exact* type `styled(Target)<Props>` produces across
- * every target kind and construction form, so a consumer who names the target and
- * props the way they wrote them to `styled` gets the real type, never a lossy
- * approximation that drops members (the failure mode of hand-assembling the type).
- *
- * The core guarantee is `_scExact`: it compiles only when the two types are
- * mutually assignable. `Props` is invariant (`in out`), so mutual assignability is
- * identity, not mere one-way compatibility -- a drift between this alias and the
- * constructor's return breaks it. The headline cases below also keep the explicit
- * `const X: StyledComponent<...> = styled...` form, the real-world usage and the
- * exact direction declaration emit exercises.
- *
- * Scope and the two `.attrs()` rules are documented on the type itself in
- * `types.ts`; the cases here enumerate them so a regression in any one fails.
+ * Contract for the public `StyledComponent<Target, Props>` annotation: it must
+ * resolve to the exact type `styled(Target)<Props>` produces for every target kind
+ * and construction form. `_scExact` compiles only when the two types are mutually
+ * assignable; `Props` is invariant, so that is an identity check, not one-way
+ * compatibility. The `.attrs()` rules the cases enumerate are documented in
+ * `types.ts`.
  */
 type _ScExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
 const _scExact = <_T extends true>(): void => {};
@@ -746,17 +735,10 @@ const _scFactoryBack: typeof _scFactory = _scFactoryAnnotated;
 void _scFactoryBack;
 
 /**
- * `.attrs()` rules. Attrs data (which keys are backfilled, and a target redirect)
- * lives only in the runtime value, so it is not derivable from `<Target, Props>`.
- * Two spellings cover it, both documented on the type:
- *
- * 1. Backfilling a prop that was required makes it optional on the component, so
- *    declare that prop optional in `Props`.
- * 2. An object-form `as` redirect keeps the base target's props and adds the
- *    resolved target's, so pass the resolved target's props as `Props`.
- *
- * Attrs that only backfill already-optional props (the common case) need neither
- * rule -- the type is unchanged.
+ * `.attrs()` rules (backfilled keys and target redirect are not in
+ * `<Target, Props>`): a backfilled required prop becomes optional in `Props`; an
+ * object-form `as` redirect adds the resolved target's props to `Props`. Attrs
+ * over already-optional props (the common case) needs neither.
  */
 const _scAttrsPlain = styled.input.attrs({ type: 'text' })<{ $x?: number }>``;
 _scExact<_ScExact<typeof _scAttrsPlain, StyledComponent<'input', { $x?: number }>>>();
@@ -772,12 +754,9 @@ _scExact<
 >();
 
 /**
- * Foolproofing floor: any annotation that *compiles* is the exact emitted type or
- * a structural equal of it (identical call-site behavior). A genuinely different
- * required prop is rejected -- never silently accepted, and never silently
- * dropped. Structural equivalences (an optional-only prop difference, two
- * intrinsic tags with identical prop shapes like div/span) are inherent to TS and
- * harmless, since equal shapes accept and reject the same props.
+ * A genuinely different required prop is rejected, never silently accepted or
+ * dropped. (Optional-only or structurally-equal mismatches stay assignable, per
+ * TS structural typing, and are harmless: equal shapes behave identically.)
  */
 // @ts-expect-error the real required prop is $y; annotating a required $x is rejected
 const _scWrongReq: StyledComponent<'div', { $x: number }> = styled.div<{ $y: number }>``;

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -435,6 +435,70 @@ export type IStyledComponent<
   Props extends BaseObject = BaseObject,
 > = IStyledComponentBase<R, Props> & string;
 
+/**
+ * The type of a web styled component, for annotating an explicit export.
+ *
+ * `isolatedDeclarations` and any package that emits its own `.d.ts` require every
+ * exported styled component to carry a nameable type annotation, which inference
+ * alone does not survive. Write it by naming the target the same way you passed it
+ * to `styled`, and the extra props the same way you passed them to `styled.tag<…>`:
+ *
+ * ```ts
+ * export const Card: StyledComponent<'div', { $active?: boolean }> = styled.div<{ $active?: boolean }>`…`;
+ * export const CloseButton: StyledComponent<typeof IconButton> = styled(IconButton)`…`;
+ * ```
+ *
+ * This resolves to the exact type `styled(Target)<Props>` produces -- across every
+ * target kind (intrinsic tag, custom element, function, class, `forwardRef`,
+ * `memo`, another styled component, a union-props or generic-polymorphic target),
+ * `.withConfig(…)`, and hoisted target statics included -- so the annotation is
+ * never a lossy approximation and the check against the inferred result stays
+ * cheap. Because the prop type is invariant, an annotation that names the wrong
+ * required prop or target is rejected at compile time rather than silently
+ * mistyped. Prefer annotating with `typeof` an existing component where a call
+ * site allows it, which is free; reach for this only where the value being
+ * annotated is the component itself.
+ *
+ * `.attrs(…)` carries information no written annotation can see (which props it
+ * backfills, and any target redirect), so two rules cover it:
+ *
+ * - Backfilling a prop that was required makes it optional on the component:
+ *   declare that prop optional in `Props`
+ *   (`StyledComponent<typeof Field, { name?: string }>`). Attrs that only touch
+ *   already-optional props need no change.
+ * - An object-form `as` redirect (`.attrs({ as: 'a' })`) keeps the base target's
+ *   props and adds the resolved target's: pass the resolved target's props as
+ *   `Props` (`StyledComponent<'button', React.ComponentPropsWithRef<'a'>>`), or
+ *   redirect with the `as` prop at the call site instead.
+ *
+ * Web only. See the native entry's `StyledComponent` for React Native.
+ */
+export type StyledComponent<
+  Target extends WebTarget,
+  Props extends BaseObject = BaseObject,
+> = IStyledComponent<
+  'web',
+  WidenForUntypedTarget<TargetProps<'web', Target>, MergeProps<TargetProps<'web', Target>, Props>>
+> &
+  (Target extends string ? {} : Omit<Target, keyof React.Component<any>>);
+
+/**
+ * The React Native counterpart to {@link StyledComponent}, re-exported as
+ * `StyledComponent` from `styled-components/native`. Same annotation pattern,
+ * with the native runtime and no hoisted-statics intersection: the constructor's
+ * statics widening is web-only, so a native styled component's type carries none.
+ */
+export type NativeStyledComponent<
+  Target extends NativeTarget,
+  Props extends BaseObject = BaseObject,
+> = IStyledComponent<
+  'native',
+  WidenForUntypedTarget<
+    TargetProps<'native', Target>,
+    MergeProps<TargetProps<'native', Target>, Props>
+  >
+>;
+
 // corresponds to createStyledComponent
 export interface IStyledComponentFactory<
   out R extends Runtime,

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -437,41 +437,27 @@ export type IStyledComponent<
 
 /**
  * The type of a web styled component, for annotating an explicit export.
- *
- * `isolatedDeclarations` and any package that emits its own `.d.ts` require every
- * exported styled component to carry a nameable type annotation, which inference
- * alone does not survive. Write it by naming the target the same way you passed it
- * to `styled`, and the extra props the same way you passed them to `styled.tag<…>`:
+ * `isolatedDeclarations` and `.d.ts`-emitting packages require one; inference does
+ * not survive declaration emit. Name the target and props as you passed them to
+ * `styled`:
  *
  * ```ts
  * export const Card: StyledComponent<'div', { $active?: boolean }> = styled.div<{ $active?: boolean }>`…`;
  * export const CloseButton: StyledComponent<typeof IconButton> = styled(IconButton)`…`;
  * ```
  *
- * This resolves to the exact type `styled(Target)<Props>` produces -- across every
- * target kind (intrinsic tag, custom element, function, class, `forwardRef`,
- * `memo`, another styled component, a union-props or generic-polymorphic target),
- * `.withConfig(…)`, and hoisted target statics included -- so the annotation is
- * never a lossy approximation and the check against the inferred result stays
- * cheap. Because the prop type is invariant, an annotation that names the wrong
- * required prop or target is rejected at compile time rather than silently
- * mistyped. Prefer annotating with `typeof` an existing component where a call
- * site allows it, which is free; reach for this only where the value being
- * annotated is the component itself.
+ * Resolves to the exact type `styled(Target)<Props>` produces for every target kind
+ * and `.withConfig(…)`, hoisted statics included.
  *
- * `.attrs(…)` carries information no written annotation can see (which props it
- * backfills, and any target redirect), so two rules cover it:
+ * `.attrs(…)` needs two adjustments, since its backfilled keys and target redirect
+ * are not in `<Target, Props>`:
+ * - A backfilled required prop becomes optional: declare it optional in `Props`.
+ * - An object-form `as` redirect (`.attrs({ as: 'a' })`) keeps the base props and
+ *   adds the resolved target's: pass those as `Props`
+ *   (`StyledComponent<'button', React.ComponentPropsWithRef<'a'>>`), or redirect
+ *   with the `as` prop at the call site.
  *
- * - Backfilling a prop that was required makes it optional on the component:
- *   declare that prop optional in `Props`
- *   (`StyledComponent<typeof Field, { name?: string }>`). Attrs that only touch
- *   already-optional props need no change.
- * - An object-form `as` redirect (`.attrs({ as: 'a' })`) keeps the base target's
- *   props and adds the resolved target's: pass the resolved target's props as
- *   `Props` (`StyledComponent<'button', React.ComponentPropsWithRef<'a'>>`), or
- *   redirect with the `as` prop at the call site instead.
- *
- * Web only. See the native entry's `StyledComponent` for React Native.
+ * Web only; the native entry exports a native `StyledComponent`.
  */
 export type StyledComponent<
   Target extends WebTarget,
@@ -484,9 +470,8 @@ export type StyledComponent<
 
 /**
  * The React Native counterpart to {@link StyledComponent}, re-exported as
- * `StyledComponent` from `styled-components/native`. Same annotation pattern,
- * with the native runtime and no hoisted-statics intersection: the constructor's
- * statics widening is web-only, so a native styled component's type carries none.
+ * `StyledComponent` from `styled-components/native`. No hoisted-statics
+ * intersection: the constructor's statics widening is web-only.
  */
 export type NativeStyledComponent<
   Target extends NativeTarget,

--- a/packages/styled-components/type-perf.augment.budget.json
+++ b/packages/styled-components/type-perf.augment.budget.json
@@ -1,9 +1,9 @@
 {
   "count": 100,
   "measured": {
-    "instantiations": 965491,
-    "memoryKb": 206495,
-    "types": 39584
+    "instantiations": 895632,
+    "memoryKb": 201742,
+    "types": 38232
   },
   "tolerancePct": {
     "instantiations": 10,

--- a/packages/styled-components/type-perf.budget.json
+++ b/packages/styled-components/type-perf.budget.json
@@ -1,9 +1,9 @@
 {
   "count": 100,
   "measured": {
-    "instantiations": 888000,
-    "memoryKb": 205788,
-    "types": 39346
+    "instantiations": 820402,
+    "memoryKb": 201312,
+    "types": 38055
   },
   "tolerancePct": {
     "instantiations": 10,


### PR DESCRIPTION
## What

A public `StyledComponent<Target, Props>` type for annotating explicitly-typed styled component exports, from the web and native entries.

## Why

Packages that emit their own declaration files, including any project using `isolatedDeclarations`, must annotate every exported styled component. There was no public type for it, so consumers reached into internal paths (`styled-components/dist/types`) or hand-assembled one that dropped members like a wrapped component's hoisted statics.

Name the target and props as you passed them to `styled`:

```tsx
import styled, { type StyledComponent } from 'styled-components';

export const Card: StyledComponent<'div', { $active?: boolean }> = styled.div<{ $active?: boolean }>`...`;
export const CloseButton: StyledComponent<typeof IconButton> = styled(IconButton)`...`;
```

## Guarantees

Resolves to the exact type `styled(Target)<Props>` produces, verified by contract tests across every target kind (intrinsic tag, custom element, function, class, `forwardRef`, `memo`, another styled component, union-props and generic-polymorphic targets, an un-introspectable factory, disjoint unions) and `.withConfig(…)`. `Props` is invariant, so the tests assert identity, not one-way compatibility.

`.attrs(…)` carries data no annotation can see (backfilled keys, target redirect), covered by two documented rules, each pinned by a test: a backfilled required prop becomes optional in `Props`; an object-form `as` redirect adds the resolved target's props to `Props`.

Only one new public name per entry; the internal helpers resolve inside the emitted declarations without entering the root namespace.

## Type performance

Three `annotatedPublic*` fixture kinds guard the alias's construction arms (intrinsic tag, statics wrap, factory widening); both budgets re-measured and moved down.
