### PR TITLE
fix: keep server-rendered styles through Suspense boundary reveals (#5808)

### DIFF
--- a/.changeset/rsc-suspense-style-removal.md
+++ b/.changeset/rsc-suspense-style-removal.md
@@ -1,0 +1,7 @@
+---
+"styled-components": patch
+---
+
+Fixed styles disappearing from a server-rendered component when it is revealed from behind a React `<Suspense>` boundary, such as a streaming Next.js route (including `cacheComponents`). A component shown first in a Suspense fallback and then in the resolved content kept its class name but lost its CSS, because the rule had been emitted only inside the fallback that React discards on reveal.
+
+Each server-rendered instance now carries its own inline `<style>`, so its styles always travel with it and survive the boundary. Identical rules compress away under gzip, so the extra output is negligible; only a very large repeated list (thousands of instances of one component on a single page) is worth collapsing into a shared class, and a development-only warning points that out if it happens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ mapped below.
 - `pnpm --filter styled-components bench` -- Run all benchmarks (web + native + RSC)
 - `pnpm --filter styled-components bench:web` -- Run web benchmarks
 - `pnpm --filter styled-components bench:native` -- Run native benchmarks (parser + render)
-- `pnpm --filter styled-components bench:rsc` -- Run RSC benchmarks (renderToString + dedup + React baseline)
+- `pnpm --filter styled-components bench:rsc` -- Run RSC benchmarks (renderToString + per-instance emission + React baseline)
 - `pnpm test:prerelease-notes` -- Regenerate prerelease GitHub release-note markdown locally (set `GITHUB_REPOSITORY=owner/name`; optional `CHANGESET_NOTES_ROOT`, `RELEASE_NOTES_OUTDIR`)
 
 ## Specifications
@@ -89,7 +89,7 @@ it rather than restating it.
 - [docs/global-styles.md](docs/global-styles.md) -- `createGlobalStyle`'s shared-group architecture,
   instance lifecycle, rebuild fast path
 - [docs/rsc-style-injection.md](docs/rsc-style-injection.md) -- how styles reach the page from server
-  components, dedup, `:where()` wrapping, `stylisPluginRSC`
+  components, per-instance emission, `:where()` wrapping, `stylisPluginRSC`
 - [docs/create-theme.md](docs/create-theme.md) -- the `createTheme` CSS-variable contract
 - [docs/attrs.md](docs/attrs.md) -- `attrs` precedence and its escape hatches
 - [docs/type-contracts.md](docs/type-contracts.md) -- how the compile-only type suites are written and

--- a/docs/rsc-style-injection.md
+++ b/docs/rsc-style-injection.md
@@ -31,8 +31,8 @@ the leaf class from `generateAndInjectStyles` plus each `:where()`-wrapped base 
 per name from the compiled cache (`getCompiledCSSForName`), so emission is O(chain length) per
 instance rather than re-scanning a component's whole accumulated variant group. Compiled CSS is cached
 on `ComponentStyle` and `Keyframes` through a `WeakMap`, which is dead-code eliminated in the browser
-build; a cache miss (a name rehydrated from SSR markup) falls back to slicing the level's tag group by
-the render's names.
+build. Every name reaching emission was compiled by `generateAndInjectStyles` before it registered its
+class, so the per-name lookup always hits; there is no tag-group fallback.
 
 There is deliberately no cross-instance or cross-request deduplication. A request-scoped `React.cache`
 Set was tried and removed: `React.cache` is request-wide with no per-Suspense-boundary scope, so a
@@ -46,7 +46,7 @@ tags compress to ~0.5% of their raw size), so per-instance emission is the minim
 
 Keyframes are emitted per instance too, scoped to the render by matching each keyframe group's
 resolved name against the render's CSS. A referenced keyframe's rules are concatenated ahead of the
-component CSS in the *same* `<style>` tag: a styled component renders at most one style element, as
+component CSS in the _same_ `<style>` tag: a styled component renders at most one style element, as
 `Fragment(styleElement, element)`.
 
 A development-only warning fires once a single component emits `RSC_REDUNDANT_EMIT_WARN_THRESHOLD`
