### PR TITLE
fix: run style interpolations on every render (#5788)

### DIFF
--- a/.changeset/interpolation-hooks-render-cache.md
+++ b/.changeset/interpolation-hooks-render-cache.md
@@ -1,0 +1,9 @@
+---
+"styled-components": patch
+---
+
+Fixed a crash ("Rendered fewer hooks than expected") and a related stale-style bug for components that call a React hook, or read any value outside their props and theme, from inside a style interpolation. This affected `@mui/styled-engine-sc` with MUI X DataGrid, which calls hooks within an interpolation, and was a regression introduced in 6.4.0.
+
+The render optimization added in 6.4.0 reused a cached result on a re-render with unchanged props, which skipped evaluating the interpolation. An interpolation runs as part of the component's own render, so skipping it dropped any hook it called (breaking React's rules of hooks) and served a stale class name when the interpolation depended on something other than props (a context value, a ref, module state). Interpolations now run on every render, and the class name always reflects their current output.
+
+Re-renders with unchanged props therefore re-evaluate interpolations again. If a component re-renders often with the same props and its styles are expensive to compute, wrap it in `React.memo` to skip the re-render entirely, which is the sound place to bail out because only the calling code knows the full set of inputs its styles depend on.

--- a/.changeset/interpolation-hooks-render-cache.md
+++ b/.changeset/interpolation-hooks-render-cache.md
@@ -4,6 +4,6 @@
 
 Fixed a crash ("Rendered fewer hooks than expected") and a related stale-style bug for components that call a React hook, or read any value outside their props and theme, from inside a style interpolation. This affected `@mui/styled-engine-sc` with MUI X DataGrid, which calls hooks within an interpolation, and was a regression introduced in 6.4.0.
 
-The render optimization added in 6.4.0 reused a cached result on a re-render with unchanged props, which skipped evaluating the interpolation. An interpolation runs as part of the component's own render, so skipping it dropped any hook it called (breaking React's rules of hooks) and served a stale class name when the interpolation depended on something other than props (a context value, a ref, module state). Interpolations now run on every render, and the class name always reflects their current output.
+Style interpolations now run on every render, so a hook called inside one runs consistently and a value read inside one always reflects its current state.
 
-Re-renders with unchanged props therefore re-evaluate interpolations again. If a component re-renders often with the same props and its styles are expensive to compute, wrap it in `React.memo` to skip the re-render entirely, which is the sound place to bail out because only the calling code knows the full set of inputs its styles depend on.
+If a component re-renders often with unchanged props and its interpolations are expensive, wrap it in `React.memo` to skip those re-renders. That is the right place to bail out, because only the calling code knows the full set of inputs its styles depend on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,10 @@ mapped below.
   `styleSheet.server` or `IS_RSC`.
 - NEVER write `typeof React.useRef === 'function'`; that is a runtime conditional hook. Gate on
   `__SERVER__`.