@@ -92,7 +92,7 @@ Object.defineProperty` to keep a stable `.name` after minification. It does two 
 **Child-index pseudo-selectors.** `:first-child`, `:last-child`, `:only-child`, `:nth-child()` and
 `:nth-last-child()` are rewritten with CSS Selectors Level 4 `of S` syntax to exclude
 `style[data-styled]` from the count. `:only-child` becomes the conjunction of a first and a last test.
-An `:nth-child()`/`:nth-last-child()` that already carries its own ` of ` clause is left alone rather
+An `:nth-child()`/`:nth-last-child()` that already carries its own `of` clause is left alone rather
 than double-wrapped. This is a precise, spec-level fix, and it requires browser support for `of S`
 (Chrome 111+, Firefox 113+, Safari 9+).
 

--- a/docs/rsc-style-injection.md
+++ b/docs/rsc-style-injection.md
@@ -10,7 +10,11 @@ Server component output is not hydrated by React, so an inline tag causes no hyd
 which never runs over RSC output.
 
 Inline body styles land after the registry's `<head>` styles in source order, so a cross-boundary
-extension (an RSC component extending a client component) wins the cascade.
+extension (an RSC component extending a client component) wins the cascade. This source-order
+placement is load-bearing and is why styles are not hoisted to `<head>` via `precedence`: the server
+never sees a client component's base class, so it cannot make the extension win by specificity, and
+`precedence` buckets order the RSC render ahead of the client registry, which would flip the cascade
+(#5672). The child-index selector plugin below likewise depends on the tag staying an inline sibling.
 
 No cleanup of RSC style tags is needed: they are the sole source of CSS for server-only components.
 
@@ -20,20 +24,35 @@ Base-level CSS in an inheritance chain is wrapped in `:where()` for zero specifi
 duplicate base CSS from sibling extensions sharing a base would override an earlier extension's
 styles.
 
-## Deduplication
+## Per-instance emission
 
-Inline `<style>` tags are deduplicated per render through name-based tracking in a `React.cache`-scoped
-Set. A dedup hit skips CSS collection entirely: no `getGroup`, no `:where()` wrapping. A dynamic
-component with several variants therefore emits CSS only for new names rather than for the full
-accumulated group. Compiled CSS is cached on `ComponentStyle` and `Keyframes` through a `WeakMap`,
-which persists across `React.cache` resets and is dead-code eliminated in the browser build.
+Each server-rendered instance emits its own inline `<style>` holding exactly that render's classes:
+the leaf class from `generateAndInjectStyles` plus each `:where()`-wrapped base level. Rules are read
+per name from the compiled cache (`getCompiledCSSForName`), so emission is O(chain length) per
+instance rather than re-scanning a component's whole accumulated variant group. Compiled CSS is cached
+on `ComponentStyle` and `Keyframes` through a `WeakMap`, which is dead-code eliminated in the browser
+build; a cache miss (a name rehydrated from SSR markup) falls back to slicing the level's tag group by
+the render's names.
 
-Keyframe rules are deduplicated separately, by keyframe ID rather than by class name, against the same
-per-render Set. On this branch they are concatenated ahead of the component CSS and emitted in the
-*same* `<style>` tag: a styled component renders at most one style element, as
-`Fragment(styleElement, element)`. Dedup survives the concatenation because each keyframe ID is
-recorded as it is emitted, so a keyframe already written this render contributes nothing to the next
-component's string.
+There is deliberately no cross-instance or cross-request deduplication. A request-scoped `React.cache`
+Set was tried and removed: `React.cache` is request-wide with no per-Suspense-boundary scope, so a
+rule emitted only inside a Suspense fallback was recorded once, skipped for the resolved child, then
+removed with the fallback when React revealed the boundary, leaving the resolved element with a class
+but no rule (#5808). The alternatives were ruled out by their costs, not overlooked: hoisting via
+`precedence` would dedup and survive the reveal but breaks #5672 and the child-index plugin (see
+above); no per-boundary cache scope exists to make a ledger safe. Byte-identical duplicates are the
+only output dedup ever collapsed, and they cost about a byte each after gzip (measured: 1000 identical
+tags compress to ~0.5% of their raw size), so per-instance emission is the minimal correct behavior.
+
+Keyframes are emitted per instance too, scoped to the render by matching each keyframe group's
+resolved name against the render's CSS. A referenced keyframe's rules are concatenated ahead of the
+component CSS in the *same* `<style>` tag: a styled component renders at most one style element, as
+`Fragment(styleElement, element)`.
+
+A development-only warning fires once a single component emits `RSC_REDUNDANT_EMIT_WARN_THRESHOLD`
+(1000) tags in one render, the point at which a very large repeated list should share one className
+instead. The counter is `React.cache`-scoped and gated on `NODE_ENV`, so production drops both the
+warning and its bookkeeping.
 
 ## Per-render reset
 

--- a/packages/sandbox/app/components/sidebar.tsx
+++ b/packages/sandbox/app/components/sidebar.tsx
@@ -11,6 +11,7 @@ const sections = [
     title: 'Tests',
     items: [
       { href: '/rsc', label: 'RSC' },
+      { href: '/suspense-5808', label: 'Suspense (#5808)' },
       { href: '/client-example', label: 'Client Components' },
       { href: '/global-style-test', label: 'Global Styles' },
     ],

--- a/packages/sandbox/app/suspense-5808/page.tsx
+++ b/packages/sandbox/app/suspense-5808/page.tsx
@@ -1,0 +1,85 @@
+import { Suspense } from 'react';
+import styled from 'styled-components';
+import { SectionDesc } from '../components/test-ui';
+import theme from '../lib/theme';
+
+/**
+ * Repro for #5808: an inline <style> tag emitted while rendering a Suspense
+ * fallback is deduped away when the resolved content renders the same styled
+ * component, then React discards the fallback subtree (and its <style>),
+ * leaving the resolved element with a class but no matching rule.
+ *
+ * SharedPanel appears ONLY inside the Suspense subtree, in both the fallback
+ * and the resolved child, so the fallback is the first (and only) emitter of
+ * its rule. AlwaysPanel lives in the static shell as a control: its styling
+ * must survive, proving the pipeline itself works.
+ */
+
+async function SlowContent() {
+  await new Promise(resolve => setTimeout(resolve, 1500));
+  return (
+    <SharedPanel data-testid="resolved-panel">
+      Resolved content. This panel must stay crimson after the fallback swaps
+      out. If it renders unstyled (white), #5808 has regressed: its rule reached
+      the DOM only inside the discarded fallback.
+    </SharedPanel>
+  );
+}
+
+export default function Suspense5808Page() {
+  return (
+    <Wrapper>
+      <Heading>#5808 Suspense inline &lt;style&gt; removal</Heading>
+
+      <SectionDesc>
+        The blue control panel lives in the static shell and proves the pipeline works. The panel
+        below streams in behind Suspense and is the actual test: it must be crimson once it replaces
+        the fallback. A white (unstyled) panel means #5808 has regressed.
+      </SectionDesc>
+
+      <AlwaysPanel data-testid="control-panel">
+        Control panel (static shell). Always blue.
+      </AlwaysPanel>
+
+      <Suspense
+        fallback={
+          <SharedPanel data-testid="fallback-panel">Loading… (fallback, crimson)</SharedPanel>
+        }
+      >
+        <SlowContent />
+      </Suspense>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const Heading = styled.h1`
+  font-size: 24px;
+  color: ${theme.colors.text};
+`;
+
+/** Rendered in the static shell; emits its own rule that is never discarded. */
+const AlwaysPanel = styled.div`
+  padding: 24px;
+  border-radius: 8px;
+  color: white;
+  font-size: 16px;
+  background-color: rgb(37, 99, 235);
+`;
+
+/** Rendered ONLY inside the Suspense subtree (fallback + resolved child). */
+const SharedPanel = styled.div`
+  padding: 24px;
+  border-radius: 8px;
+  color: white;
+  font-size: 16px;
+  background-color: rgb(220, 20, 60);
+`;

--- a/packages/styled-components/src/bench/rsc.test.tsx
+++ b/packages/styled-components/src/bench/rsc.test.tsx
@@ -4,8 +4,8 @@
  * Run: pnpm --filter styled-components bench:rsc
  *
  * Measures server-side renderToString performance with IS_RSC=true,
- * including inline style tag emission, dedup, :where() wrapping,
- * and keyframe handling.
+ * including inline style tag emission, per-instance emission of repeated
+ * components, :where() wrapping, and keyframe handling.
  */
 
 // Mock React.cache - scoped per render via manual clear
@@ -163,8 +163,8 @@ describe('RSC benchmarks', () => {
     });
   });
 
-  it('dedup efficiency', () => {
-    console.log('\n--- Dedup (1K iterations, median of 5) ---');
+  it('repeated-component emission efficiency', () => {
+    console.log('\n--- Repeated-component emission (1K iterations, median of 5) ---');
 
     const Item = styled.div`
       color: red;

--- a/packages/styled-components/src/constructors/test/styled.rsc.test.tsx
+++ b/packages/styled-components/src/constructors/test/styled.rsc.test.tsx
@@ -211,7 +211,7 @@ describe('styled RSC mode', () => {
 
       // Avatar's base styles and LargeAvatar's own styles
       expect(allCSS).toMatchInlineSnapshot(
-        `".gA-dcpr{width:48px;height:48px;border-radius:50%;object-fit:cover;}.bmhOVL{width:96px;height:96px;border:3px solid #fff;}"`
+        `".gA-dcpr{width:48px;height:48px;border-radius:50%;object-fit:cover;}:where(.gA-dcpr){width:48px;height:48px;border-radius:50%;object-fit:cover;}.bmhOVL{width:96px;height:96px;border:3px solid #fff;}"`
       );
     });
 
@@ -238,7 +238,7 @@ describe('styled RSC mode', () => {
       // All CSS should be present
       const allCSS = extractStyleContents(html);
       expect(allCSS).toMatchInlineSnapshot(
-        `".lluOde{display:flex;padding:16px;}.inzFhn{color:red;}"`
+        `".lluOde{display:flex;padding:16px;}:where(.lluOde){display:flex;padding:16px;}.inzFhn{color:red;}"`
       );
     });
 
@@ -269,7 +269,7 @@ describe('styled RSC mode', () => {
 
       // Base styles and each variant's own styles
       expect(allCSS).toMatchInlineSnapshot(
-        `":where(.jZzqsQ){padding:8px 16px;border:none;border-radius:4px;cursor:pointer;font-size:14px;}.dqxjmS{background:#007bff;color:#fff;}.gffCwu{background:#dc3545;color:#fff;}"`
+        `":where(.jZzqsQ){padding:8px 16px;border:none;border-radius:4px;cursor:pointer;font-size:14px;}.dqxjmS{background:#007bff;color:#fff;}:where(.jZzqsQ){padding:8px 16px;border:none;border-radius:4px;cursor:pointer;font-size:14px;}.gffCwu{background:#dc3545;color:#fff;}"`
       );
     });
 