-- NEVER place a hook on one side of the render cache's hit/miss branch. The hook sequence must be
-  identical whether or not props changed. See
+- NEVER skip evaluating interpolations or attr functions across renders, and never reintroduce a
+  props-equal render cache that does. They are the component's own render body and may call hooks or
+  read state outside props and theme, so skipping them breaks the rules of hooks and serves stale
+  styles (#5788). Keep every styled-components hook call unconditional. See
   [docs/runtime-performance.md](docs/runtime-performance.md).
 - NEVER use `new Array(n)`. It creates HOLEY_ELEMENTS arrays that infect V8 type feedback.
 - NEVER mutate `rule.props` in place on a stylis AST node; allocate a fresh array.
@@ -33,6 +35,11 @@ mapped below.
 ## Mandates
 
 - React 16.8 compat
+- The web and native render paths mirror each other: `src/models/StyledComponent.ts` with
+  `ComponentStyle.ts` for web, `src/models/StyledNativeComponent.ts` with `InlineStyle.ts` for native.
+  When changing one, check whether the other needs the same change. A render-path, interpolation, or
+  attr-evaluation fix on web almost always applies to native, and the reverse. Land both together or
+  state why one is exempt.
 - Always microbenchmark to validate optimizations, and bench the realistic workload rather than a
   synthetic best case. Revert changes that pessimize the path actual callers take, even if they win in
   isolation.
@@ -77,7 +84,7 @@ it rather than restating it.
   detection mechanisms, native entry isolation, module resolution, CSS injection ordering
 - [docs/rendering-flow.md](docs/rendering-flow.md) -- the full render sequence diagram
 - [docs/runtime-performance.md](docs/runtime-performance.md) -- microbenchmark-validated patterns, the
-  dynamic re-render hot path and its render cache, V8 gotchas, stylis AST handling
+  dynamic render hot path, V8 gotchas, stylis AST handling
 - [docs/global-styles.md](docs/global-styles.md) -- `createGlobalStyle`'s shared-group architecture,
   instance lifecycle, rebuild fast path
 - [docs/rsc-style-injection.md](docs/rsc-style-injection.md) -- how styles reach the page from server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@ mapped below.
 - NEVER skip evaluating interpolations or attr functions across renders, and never reintroduce a
   props-equal render cache that does. They are the component's own render body and may call hooks or
   read state outside props and theme, so skipping them breaks the rules of hooks and serves stale
-  styles (#5788). Keep every styled-components hook call unconditional. See
+  styles (#5788). A hook may be gated only on a build or runtime constant (`__SERVER__`, `IS_RSC`),
+  which is stable across a component's renders, never on per-render state. See
   [docs/runtime-performance.md](docs/runtime-performance.md).
 - NEVER use `new Array(n)`. It creates HOLEY_ELEMENTS arrays that infect V8 type feedback.
 - NEVER mutate `rule.props` in place on a stylis AST node; allocate a fresh array.

--- a/docs/runtime-performance.md
+++ b/docs/runtime-performance.md
@@ -26,10 +26,10 @@ The pure work downstream of the produced CSS string is memoized, so a repeat ren
 same CSS is cheap:
 
 1. `resolveContext`: object spread plus attrs evaluation.
-2. `flatten()` fast path: an inline function call for string-returning interpolations, roughly 0.05us
-   each.
-3. `dynamicNameCache` lookup: a `Map.get` on the CSS string, O(1), which skips `phash` and
-   `generateName` on a hit.
+2. Interpolation fast path: an inline function call for string-returning interpolations that bypasses
+   `flatten`'s type dispatch and array allocation, roughly 0.05us each.
+3. `dynamicNameCache` lookup: a `Map.get` on the CSS string (prefixed by the stylis plugin hash when
+   one is set), O(1), which skips `phash` and `generateName` on a hit.
 4. `phash()` and `generateName`: only on a `dynamicNameCache` miss, the first time this CSS is seen.
 5. `stylis` compile and serialize: only when `hasNameForId` misses, the first injection of this class.
 6. `hasNameForId`: a `Map.has`, negligible.

--- a/docs/runtime-performance.md
+++ b/docs/runtime-performance.md
@@ -14,15 +14,16 @@ microbenchmark against the realistic workload, not a synthetic best case.
 | Template literals | Manual `+` concat is 1.3x faster than `` `${a}${b}` `` in tight loops |
 | `React.createElement` | Raw element objects measure 60-120x faster, but are NOT used on this branch: `StyledComponent` calls React's own `createElement`. Measurement only, not an inventory entry |
 
-## Dynamic re-render hot path
+## Dynamic render hot path
 
-On a cache hit, meaning props and theme are unchanged and this is the most common re-render:
+Interpolations and attr functions run on every render. They are the component's own render-body user
+code, so a hook called inside an interpolation (React `useContext` from an `@mui/styled-engine-sc`
+adapter, for example) is one of the component's hooks and must run every render like any other hook
+site. Skipping evaluation on a props-equal re-render would drop that hook and serve a stale class name
+whenever an interpolation reads state outside props and theme (#5788).
 
-- `shallowEqualContext` costs roughly 0.2us, comparing props by `for..in` against a stored key count.
-- Everything else is skipped: `resolveContext`, flatten, hash and `generateName`.
-  `buildPropsForElement` still runs.
-
-On a cache miss, meaning props changed:
+The pure work downstream of the produced CSS string is memoized, so a repeat render that yields the
+same CSS is cheap:
 
 1. `resolveContext`: object spread plus attrs evaluation.
 2. `flatten()` fast path: an inline function call for string-returning interpolations, roughly 0.05us
@@ -33,11 +34,12 @@ On a cache miss, meaning props changed:
 5. `stylis` compile and serialize: only when `hasNameForId` misses, the first injection of this class.
 6. `hasNameForId`: a `Map.has`, negligible.
 
-The render cache splits this path in two, and only the miss side runs the style work. Any hook placed
-on one side of that split is called on a miss and skipped on a hit, which makes the component emit a
-different hook sequence depending on whether its props happened to change. React rejects that outright
-(#5788). `memoization.test.tsx` records the hook sequence across both cache states and asserts they
-match, so a hook added inside the branch fails there rather than in a consumer's app.
+A props-equal re-render bailout belongs at the component boundary via `React.memo`, which only the
+caller can key against the full set of inputs the styles depend on. `memoization.test.tsx` records the
+hook sequence across a re-render with unchanged props and asserts it matches the mount, so a change
+that reintroduces skipped evaluation fails there rather than in a consumer's app. The native path is
+the same: `InlineStyle` caches CSS-to-style-object by content, so `generateStyleObject` returns a
+stable reference for equal styles without an outer render cache.
 
 ## V8 gotchas
 

--- a/packages/styled-components/src/models/InlineStyle.ts
+++ b/packages/styled-components/src/models/InlineStyle.ts
@@ -1,6 +1,5 @@
 import transformDeclPairs from 'css-to-react-native';
 import {
-  Dict,
   ExecutionContext,
   IInlineStyle,
   IInlineStyleConstructor,
@@ -8,7 +7,6 @@ import {
   StyleSheet,
 } from '../types';
 import flatten from '../utils/flatten';
-import generateComponentId from '../utils/generateComponentId';
 import { joinStringArray } from '../utils/joinStrings';
 
 // List of CSS values not supported by React Native
@@ -161,40 +159,42 @@ export function parseCSSDeclarations(rawCss: string): [string, string][] {
   return pairs;
 }
 
-let generated: Dict<any> = {};
+let generated = new Map<string, any>();
 
 /** Clear the cached CSS-to-style-object mappings. Useful in tests or long-running RN apps with highly dynamic styles. */
 export const resetStyleCache = (): void => {
-  generated = {};
+  generated = new Map();
 };
 
 /**
  * Parse flat CSS into a style object via css-to-react-native, with caching.
+ * Keyed by the flat CSS string itself: the transform is a pure function of it,
+ * and a string key cannot collide the way a 32-bit hash could.
  */
 export function cssToStyleObject(flatCSS: string, styleSheet: StyleSheet) {
-  const hash = generateComponentId(flatCSS);
+  const cached = generated.get(flatCSS);
+  if (cached !== undefined) return cached;
 
-  if (!generated[hash]) {
-    const declPairs: [string, string][] = [];
-    for (const [prop, value] of parseCSSDeclarations(flatCSS)) {
-      if (RN_UNSUPPORTED_VALUES.includes(value)) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(
-            `[styled-components/native] The value "${value}" for property "${prop}" is not supported in React Native and will be ignored.`
-          );
-        }
-      } else {
-        declPairs.push([prop, value]);
+  const declPairs: [string, string][] = [];
+  for (const [prop, value] of parseCSSDeclarations(flatCSS)) {
+    if (RN_UNSUPPORTED_VALUES.includes(value)) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `[styled-components/native] The value "${value}" for property "${prop}" is not supported in React Native and will be ignored.`
+        );
       }
+    } else {
+      declPairs.push([prop, value]);
     }
-
-    // RN does not support differing border values for Image components (but does for View).
-    // https://github.com/styled-components/styled-components/issues/4181
-    const styleObject = transformDeclPairs(declPairs, ['borderWidth', 'borderColor']);
-
-    generated[hash] = styleSheet.create({ generated: styleObject }).generated;
   }
-  return generated[hash];
+
+  // RN does not support differing border values for Image components (but does for View).
+  // https://github.com/styled-components/styled-components/issues/4181
+  const styleObject = transformDeclPairs(declPairs, ['borderWidth', 'borderColor']);
+
+  const result = styleSheet.create({ generated: styleObject }).generated;
+  generated.set(flatCSS, result);
+  return result;
 }
 
 /**

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -15,7 +15,6 @@ import type {
   IStyledStatics,
   OmitNever,
   RuleSet,
-  Stringifier,
   StyledOptions,
   WebTarget,
 } from '../types';
@@ -39,8 +38,6 @@ import { useStyleSheetContext } from './StyleSheetManager';
 import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
 declare const __SERVER__: boolean;
-
-const hasOwn = Object.prototype.hasOwnProperty;
 
 const identifiers: { [key: string]: number } = {};
 
@@ -70,36 +67,6 @@ function generateId(
 
   return parentComponentId ? parentComponentId + '-' + componentId : componentId;
 }
-
-/**
- * Shallow-compare two context objects using a stored key count to avoid
- * a second iteration pass. Returns true if all own-property values match.
- */
-function shallowEqualContext(prev: object, next: object, prevKeyCount: number): boolean {
-  const a = prev as Record<string, unknown>;
-  const b = next as Record<string, unknown>;
-  let nextKeyCount = 0;
-  for (const key in b) {
-    if (hasOwn.call(b, key)) {
-      nextKeyCount++;
-      if (a[key] !== b[key]) return false;
-    }
-  }
-  return nextKeyCount === prevKeyCount;
-}
-
-// Cached render inputs + style result: [prevProps, prevTheme, prevStyleSheet, prevStylis,
-// prevPropsKeyCount, cachedContext, cachedClassName]
-type RenderCache = [
-  object, // prevProps
-  DefaultTheme | undefined, // prevTheme
-  StyleSheet, // prevStyleSheet
-  Stringifier, // prevStylis
-  number, // prevPropsKeyCount
-  object, // cachedContext
-  string, // cachedClassName
-  ComponentStyle, // prevComponentStyle (for HMR invalidation)
-];
 
 function resolveContext<Props extends BaseObject>(
   attrs: Attrs<React.HTMLAttributes<Element> & Props>[],
@@ -235,60 +202,21 @@ function useStyledComponentImpl<Props extends BaseObject>(
   const theme =
     determineTheme(props, contextTheme, defaultProps) || (IS_RSC ? undefined : EMPTY_OBJECT);
 
-  let context: React.HTMLAttributes<Element> & ExecutionContext & Props;
-  let generatedClassName: string;
+  // Interpolations and attr functions run on every render. They are this
+  // component's own user code and may call hooks or read inputs outside
+  // (props + theme), so skipping their evaluation across renders breaks the
+  // rules of hooks (a hook count that changes between renders) and serves stale
+  // styles (#5788). The pure work downstream of the produced CSS string
+  // (hashing, compile, injection) is already memoized inside ComponentStyle; a
+  // props-equal re-render bailout belongs at the component boundary via
+  // React.memo, which only the caller can key correctly.
+  const context = resolveContext<Props>(componentAttrs, props, theme);
+  const generatedClassName = componentStyle.generateAndInjectStyles(
+    context,
+    ssc.styleSheet,
+    ssc.stylis
+  );
 
-  // Client-only render cache: skip resolveContext and generateAndInjectStyles
-  // when props+theme haven't changed. propsForElement is always rebuilt since
-  // it's mutated with className/ref after construction.
-  // __SERVER__ and IS_RSC are build/module-level constants for dead-code elimination.
-  if (!__SERVER__ && !IS_RSC) {
-    const renderCacheRef = React.useRef<RenderCache | null>(null);
-    const prev = renderCacheRef.current;
-
-    if (
-      prev !== null &&
-      prev[1] === theme &&
-      prev[2] === ssc.styleSheet &&
-      prev[3] === ssc.stylis &&
-      prev[7] === componentStyle &&
-      shallowEqualContext(prev[0], props, prev[4])
-    ) {
-      context = prev[5] as typeof context;
-      generatedClassName = prev[6];
-    } else {
-      context = resolveContext<Props>(componentAttrs, props, theme);
-      generatedClassName = componentStyle.generateAndInjectStyles(
-        context,
-        ssc.styleSheet,
-        ssc.stylis
-      );
-      let propsKeyCount = 0;
-      for (const key in props) {
-        if (hasOwn.call(props, key)) propsKeyCount++;
-      }
-      renderCacheRef.current = [
-        props,
-        theme,
-        ssc.styleSheet,
-        ssc.stylis,
-        propsKeyCount,
-        context,
-        generatedClassName,
-        componentStyle,
-      ];
-    }
-  } else {
-    context = resolveContext<Props>(componentAttrs, props, theme);
-    generatedClassName = componentStyle.generateAndInjectStyles(
-      context,
-      ssc.styleSheet,
-      ssc.stylis
-    );
-  }
-
-  // Outside the render-cache branch: a hook skipped on a cache hit is a hook
-  // count that changes between renders, which React rejects outright (#5788).
   if (process.env.NODE_ENV !== 'production' && React.useDebugValue) {
     React.useDebugValue(generatedClassName);
   }

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -23,21 +23,6 @@ import isStyledComponent from '../utils/isStyledComponent';
 import merge from '../utils/mixinDeep';
 import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
-const hasOwn = Object.prototype.hasOwnProperty;
-
-function shallowEqualContext(prev: object, next: object, prevKeyCount: number): boolean {
-  const a = prev as Record<string, unknown>;
-  const b = next as Record<string, unknown>;
-  let nextKeyCount = 0;
-  for (const key in b) {
-    if (hasOwn.call(b, key)) {
-      nextKeyCount++;
-      if (a[key] !== b[key]) return false;
-    }
-  }
-  return nextKeyCount === prevKeyCount;
-}
-
 function resolveContext<Props extends object>(
   theme: DefaultTheme = EMPTY_OBJECT,
   props: Props,
@@ -80,9 +65,6 @@ function buildPropsForElement(
   return propsForElement;
 }
 
-// [prevProps, prevTheme, prevPropsKeyCount, cachedContext, cachedStyles]
-type RenderCache = [object, DefaultTheme | undefined, number, object, any];
-
 function useStyledComponentImpl<Props extends StyledComponentImplProps>(
   forwardedComponent: IStyledComponent<'native', Props>,
   props: Props,
@@ -100,25 +82,14 @@ function useStyledComponentImpl<Props extends StyledComponentImplProps>(
   const contextTheme = React.useContext ? React.useContext(ThemeContext) : undefined;
   const theme = determineTheme(props, contextTheme, defaultProps) || EMPTY_OBJECT;
 
-  let context: ExecutionContext & Props;
-  let generatedStyles: any;
-
-  const renderCacheRef = React.useRef ? React.useRef<RenderCache | null>(null) : { current: null };
-  const prev = renderCacheRef.current;
-
-  if (prev !== null && prev[1] === theme && shallowEqualContext(prev[0], props, prev[2])) {
-    context = prev[3] as typeof context;
-    generatedStyles = prev[4];
-  } else {
-    context = resolveContext<Props>(theme, props, componentAttrs);
-    generatedStyles = inlineStyle.generateStyleObject(context);
-
-    let propsKeyCount = 0;
-    for (const key in props) {
-      if (hasOwn.call(props, key)) propsKeyCount++;
-    }
-    renderCacheRef.current = [props, theme, propsKeyCount, context, generatedStyles];
-  }
+  // Interpolations and attr functions run on every render: they are this
+  // component's own user code and may call hooks or read inputs outside
+  // (props + theme), so skipping their evaluation across renders breaks the
+  // rules of hooks and serves stale styles (#5788). generateStyleObject returns
+  // a stable style reference for equal CSS via InlineStyle's own cache, so the
+  // style useMemo below keeps a stable identity without an outer render cache.
+  const context = resolveContext<Props>(theme, props, componentAttrs);
+  const generatedStyles = inlineStyle.generateStyleObject(context);
 
   const elementToBeCreated: NativeTarget = (context as any).as || props.as || target;
   const propsForElement = buildPropsForElement(context, elementToBeCreated, shouldForwardProp);

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -594,4 +594,87 @@ describe('native', () => {
       expect(props.filterThis).toBeUndefined();
     });
   });
+
+  // Mirrors the web coverage in src/test/memoization.test.tsx: skipping style
+  // evaluation on an unchanged-props re-render would drop a hook called inside an
+  // interpolation and serve a stale style object (#5788).
+  describe('interpolation evaluation on every render (#5788)', () => {
+    it('runs a hook called inside an interpolation on every render', () => {
+      const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
+      const Ctx = React.createContext('0.5');
+      const hookNames = Object.keys(React).filter(
+        key => key.startsWith('use') && typeof reactHooks[key] === 'function'
+      );
+
+      let recording: string[] | null = null;
+      const originals = new Map<string, (...args: unknown[]) => unknown>();
+
+      function record<T>(render: () => T): [T, string[]] {
+        const calls: string[] = [];
+        recording = calls;
+        try {
+          return [render(), calls];
+        } finally {
+          recording = null;
+        }
+      }
+
+      try {
+        for (const name of hookNames) {
+          const original = reactHooks[name];
+          originals.set(name, original);
+          reactHooks[name] = (...args) => {
+            if (recording) recording.push(name);
+            return original(...args);
+          };
+        }
+
+        const Comp = styled.View<{ $pad: number }>`
+          padding: ${p => p.$pad}px;
+          opacity: ${() => React.useContext(Ctx)};
+        `;
+
+        const [wrapper, mount] = record(() =>
+          TestRenderer.create(
+            <Ctx.Provider value="0.5">
+              <Comp $pad={1} />
+            </Ctx.Provider>
+          )
+        );
+        const [, cacheHit] = record(() =>
+          wrapper.update(
+            <Ctx.Provider value="0.5">
+              <Comp $pad={1} />
+            </Ctx.Provider>
+          )
+        );
+
+        expect(mount).toContain('useContext');
+        expect(cacheHit).toEqual(mount);
+
+        wrapper.unmount();
+      } finally {
+        for (const [name, original] of originals) reactHooks[name] = original;
+      }
+    });
+
+    it('recomputes when an interpolation reads external state that changed but props did not', () => {
+      let external = 'red';
+      const Comp = styled.View<{ $pad: number }>`
+        padding: ${p => p.$pad}px;
+        color: ${() => external};
+      `;
+
+      const padding = { paddingBottom: 1, paddingLeft: 1, paddingRight: 1, paddingTop: 1 };
+      const wrapper = TestRenderer.create(<Comp $pad={1} />);
+      expect(wrapper.root.findByType(View).props.style).toEqual({ color: 'red', ...padding });
+
+      external = 'blue';
+      // Same props: the former cache would hit and return the stale red style.
+      wrapper.update(<Comp $pad={1} />);
+      expect(wrapper.root.findByType(View).props.style).toEqual({ color: 'blue', ...padding });
+
+      wrapper.unmount();
+    });
+  });
 });

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -3,6 +3,7 @@ import { Image, Text, View, ViewProps } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import styled, { ThemeProvider, css, toStyleSheet } from '../';
 import { RN_UNSUPPORTED_VALUES } from '../../models/InlineStyle';
+import { withHookRecording } from '../../test/recordHooks';
 
 // NOTE: These tests are like the ones for Web but a "light-version" of them
 // This is mostly due to the similar logic
@@ -595,40 +596,14 @@ describe('native', () => {
     });
   });
 
-  // Mirrors the web coverage in src/test/memoization.test.tsx: skipping style
-  // evaluation on an unchanged-props re-render would drop a hook called inside an
-  // interpolation and serve a stale style object (#5788).
+  // Mirrors the web coverage in src/test/memoization.test.tsx: an interpolation,
+  // and any hook it calls or external value it reads, runs on every render and is
+  // not skipped on an unchanged-props re-render (#5788).
   describe('interpolation evaluation on every render (#5788)', () => {
     it('runs a hook called inside an interpolation on every render', () => {
-      const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
       const Ctx = React.createContext('0.5');
-      const hookNames = Object.keys(React).filter(
-        key => key.startsWith('use') && typeof reactHooks[key] === 'function'
-      );
 
-      let recording: string[] | null = null;
-      const originals = new Map<string, (...args: unknown[]) => unknown>();
-
-      function record<T>(render: () => T): [T, string[]] {
-        const calls: string[] = [];
-        recording = calls;
-        try {
-          return [render(), calls];
-        } finally {
-          recording = null;
-        }
-      }
-
-      try {
-        for (const name of hookNames) {
-          const original = reactHooks[name];
-          originals.set(name, original);
-          reactHooks[name] = (...args) => {
-            if (recording) recording.push(name);
-            return original(...args);
-          };
-        }
-
+      withHookRecording(record => {
         const Comp = styled.View<{ $pad: number }>`
           padding: ${p => p.$pad}px;
           opacity: ${() => React.useContext(Ctx)};
@@ -641,7 +616,8 @@ describe('native', () => {
             </Ctx.Provider>
           )
         );
-        const [, cacheHit] = record(() =>
+        // Same props: the interpolation, and the useContext it calls, still run.
+        const [, reRender] = record(() =>
           wrapper.update(
             <Ctx.Provider value="0.5">
               <Comp $pad={1} />
@@ -650,12 +626,10 @@ describe('native', () => {
         );
 
         expect(mount).toContain('useContext');
-        expect(cacheHit).toEqual(mount);
+        expect(reRender).toEqual(mount);
 
         wrapper.unmount();
-      } finally {
-        for (const [name, original] of originals) reactHooks[name] = original;
-      }
+      });
     });
 
     it('recomputes when an interpolation reads external state that changed but props did not', () => {
@@ -670,7 +644,7 @@ describe('native', () => {
       expect(wrapper.root.findByType(View).props.style).toEqual({ color: 'red', ...padding });
 
       external = 'blue';
-      // Same props: the former cache would hit and return the stale red style.
+      // Same props, but the interpolation's external input changed.
       wrapper.update(<Comp $pad={1} />);
       expect(wrapper.root.findByType(View).props.style).toEqual({ color: 'blue', ...padding });
 

--- a/packages/styled-components/src/test/hmr-createTheme.test.tsx
+++ b/packages/styled-components/src/test/hmr-createTheme.test.tsx
@@ -239,10 +239,9 @@ describe('HMR + createTheme interaction', () => {
     expect(css).toContain('var(--v2-color, red)');
   });
 
-  it('render cache busts when ComponentStyle instance changes (HMR invalidation)', () => {
-    // The render cache tuple stores componentStyle at index [7].
-    // On HMR, styled() creates a new ComponentStyle, so prev[7] !== componentStyle.
-    // This forces re-computation even if props/theme are identical.
+  it('HMR with a new ComponentStyle for identical CSS keeps the same class name', () => {
+    // On HMR, styled() creates a new ComponentStyle instance. Identical CSS must
+    // still hash to the same class name so a hot reload does not churn classes.
     const themeV1 = createTheme({ gap: '8px' });
     const CompV1 = styled.div.withConfig({ componentId: 'sc-hmr-rendercache' })`
       gap: ${themeV1.gap};
@@ -250,11 +249,10 @@ describe('HMR + createTheme interaction', () => {
 
     const { container, rerender } = render(<CompV1 />);
 
-    // Re-render with SAME props - should be a cache hit
     rerender(<CompV1 />);
-    const classAfterCacheHit = container.firstElementChild!.className;
+    const classBefore = container.firstElementChild!.className;
 
-    // Now simulate HMR: new ComponentStyle instance, same CSS
+    // Simulate HMR: a new ComponentStyle instance producing the same CSS.
     const themeV1Copy = createTheme({ gap: '8px' });
     const CompV1Reval = styled.div.withConfig({ componentId: 'sc-hmr-rendercache' })`
       gap: ${themeV1Copy.gap};
@@ -263,8 +261,8 @@ describe('HMR + createTheme interaction', () => {
     rerender(<CompV1Reval />);
     const classAfterHmr = container.firstElementChild!.className;
 
-    // Same CSS -> same generated class name, even though cache was busted
-    expect(classAfterHmr).toBe(classAfterCacheHit);
+    // Same CSS -> same generated class name across the instance swap.
+    expect(classAfterHmr).toBe(classBefore);
   });
 
   it('vars property reflects theme structure changes across HMR', () => {

--- a/packages/styled-components/src/test/memoization.test.tsx
+++ b/packages/styled-components/src/test/memoization.test.tsx
@@ -1,13 +1,12 @@
 /**
- * Tests for the styled component render cache.
- *
- * Verifies that the useRef-based shallow context comparison correctly
- * caches and invalidates under various scenarios, and that the cache's
- * hit/miss branch does not change the component's hook sequence.
+ * Tests for styled component render behavior: class-name stability across
+ * re-renders, and the rules-of-hooks guarantee that interpolations, and any
+ * hooks they call, run on every render (#5788).
  */
 import React, { useState } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import { LIMIT as TOO_MANY_CLASSES_LIMIT } from '../utils/createWarnTooManyClasses';
+import { withHookRecording } from './recordHooks';
 import { getCSS, resetStyled } from './utils';
 
 let styled: ReturnType<typeof resetStyled>;
@@ -359,76 +358,31 @@ describe('memoization correctness', () => {
   });
 
   /**
-   * The render cache splits the render path in two, and only one side runs the
-   * style work. Any hook that ends up on one side of that split is called on a
-   * cache miss and skipped on a cache hit, so the component emits a different
-   * hook sequence depending on whether its props happened to change -- exactly
-   * the shape React rejects with "Rendered fewer hooks than expected" (#5788).
-   *
-   * Asserting the sequence rather than a count: a swap of two hooks keeps the
-   * count identical and still breaks React's ordering rule. The recording is
-   * done by wrapping React's own `use*` exports, so a hook added to the render
-   * path in future is picked up without this test being told about it.
+   * A styled component must emit the same hook sequence on every render.
+   * Recording React's `use*` calls across a mount, a same-props re-render, and a
+   * changed-props re-render and asserting all three match catches a hook that
+   * runs on one render but not another, the shape React rejects with "Rendered
+   * fewer hooks than expected" (#5788). Asserting the sequence, not a count,
+   * also catches a swap of two hooks that keeps the count identical.
    */
-  it('emits an identical hook sequence on cache-hit and cache-miss renders', () => {
-    // React's module namespace, typed as what it is here: a bag of hook
-    // functions keyed by name. Spelling it once keeps the casts out of the body.
-    const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
-    const hookNames = Object.keys(React).filter(
-      key => key.startsWith('use') && typeof reactHooks[key] === 'function'
-    );
-    // Positive control: if the wrapping ever stops seeing React's hooks, every
-    // sequence below is trivially empty and the comparison passes vacuously.
-    expect(hookNames).toContain('useRef');
-
-    let recording: string[] | null = null;
-    // Restored in `finally`, which the install loop is inside: a throw partway
-    // through installation must not leave React half-patched for later tests.
-    const originals = new Map<string, (...args: unknown[]) => unknown>();
-
-    // Returns what the render produced alongside the hooks it called, so the
-    // renderer needs no `let` declared ahead of its assignment.
-    function record<T>(render: () => T): [T, string[]] {
-      const calls: string[] = [];
-      recording = calls;
-      try {
-        return [render(), calls];
-      } finally {
-        // Cleared even when the render throws, so a later render cannot append
-        // to a dead array and turn one failure into a confusing second one.
-        recording = null;
-      }
-    }
-
-    try {
-      for (const name of hookNames) {
-        const original = reactHooks[name];
-        originals.set(name, original);
-        reactHooks[name] = (...args) => {
-          if (recording) recording.push(name);
-          return original(...args);
-        };
-      }
-
+  it('emits an identical hook sequence across re-renders', () => {
+    withHookRecording(record => {
       const Comp = styled.div<{ $color: string }>`
         color: ${p => p.$color};
       `;
 
       // Rendered as the root so every recorded hook belongs to this component.
       const [renderer, mount] = record(() => TestRenderer.create(<Comp $color="red" />));
-      // Identical props: the render cache hits and skips the style work.
-      const [, cacheHit] = record(() => renderer.update(<Comp $color="red" />));
-      // Changed props: the cache misses and the style work runs again.
-      const [, cacheMiss] = record(() => renderer.update(<Comp $color="blue" />));
+      const [, sameProps] = record(() => renderer.update(<Comp $color="red" />));
+      const [, changedProps] = record(() => renderer.update(<Comp $color="blue" />));
 
+      // A non-empty mount doubles as a positive control on the recording.
       expect(mount.length).toBeGreaterThan(0);
-      expect(cacheHit).toEqual(cacheMiss);
-      expect(mount).toEqual(cacheHit);
+      expect(sameProps).toEqual(changedProps);
+      expect(mount).toEqual(sameProps);
 
       renderer.unmount();
-    } finally {
-      for (const [name, original] of originals) reactHooks[name] = original;
-    }
+    });
   });
 
   /**
@@ -440,50 +394,23 @@ describe('memoization correctness', () => {
    * + MUI X DataGrid, which calls useGridSelector -> useContext in an interpolation).
    */
   it('runs a hook called inside an interpolation on every render (#5788)', () => {
-    const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
     const Ctx = React.createContext('red');
-    const hookNames = Object.keys(React).filter(
-      key => key.startsWith('use') && typeof reactHooks[key] === 'function'
-    );
 
-    let recording: string[] | null = null;
-    const originals = new Map<string, (...args: unknown[]) => unknown>();
-
-    function record<T>(render: () => T): [T, string[]] {
-      const calls: string[] = [];
-      recording = calls;
-      try {
-        return [render(), calls];
-      } finally {
-        recording = null;
-      }
-    }
-
-    try {
-      for (const name of hookNames) {
-        const original = reactHooks[name];
-        originals.set(name, original);
-        reactHooks[name] = (...args) => {
-          if (recording) recording.push(name);
-          return original(...args);
-        };
-      }
-
+    withHookRecording(record => {
       const Comp = styled.div<{ $pad: number }>`
         padding: ${p => p.$pad}px;
         color: ${() => React.useContext(Ctx)};
       `;
 
-      const tree = (
-        <Ctx.Provider value="red">
-          <Comp $pad={1} />
-        </Ctx.Provider>
+      const [renderer, mount] = record(() =>
+        TestRenderer.create(
+          <Ctx.Provider value="red">
+            <Comp $pad={1} />
+          </Ctx.Provider>
+        )
       );
-
-      const [renderer, mount] = record(() => TestRenderer.create(tree));
-      // Identical props: previously a cache hit that skipped the interpolation,
-      // dropping its useContext call and shortening the hook sequence.
-      const [, cacheHit] = record(() =>
+      // Same props: the interpolation, and the useContext it calls, still run.
+      const [, reRender] = record(() =>
         renderer.update(
           <Ctx.Provider value="red">
             <Comp $pad={1} />
@@ -492,19 +419,16 @@ describe('memoization correctness', () => {
       );
 
       expect(mount).toContain('useContext');
-      expect(cacheHit).toEqual(mount);
+      expect(reRender).toEqual(mount);
 
       renderer.unmount();
-    } finally {
-      for (const [name, original] of originals) reactHooks[name] = original;
-    }
+    });
   });
 
   /**
-   * An interpolation may read inputs the (props + theme) cache key does not
-   * capture. Reusing a cached class name when such a hidden input changed serves
-   * a stale style: the class name must track the interpolation's real output,
-   * not the props alone (#5788).
+   * An interpolation may read inputs that props and theme do not capture. The
+   * class name must track the interpolation's real output, so a change to such a
+   * hidden input updates the class even when props are unchanged (#5788).
    */
   it('recomputes when an interpolation reads external state that changed but props did not (#5788)', () => {
     let external = 'red';
@@ -517,7 +441,7 @@ describe('memoization correctness', () => {
     const withRed = renderer.root.findByType('div').props.className;
 
     external = 'blue';
-    // Same props: the former cache would hit and return the stale red class name.
+    // Same props, but the interpolation's external input changed.
     renderer.update(<Comp $pad={1} />);
     const withBlue = renderer.root.findByType('div').props.className;
 

--- a/packages/styled-components/src/test/memoization.test.tsx
+++ b/packages/styled-components/src/test/memoization.test.tsx
@@ -430,4 +430,99 @@ describe('memoization correctness', () => {
       for (const [name, original] of originals) reactHooks[name] = original;
     }
   });
+
+  /**
+   * A hook called inside an interpolation is one of this component's own hooks:
+   * it runs synchronously in the styled component's render body. Skipping the
+   * interpolation on a re-render with unchanged props drops that hook, so the
+   * component emits fewer hooks than the previous render and React crashes with
+   * "Rendered fewer hooks than expected" (#5788, as seen with @mui/styled-engine-sc
+   * + MUI X DataGrid, which calls useGridSelector -> useContext in an interpolation).
+   */
+  it('runs a hook called inside an interpolation on every render (#5788)', () => {
+    const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
+    const Ctx = React.createContext('red');
+    const hookNames = Object.keys(React).filter(
+      key => key.startsWith('use') && typeof reactHooks[key] === 'function'
+    );
+
+    let recording: string[] | null = null;
+    const originals = new Map<string, (...args: unknown[]) => unknown>();
+
+    function record<T>(render: () => T): [T, string[]] {
+      const calls: string[] = [];
+      recording = calls;
+      try {
+        return [render(), calls];
+      } finally {
+        recording = null;
+      }
+    }
+
+    try {
+      for (const name of hookNames) {
+        const original = reactHooks[name];
+        originals.set(name, original);
+        reactHooks[name] = (...args) => {
+          if (recording) recording.push(name);
+          return original(...args);
+        };
+      }
+
+      const Comp = styled.div<{ $pad: number }>`
+        padding: ${p => p.$pad}px;
+        color: ${() => React.useContext(Ctx)};
+      `;
+
+      const tree = (
+        <Ctx.Provider value="red">
+          <Comp $pad={1} />
+        </Ctx.Provider>
+      );
+
+      const [renderer, mount] = record(() => TestRenderer.create(tree));
+      // Identical props: previously a cache hit that skipped the interpolation,
+      // dropping its useContext call and shortening the hook sequence.
+      const [, cacheHit] = record(() =>
+        renderer.update(
+          <Ctx.Provider value="red">
+            <Comp $pad={1} />
+          </Ctx.Provider>
+        )
+      );
+
+      expect(mount).toContain('useContext');
+      expect(cacheHit).toEqual(mount);
+
+      renderer.unmount();
+    } finally {
+      for (const [name, original] of originals) reactHooks[name] = original;
+    }
+  });
+
+  /**
+   * An interpolation may read inputs the (props + theme) cache key does not
+   * capture. Reusing a cached class name when such a hidden input changed serves
+   * a stale style: the class name must track the interpolation's real output,
+   * not the props alone (#5788).
+   */
+  it('recomputes when an interpolation reads external state that changed but props did not (#5788)', () => {
+    let external = 'red';
+    const Comp = styled.div<{ $pad: number }>`
+      padding: ${p => p.$pad}px;
+      color: ${() => external};
+    `;
+
+    const renderer = TestRenderer.create(<Comp $pad={1} />);
+    const withRed = renderer.root.findByType('div').props.className;
+
+    external = 'blue';
+    // Same props: the former cache would hit and return the stale red class name.
+    renderer.update(<Comp $pad={1} />);
+    const withBlue = renderer.root.findByType('div').props.className;
+
+    expect(withBlue).not.toBe(withRed);
+
+    renderer.unmount();
+  });
 });

--- a/packages/styled-components/src/test/recordHooks.ts
+++ b/packages/styled-components/src/test/recordHooks.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+
+/**
+ * React's module namespace, typed as what it is here: a bag of hook functions
+ * keyed by name. Spelling the cast once keeps it out of every caller.
+ */
+const reactHooks = React as unknown as Record<string, (...args: unknown[]) => unknown>;
+
+/**
+ * Run `body` with every React `use*` export wrapped so each hook call is
+ * recorded. `body` receives a `record` that returns what a render produced
+ * alongside the ordered names of the hooks that render called.
+ *
+ * Names come from React's own namespace, so a hook added to the render path is
+ * picked up without this helper being told about it. Originals are restored in a
+ * `finally`, so a render that throws cannot leave React patched for later tests.
+ * A caller asserting the recorded sequence is non-empty doubles as a positive
+ * control: if wrapping ever stops seeing hooks, that assertion fails rather than
+ * every sequence comparing equal because all are empty.
+ */
+export function withHookRecording<T>(
+  body: (record: <R>(render: () => R) => [R, string[]]) => T
+): T {
+  const hookNames = Object.keys(React).filter(
+    key => key.startsWith('use') && typeof reactHooks[key] === 'function'
+  );
+  const originals = new Map<string, (...args: unknown[]) => unknown>();
+  let recording: string[] | null = null;
+
+  function record<R>(render: () => R): [R, string[]] {
+    const calls: string[] = [];
+    recording = calls;
+    try {
+      return [render(), calls];
+    } finally {
+      recording = null;
+    }
+  }
+
+  try {
+    for (const name of hookNames) {
+      const original = reactHooks[name];
+      originals.set(name, original);
+      reactHooks[name] = (...args) => {
+        if (recording) recording.push(name);
+        return original(...args);
+      };
+    }
+    return body(record);
+  } finally {
+    for (const [name, original] of originals) reactHooks[name] = original;
+  }
+}


### PR DESCRIPTION
Fixes #5788.

Upgrading past 6.3.12 crashed any component that calls a React hook, or reads a value outside its props and theme, from inside a style interpolation, with "Rendered fewer hooks than expected", in both development and production. `@mui/styled-engine-sc` with MUI X DataGrid hit this on mount. The same components could also render with stale styles. It was a regression introduced in 6.4.0.

## What changes

- Style interpolations run on every render again, so a hook called inside one runs consistently and a value read inside one always reflects its current state. The crash and the stale styles are both fixed, on the web and on React Native.
- If a component re-renders often with unchanged props and its interpolations are expensive, wrap it in `React.memo` to skip those re-renders.
- React Native styling is faster across first render, re-render, and long lists, and two distinct styles can no longer collide onto one another's cached result.

Thanks to @stuaylward for the clear report and the version bisect that pinned the regression.

The same fix applies to v7 on `main`; I'll open that separately.