@@ -295,7 +295,7 @@ describe('styled RSC mode', () => {
 
       // Both dynamic variants must be present
       expect(allCSS).toMatchInlineSnapshot(
-        `":where(.UggJu){background:red;padding:16px;}.gMmhUh{border:1px solid #ccc;}:where(.ezOOCn){background:blue;padding:16px;}"`
+        `":where(.UggJu){background:red;padding:16px;}.gMmhUh{border:1px solid #ccc;}:where(.ezOOCn){background:blue;padding:16px;}.gMmhUh{border:1px solid #ccc;}"`
       );
     });
   });
@@ -483,7 +483,7 @@ describe('styled RSC mode', () => {
 
       assertValidWhereSelectors(allCSS);
       expect(allCSS).toMatchInlineSnapshot(
-        `":where(.YKVKw){color:red;}.bYbnUR{font-size:16px;}:where(.jDUPMZ){color:blue;}"`
+        `":where(.YKVKw){color:red;}.bYbnUR{font-size:16px;}:where(.jDUPMZ){color:blue;}.bYbnUR{font-size:16px;}"`
       );
     });
 
@@ -509,7 +509,7 @@ describe('styled RSC mode', () => {
       const allCSS = extractStyleContents(html);
 
       expect(allCSS).toMatchInlineSnapshot(
-        `":where(.bHuNuc){display:flex;padding:16px;background:white;}.fDRrJU{background:red;}.hpcalM{background:blue;}"`
+        `":where(.bHuNuc){display:flex;padding:16px;background:white;}.fDRrJU{background:red;}:where(.bHuNuc){display:flex;padding:16px;background:white;}.hpcalM{background:blue;}"`
       );
       // Both extension selectors must NOT be wrapped
       expect(allCSS).not.toMatch(/:where\(\.\w+\)\{[^}]*background:red/);
@@ -1174,8 +1174,12 @@ describe('styled RSC mode', () => {
     });
   });
 
-  describe('RSC style tag deduplication', () => {
-    it('should emit only one style tag for multiple instances of the same static component', () => {
+  describe('RSC per-instance style emission', () => {
+    // Each server-rendered instance emits its own inline <style> so a rule is
+    // never left recorded-but-absent when React discards a Suspense fallback
+    // that emitted it (#5808). Byte-identical duplicates compress away under
+    // gzip; they are not merged in the DOM.
+    it('should emit a style tag for each instance of the same static component', () => {
       const Button = styled.button`
         padding: 8px;
         color: blue;
@@ -1191,13 +1195,13 @@ describe('styled RSC mode', () => {
         </div>
       );
 
-      expect(countStyleTags(html)).toBe(1);
+      expect(countStyleTags(html)).toBe(5);
       expect(extractStyleContents(html)).toMatchInlineSnapshot(
-        `".iIYYsP{padding:8px;color:blue;}"`
+        `".iIYYsP{padding:8px;color:blue;}.iIYYsP{padding:8px;color:blue;}.iIYYsP{padding:8px;color:blue;}.iIYYsP{padding:8px;color:blue;}.iIYYsP{padding:8px;color:blue;}"`
       );
     });
 
-    it('should emit only one style tag for dynamic components with identical props', () => {
+    it('should emit a style tag per instance for dynamic components with identical props', () => {
       const Box = styled.div<{ $color: string }>`
         color: ${p => p.$color};
       `;
@@ -1210,8 +1214,10 @@ describe('styled RSC mode', () => {
         </div>
       );
 
-      expect(countStyleTags(html)).toBe(1);
-      expect(extractStyleContents(html)).toMatchInlineSnapshot(`".YKVKw{color:red;}"`);
+      expect(countStyleTags(html)).toBe(3);
+      expect(extractStyleContents(html)).toMatchInlineSnapshot(
+        `".YKVKw{color:red;}.YKVKw{color:red;}.YKVKw{color:red;}"`
+      );
     });
 
     it('should emit separate style tags for dynamic components with different props', () => {
@@ -1234,7 +1240,7 @@ describe('styled RSC mode', () => {
       );
     });
 
-    it('should deduplicate across multiple instances of extended component', () => {
+    it('should emit a tag per instance of an extended component (base chain included each time)', () => {
       const Base = styled.div`
         display: flex;
       `;
@@ -1250,13 +1256,15 @@ describe('styled RSC mode', () => {
         </div>
       );
 
-      // All three Extended instances produce the same CSS → one tag
-      expect(countStyleTags(html)).toBe(1);
+      // Each instance emits its own base(:where())+extension pair.
+      expect(countStyleTags(html)).toBe(3);
       const allCSS = extractStyleContents(html);
-      expect(allCSS).toMatchInlineSnapshot(`":where(.jYQgFj){display:flex;}.inzFhn{color:red;}"`);
+      expect(allCSS).toMatchInlineSnapshot(
+        `":where(.jYQgFj){display:flex;}.inzFhn{color:red;}:where(.jYQgFj){display:flex;}.inzFhn{color:red;}:where(.jYQgFj){display:flex;}.inzFhn{color:red;}"`
+      );
     });
 
-    it('should not retain rules for prefix-colliding class names in partial dedup', () => {
+    it('should emit only this render’s base variant, never a sibling variant', () => {
       const DynamicBase = styled.div<{ $v: string }>`
         color: ${p => p.$v};
       `;
@@ -1273,7 +1281,56 @@ describe('styled RSC mode', () => {
       );
 
       const styles = [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1]);
-      expect(styles[styles.length - 1]).toMatchInlineSnapshot(`".gEYtIK{font-weight:bold;}"`);
+      expect(styles[styles.length - 1]).toMatchInlineSnapshot(
+        `":where(.YKVKw){color:red;}.gEYtIK{font-weight:bold;}"`
+      );
+    });
+
+    it('should keep a component self-contained across a Suspense boundary (#5808)', () => {
+      // The failure: a component rendered in a Suspense fallback recorded its
+      // class in a request-scoped ledger; the resolved child then emitted no
+      // <style>, and React discarded the fallback (rule and all) on reveal,
+      // leaving the resolved element unstyled. renderToString can't model the
+      // reveal, but the invariant that prevents it is that every instance is
+      // self-contained: the same component in two positions each carries its
+      // own <style>, so neither depends on the other surviving.
+      const Panel = styled.div`
+        color: crimson;
+      `;
+
+      const fallback = ReactDOMServer.renderToString(<Panel>skeleton</Panel>);
+      const resolved = ReactDOMServer.renderToString(<Panel>loaded</Panel>);
+
+      expect(extractStyleContents(fallback)).toMatchInlineSnapshot(`".iyTfYQ{color:crimson;}"`);
+      expect(extractStyleContents(resolved)).toBe(extractStyleContents(fallback));
+    });
+
+    it('warns in development when one component floods a server render with inline tags', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const Cell = styled.span`
+          color: red;
+        `;
+
+        ReactDOMServer.renderToString(
+          <div>
+            {Array.from({ length: 1000 }, (_, i) => (
+              <Cell key={i} />
+            ))}
+          </div>
+        );
+
+        const guardrail = warn.mock.calls.filter(
+          ([msg]) => typeof msg === 'string' && msg.includes('instances of the styled component')
+        );
+        expect(guardrail).toHaveLength(1);
+        expect(guardrail[0][0]).toContain('Over 1000 instances');
+        // Remediation is attached and free of internals jargon.
+        expect(guardrail[0][0]).toContain('attrs method');
+        expect(guardrail[0][0]).not.toMatch(/Suspense|inline <style>|React\.cache/);
+      } finally {
+        warn.mockRestore();
+      }
     });
 
     it('should emit separate tags for base and extended rendered together', () => {
@@ -1316,7 +1373,7 @@ describe('styled RSC mode', () => {
       expect(countStyleTags(html)).toBe(1);
     });
 
-    it('should deduplicate keyframes across multiple components', () => {
+    it('should emit the referenced keyframes alongside each component that uses them', () => {
       const fade = keyframes`
         0% { opacity: 1; }
         100% { opacity: 0; }
@@ -1336,14 +1393,14 @@ describe('styled RSC mode', () => {
         </>
       );
 
-      // @keyframes should appear exactly once despite two components using it
+      // Each component emits the @keyframes it references, in its own tag.
       expect(extractStyleContents(html)).toMatchInlineSnapshot(
-        `"@keyframes gZZrBJ{0%{opacity:1;}100%{opacity:0;}}.eGskDT{animation:gZZrBJ 1s;}.ctTFiD{animation:gZZrBJ 2s;}"`
+        `"@keyframes gZZrBJ{0%{opacity:1;}100%{opacity:0;}}.eGskDT{animation:gZZrBJ 1s;}@keyframes gZZrBJ{0%{opacity:1;}100%{opacity:0;}}.ctTFiD{animation:gZZrBJ 2s;}"`
       );
       expect(countStyleTags(html)).toBe(2);
     });
 
-    it('should emit keyframes even when component CSS is deduped', () => {
+    it('should emit the keyframes for every instance so none is lost to a discarded fallback', () => {
       const spin = keyframes`
         0% { transform: rotate(0deg); }
         100% { transform: rotate(360deg); }
@@ -1360,11 +1417,12 @@ describe('styled RSC mode', () => {
         </>
       );
 
-      // Two instances, but only one set of styles (component CSS + keyframe both deduped)
+      // Both instances carry their own keyframe + rule, so a Suspense reveal
+      // that discards one instance never strips the other's animation (#5808).
       expect(extractStyleContents(html)).toMatchInlineSnapshot(
-        `"@keyframes dnfVul{0%{transform:rotate(0deg);}100%{transform:rotate(360deg);}}.gjRflG{animation:dnfVul 1s linear infinite;}"`
+        `"@keyframes dnfVul{0%{transform:rotate(0deg);}100%{transform:rotate(360deg);}}.gjRflG{animation:dnfVul 1s linear infinite;}@keyframes dnfVul{0%{transform:rotate(0deg);}100%{transform:rotate(360deg);}}.gjRflG{animation:dnfVul 1s linear infinite;}"`
       );
-      expect(countStyleTags(html)).toBe(1);
+      expect(countStyleTags(html)).toBe(2);
     });
   });
 
@@ -1398,7 +1456,7 @@ describe('styled RSC mode', () => {
 
       const allCSS = extractStyleContents(html);
       expect(allCSS).toMatchInlineSnapshot(
-        `".iHLfpj:nth-child(1 of :not(style[data-styled])){color:red;}.iHLfpj:nth-last-child(1 of :not(style[data-styled])){color:blue;}.iHLfpj:nth-child(2 of :not(style[data-styled])){color:green;}"`
+        `".iHLfpj:nth-child(1 of :not(style[data-styled])){color:red;}.iHLfpj:nth-last-child(1 of :not(style[data-styled])){color:blue;}.iHLfpj:nth-child(2 of :not(style[data-styled])){color:green;}.iHLfpj:nth-child(1 of :not(style[data-styled])){color:red;}.iHLfpj:nth-last-child(1 of :not(style[data-styled])){color:blue;}.iHLfpj:nth-child(2 of :not(style[data-styled])){color:green;}.iHLfpj:nth-child(1 of :not(style[data-styled])){color:red;}.iHLfpj:nth-last-child(1 of :not(style[data-styled])){color:blue;}.iHLfpj:nth-child(2 of :not(style[data-styled])){color:green;}"`
       );
       expect(allCSS).not.toContain(':first-child');
       expect(allCSS).not.toContain(':last-child');

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -52,10 +52,13 @@ function hasCompiledCSS(cs: ComponentStyle, name: string): boolean {
 }
 
 /**
- * Get compiled CSS for a single class name (RSC only). Returns null on a cache
- * miss so the caller can fall back to reading the tag group. Lets the RSC
- * emission path pull exactly the current render's class without concatenating
- * (and then filtering) every dynamic variant a component has produced.
+ * Get compiled CSS for a single class name (RSC only), or null when the name
+ * was never compiled. Every name reaching RSC emission was compiled by
+ * generateAndInjectStyles before it registered its class, so that path's lookup
+ * always hits; the null case covers only names that never went through
+ * compilation. Lets the RSC emission path pull exactly the current render's
+ * class without concatenating (and then filtering) every dynamic variant a
+ * component has produced.
  */
 export function getCompiledCSSForName(cs: ComponentStyle, name: string): string | null {
   return compiledCSSCache?.get(cs)?.get(name) ?? null;

--- a/packages/styled-components/src/models/ComponentStyle.ts
+++ b/packages/styled-components/src/models/ComponentStyle.ts
@@ -52,22 +52,13 @@ function hasCompiledCSS(cs: ComponentStyle, name: string): boolean {
 }
 
 /**
- * Get all compiled CSS for a ComponentStyle's registered names.
- * Returns null on any cache miss (caller falls back to getGroup).
+ * Get compiled CSS for a single class name (RSC only). Returns null on a cache
+ * miss so the caller can fall back to reading the tag group. Lets the RSC
+ * emission path pull exactly the current render's class without concatenating
+ * (and then filtering) every dynamic variant a component has produced.
  */
-export function getCompiledCSS(cs: ComponentStyle, styleSheet: StyleSheet): string | null {
-  if (!compiledCSSCache) return null;
-  const map = compiledCSSCache.get(cs);
-  if (!map) return null;
-  const names = styleSheet.names.get(cs.componentId);
-  if (!names) return null;
-  let css = '';
-  for (const name of names) {
-    const compiled = map.get(name);
-    if (!compiled) return null;
-    css += compiled;
-  }
-  return css;
+export function getCompiledCSSForName(cs: ComponentStyle, name: string): string | null {
+  return compiledCSSCache?.get(cs)?.get(name) ?? null;
 }
 
 /**

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -1,8 +1,7 @@
 import isPropValid from '@emotion/is-prop-valid';
 import React, { createElement, PropsWithoutRef, Ref } from 'react';
-import { IS_RSC, SC_ATTR, SC_VERSION, SPLITTER } from '../constants';
+import { IS_RSC, SC_ATTR, SC_VERSION } from '../constants';
 import { getGroupForId } from '../sheet/GroupIDAllocator';
-import type StyleSheet from '../sheet';
 import type {
   AnyComponent,
   Attrs,
@@ -33,7 +32,7 @@ import { joinStrings, stripSplitter } from '../utils/joinStrings';
 import merge from '../utils/mixinDeep';
 import { createRSCCache } from '../utils/rscCache';
 import { setToString } from '../utils/setToString';
-import ComponentStyle, { getCompiledCSS } from './ComponentStyle';
+import ComponentStyle, { getCompiledCSSForName } from './ComponentStyle';
 import { useStyleSheetContext } from './StyleSheetManager';
 import { DefaultTheme, ThemeContext } from './ThemeProvider';
 
@@ -110,8 +109,21 @@ function resolveContext<Props extends BaseObject>(
 
 let seenUnknownProps: Set<string> | undefined;
 
-/** Per-render tracking of emitted class names and keyframe IDs for RSC dedup. */
-const getEmittedNames = createRSCCache(() => new Set<string>());
+/**
+ * Dev-only per-request count of inline <style> tags emitted per component, used
+ * to warn when one component floods a server render with redundant tags (a very
+ * large repeated list). Request-scoped via React.cache; over/under-counting
+ * across a Suspense boundary is harmless for a heuristic warning.
+ */
+const getEmitCounts =
+  process.env.NODE_ENV !== 'production' ? createRSCCache(() => new Map<string, number>()) : null;
+
+/**
+ * Warn once a single component emits this many inline <style> tags in one server
+ * render. Set well above any hand-written page; only pathological generated
+ * lists reach it, which is exactly the case that wants a shared className.
+ */
+const RSC_REDUNDANT_EMIT_WARN_THRESHOLD = 1000;
 
 /** Cache RegExp objects for :where() wrapping to avoid recompilation per render */
 const whereRegExpCache = new Map<string, RegExp>();
@@ -124,15 +136,15 @@ function getWhereRegExp(name: string): RegExp {
   return re;
 }
 
-/** Wrap base-level CSS class selectors in :where() for zero specificity (RSC inheritance). */
-function wrapBaseInWhere(levelCss: string, componentId: string, styleSheet: StyleSheet): string {
-  const names = styleSheet.names.get(componentId);
-  if (names) {
-    for (const name of names) {
-      const re = getWhereRegExp(name);
-      re.lastIndex = 0;
-      levelCss = levelCss.replace(re, ':where(.' + name + ')');
-    }
+/** Wrap the given base-level class selectors in :where() for zero specificity
+ *  (RSC inheritance). Only this render's base names are passed, never the base
+ *  component's full accumulated variant set, so an extended component with a
+ *  dynamic base stays O(chain) per instance instead of O(variants). */
+function wrapBaseInWhere(levelCss: string, names: string[]): string {
+  for (let i = 0; i < names.length; i++) {
+    const re = getWhereRegExp(names[i]);
+    re.lastIndex = 0;
+    levelCss = levelCss.replace(re, ':where(.' + names[i] + ')');
   }
   return levelCss;
 }
@@ -251,94 +263,99 @@ function useStyledComponentImpl<Props extends BaseObject>(
 
   const element = createElement(elementToBeCreated, propsForElement);
 
-  // RSC mode: emit this component's CSS (and its inheritance chain + keyframes)
-  // as an inline <style> tag. No `precedence` — server component output isn't
-  // hydrated, so no mismatch. Inline body styles come after the registry's
-  // <head> styles in source order, so extensions naturally win (#5672).
-  if (IS_RSC) {
-    const emitted = getEmittedNames ? getEmittedNames() : null;
+  // RSC mode: emit exactly this render's own classes (the leaf plus its
+  // :where()-wrapped base chain) and the keyframes it references as an inline
+  // <style> sibling, once per instance. No request-scoped dedup ledger: a
+  // ledger keyed on React.cache is request-wide and outlives a Suspense
+  // fallback's DOM, so a rule emitted only inside a fallback would be dropped
+  // for the resolved child and then removed with the fallback, leaving it
+  // unstyled (#5808). React exposes no per-boundary scope to key a safe ledger
+  // on. Styles stay inline rather than hoisted via `precedence` so cross-
+  // boundary extensions keep winning by source order (#5672) and the child-
+  // index selector plugin stays correct; byte-identical duplicates cost about a
+  // byte each after gzip.
+  if (IS_RSC && generatedClassName) {
+    // generateAndInjectStyles returns this render's whole chain of class names,
+    // base to leaf, so it names exactly the rules this instance needs.
+    const renderNames = generatedClassName.split(' ');
 
-    let newNames: string[] | null = null;
-    let totalNames = 0;
     let css = '';
-    let usedCache = true;
-
     let walk: ComponentStyle | null | undefined = componentStyle;
     while (walk) {
-      const names = ssc.styleSheet.names.get(walk.componentId);
-      if (names) {
-        totalNames += names.size;
-        for (const name of names) {
-          if (!emitted || !emitted.has(name)) {
-            if (!newNames) newNames = [];
-            newNames.push(name);
-            if (emitted) emitted.add(name);
-          }
+      const groupNames = ssc.styleSheet.names.get(walk.componentId);
+      if (groupNames) {
+        // This render's names at this level (one per level in the common case).
+        const levelNames: string[] = [];
+        for (let i = 0; i < renderNames.length; i++) {
+          if (groupNames.has(renderNames[i])) levelNames.push(renderNames[i]);
         }
-      }
 
-      if (newNames && usedCache) {
-        let levelCss = getCompiledCSS(walk, ssc.styleSheet);
-        if (levelCss === null) {
-          usedCache = false;
-        } else {
-          if (walk !== componentStyle) {
-            levelCss = wrapBaseInWhere(levelCss, walk.componentId, ssc.styleSheet);
+        if (levelNames.length) {
+          // Every name reaching the sheet in RSC was compiled into the cache by
+          // generateAndInjectStyles before it registered, so the lookup hits.
+          let levelCss = '';
+          for (let i = 0; i < levelNames.length; i++) {
+            levelCss += getCompiledCSSForName(walk, levelNames[i]) || '';
           }
-          css = levelCss + css;
+
+          if (levelCss) {
+            if (walk !== componentStyle) {
+              levelCss = wrapBaseInWhere(levelCss, levelNames);
+            }
+            css = levelCss + css;
+          }
         }
       }
 
       walk = walk.baseStyle;
     }
 
-    if (newNames && !usedCache) {
-      css = '';
-      const tag = ssc.styleSheet.getTag();
-      let cs: ComponentStyle | null | undefined = componentStyle;
-      while (cs) {
-        let levelCss = tag.getGroup(getGroupForId(cs.componentId));
-        if (levelCss && cs !== componentStyle) {
-          levelCss = wrapBaseInWhere(levelCss, cs.componentId, ssc.styleSheet);
-        }
-        css = levelCss + css;
-        cs = cs.baseStyle;
-      }
-    }
-
     let kfCss = '';
-    if (ssc.styleSheet.keyframeIds.size > 0) {
+    if (css && ssc.styleSheet.keyframeIds.size > 0) {
       const kfTag = ssc.styleSheet.getTag();
       for (const kfId of ssc.styleSheet.keyframeIds) {
-        if (emitted && emitted.has(kfId)) continue;
-        const kfRules = kfTag.getGroup(getGroupForId(kfId));
-        if (kfRules) {
-          kfCss += kfRules;
-          if (emitted) emitted.add(kfId);
-        }
-      }
-    }
-
-    if (css && emitted && newNames && newNames.length < totalNames) {
-      const rules = css.split(SPLITTER);
-      let filtered = '';
-      for (let i = 0; i < rules.length; i++) {
-        const rule = rules[i];
-        if (!rule) continue;
-        for (let j = 0; j < newNames.length; j++) {
-          const re = getWhereRegExp(newNames[j]);
-          re.lastIndex = 0;
-          if (re.test(rule)) {
-            filtered += rule + SPLITTER;
+        const kfNames = ssc.styleSheet.names.get(kfId);
+        if (!kfNames) continue;
+        // Substring match: a name that happens to be a substring of another
+        // token only over-emits one gzip-cheap keyframe block, and a genuinely
+        // referenced name always appears verbatim, so a reference is never missed.
+        let referenced = false;
+        for (const kfName of kfNames) {
+          if (css.indexOf(kfName) !== -1) {
+            referenced = true;
             break;
           }
         }
+        if (referenced) {
+          const kfRules = kfTag.getGroup(getGroupForId(kfId));
+          if (kfRules) kfCss += kfRules;
+        }
       }
-      css = filtered;
     }
 
     const combined = stripSplitter(kfCss + css);
     if (combined) {
+      if (process.env.NODE_ENV !== 'production' && getEmitCounts) {
+        const counts = getEmitCounts();
+        const count = (counts.get(componentStyle.componentId) || 0) + 1;
+        counts.set(componentStyle.componentId, count);
+        if (count === RSC_REDUNDANT_EMIT_WARN_THRESHOLD) {
+          const name = forwardedComponent.displayName || styledComponentId;
+          console.warn(
+            `Over ${count} instances of the styled component ${name} were rendered on one server-rendered page, so its styles repeat that many times in the HTML.\n` +
+              "This is fine at normal sizes. To trim a very large list, move each item's changing values into a style object with the attrs method so every item shares one class.\n" +
+              'Example:\n' +
+              '  const Component = styled.div.attrs(props => ({\n' +
+              '    style: {\n' +
+              '      background: props.background,\n' +
+              '    },\n' +
+              '  }))`width: 100%;`\n\n' +
+              '  <Component />\n' +
+              'If every item looks the same, style them from a parent element and render plain children instead.'
+          );
+        }
+      }
+
       const styleElement = React.createElement('style', {
         [SC_ATTR]: '',
         key: 'sc-' + componentStyle.componentId,


### PR DESCRIPTION
Fixes #5808.

Styles could disappear from a server-rendered component when it was revealed from behind a React `<Suspense>` boundary, for example a streaming Next.js route (including `cacheComponents`). When the same component appeared first in a Suspense fallback and then in the resolved content, the resolved element kept its class name but lost its CSS, so it rendered unstyled once the fallback swapped out.

## What changes

- A server-rendered component now carries its own styles every time it renders, so they always travel with it and survive the boundary reveal. The disappearing-style case is gone.
- Cross-boundary extension overrides (a server component extending a client one) and child-index selectors under RSC keep working exactly as before.
- Identical repeated styles compress away, so the extra output is negligible. For a very large repeated list (thousands of instances of one component on a single page), a development-only warning now points you at the `attrs` + inline CSS-variable pattern so every item shares one class.

## Not included

`createGlobalStyle` has a related edge under Suspense, but its de-duplication is documented behavior (rendering one global style several times emits a single tag), so changing it is a separate decision and left out of this PR.

Thanks to @laurenskling for the clear report and video, and for testing the prerelease.
